### PR TITLE
WIP: Make DOCKER_ENTRYPOINT_LINK behave like normal normal binds would

### DIFF
--- a/linux/docker_compose_override
+++ b/linux/docker_compose_override
@@ -103,13 +103,17 @@ function generate_docker_compose_override()
 {
   local volumes_name
   local volume
-  local volumes
+  local compose_volumes
+  local compose_volumes_reversed
   local indirect
   local volumes_name_all
+  local volume_will_mount
+  local should_add
   local indirect_all
   local host_mount_point
   local i
   local volume_info
+  local volume_will_mount_info
   local just_docker_entrypoint_links
 
   local project_prefix=$1
@@ -129,7 +133,7 @@ function generate_docker_compose_override()
 
     # Clear list for this service
     just_docker_entrypoint_links=()
-    volumes=()
+    compose_volumes_reversed=()
 
     # Indirect fun
     volumes_name="${project_prefix}_${services_upper[$i]}_VOLUMES"
@@ -137,7 +141,17 @@ function generate_docker_compose_override()
     volumes_name_all="${project_prefix}_VOLUMES"
     indirect_all="${volumes_name_all}[@]"
 
-    for volume in ${!volumes_name_all+"${!indirect_all}"} ${!volumes_name+"${!indirect}"}; do
+    # docker/docker-compose assume that if two volumes mount to the same
+    # location, the last one wins. replicate that functionality
+    local volumes
+    local volumes_reversed
+    volumes=(${!volumes_name_all+"${!indirect_all}"} ${!volumes_name+"${!indirect}"})
+    volumes_reversed=()
+    for (( idx=${#volumes[@]}-1 ; idx>=0 ; idx-- )) ; do
+        volumes_reversed+=("${volumes[$idx]}")
+    done
+
+    for volume in ${volumes_reversed+"${volumes_reversed[@]}"}; do
       IFS=:
       volume_info=(${volume})
       IFS="${OLD_IFS}"
@@ -180,25 +194,49 @@ function generate_docker_compose_override()
         if [ "${host_mount_point}" != "${volume_info[0]}" ] && \
             is_nfs "$(mount_type "${host_mount_point}")"; then
 
-          # Add to the entrypoint list
-          just_docker_entrypoint_links+=("${volume_info[1]}"
-                                         "${MOUNT_PREFIX-/host_mnt}${volume_info[0]}")
-          # Rewrite this volume
-          volume_info[0]="${host_mount_point}"
-          volume_info[1]="${MOUNT_PREFIX-/host_mnt}${host_mount_point}"
+          # If the mount point will be overridden by another mount, don't bother
+          # trying to symlink it
+          should_add=1
+          for volume_will_mount in "${compose_volumes_reversed[@]}"; do
+            IFS=:
+            # NOTE "${volume_will_mount_info[0]}" is prefixed with "      - "
+            volume_will_mount_info=(${volume_will_mount})
+            IFS="${OLD_IFS}"
+
+            if [ "${volume_will_mount_info[1]}" == "${volume_info[1]}" ]; then
+              should_add=0
+              break
+            fi
+          done
+          if [ "${should_add}" == "1" ]; then
+            # Add to the entrypoint list
+            just_docker_entrypoint_links+=("${volume_info[1]}"
+                                           "${MOUNT_PREFIX-/host_mnt}${volume_info[0]}")
+            # Rewrite this volume
+            volume_info[0]="${host_mount_point}"
+            volume_info[1]="${MOUNT_PREFIX-/host_mnt}${host_mount_point}"
+          fi
         fi
       fi
 
       IFS=:
-      volumes+=("      - ${volume_info[*]}")
+      compose_volumes_reversed+=("      - ${volume_info[*]}")
+      IFS="${OLD_IFS}"
     done
+
+    # restore the original order
+    compose_volumes=()
+    for (( idx=${#compose_volumes_reversed[@]}-1 ; idx>=0 ; idx-- )) ; do
+        compose_volumes+=("${compose_volumes_reversed[$idx]}")
+    done
+
     # remove duplicates https://unix.stackexchange.com/q/159695,
     # docker-compose doesn't like them
     IFS=$'\n'
-    volumes=($(awk '!count[$0]++' <<< ${volumes+"${volumes[*]}"}))
-    if [ "${volumes+set}" == "set" ]; then
+    compose_volumes=($(awk '!count[$0]++' <<< ${compose_volumes+"${compose_volumes[*]}"}))
+    if [ "${compose_volumes+set}" == "set" ]; then
       echo "    volumes:"
-      echo ${volumes+"${volumes[*]}"}
+      echo ${compose_volumes+"${compose_volumes[*]}"}
     fi
     IFS="${OLD_IFS}"
 

--- a/linux/docker_compose_override
+++ b/linux/docker_compose_override
@@ -189,26 +189,30 @@ function generate_docker_compose_override()
       # Check to see that the volume is not a docker volume
       if [[ ${volume_info[0]:0:1} =~ [./] ]]; then
         host_mount_point="$(mount_point "${volume_info[0]}")"
-        # If the mount point isn't already the same as the mount, check to see
-        # if it's nfs
-        if [ "${host_mount_point}" != "${volume_info[0]}" ] && \
-            is_nfs "$(mount_type "${host_mount_point}")"; then
-
+        # If the mount point is nfs
+        if is_nfs "$(mount_type "${host_mount_point}")"; then
           # If the mount point will be overridden by another mount, don't bother
-          # trying to symlink it
+          # trying to add it
           should_add=1
-          for volume_will_mount in "${compose_volumes_reversed[@]}"; do
+          for volume_will_mount in ${compose_volumes_reversed+"${compose_volumes_reversed[@]}"}; do
             IFS=:
             # NOTE "${volume_will_mount_info[0]}" is prefixed with "      - "
             volume_will_mount_info=(${volume_will_mount})
             IFS="${OLD_IFS}"
 
-            if [ "${volume_will_mount_info[1]}" == "${volume_info[1]}" ]; then
-              should_add=0
+            volume_mount_point="$(mount_point "${volume_will_mount_info[1]}")"
+            if [ "${volume_mount_point}" == "${host_mount_point}" ]; then
+              should_add=0 # don't add the mount point
               break
             fi
           done
-          if [ "${should_add}" == "1" ]; then
+          # Corner case: if the mount point is already the same as the mount
+          # and will be overridden by another mount, skip it entirely
+          if [ "${should_add}" == "0" ] && \
+             [ "${host_mount_point}" == "${volume_info[0]}" ]; then
+              continue
+          elif [ "${should_add}" == "1" ] && \
+               [ "${host_mount_point}" != "${volume_info[0]}" ]; then
             # Add to the entrypoint list
             just_docker_entrypoint_links+=("${volume_info[1]}"
                                            "${MOUNT_PREFIX-/host_mnt}${volume_info[0]}")

--- a/linux/docker_entrypoint.bsh
+++ b/linux/docker_entrypoint.bsh
@@ -122,7 +122,8 @@ function docker_setup_user()
 #   with squash root. Instead the base mount point is mounted into the
 #   container and a symlink is created to link the desired locations. This
 #   function creates these symlinks based on the colon separated string
-#   JUST_DOCKER_ENTRYPOINT_LINKS. Links within other links are not created.
+#   JUST_DOCKER_ENTRYPOINT_LINKS, e.g., "destination:source:destination:source".
+#   Links within other links are not created.
 # INPUTS
 #   [DOCKER_LINK_MOUNTS_FORCE] - Default: 0
 # AUTHOR


### PR DESCRIPTION
if the mount point will be overridden by another mount, don't bother trying to symlink it

- [ ] `docker-compose-volumes` needs to be used on every file in `docker_compose_files`
    - [x] This can be done at once using one `docker-compose -f file1 -f file2 config` command
    - [x] Note: This does not support long volume format. It should for completeness
    - [ ] Additional `-v`/`--volumes` flags in `docker_compose_command_args` need to be parsed too. I believe they come last, since last order wins
    - [ ] Same for `--mount`
- [ ] `docker_compose_override` will have to completely replace all the docker-compose files, rather than supplementing them.
    - [ ] copy all the docker-compose yaml files, remove the volumes from all of them, and **prefix** those volumes to `{PROJECT}_{SERVICE}_VOLUMES` arrays. Or this get thrown into a `docker-compose.yml` file
    - [ ] rewrite the `docker_compose_args` to point to the docker-compose files with volumes removed.
- [ ] Add Windows support
    - [ ] Support Linux style paths in mounts without needing `//` prefix
    - [ ] Support Linux style paths in environment variables without needing `//` prefix
    - [ ] Add unit test for windows catching the error