### PR TITLE
jump over holes in the array

### DIFF
--- a/linux/docker_entrypoint.bsh
+++ b/linux/docker_entrypoint.bsh
@@ -166,7 +166,7 @@ function docker_link_mounts()
   # are strictly worse than bind mounts; don't try to make them as capable.
   for x in ${!link_destinations[@]}; do
     for ((y=0; y<x; y++)); do
-      if [[ ${link_destinations[$x]} == "${link_destinations[$y]}/"* ]]; then
+      if [[ "${link_destinations[$y]+set}" == "set" && "${link_destinations[$x]}" == "${link_destinations[$y]}/"* ]]; then
         unset link_destinations[$x]
         break
       fi
@@ -176,7 +176,7 @@ function docker_link_mounts()
   for y in ${!link_destinations[@]}; do
     # Last link wins; this matches docker-compose behavior
     for ((x=${#JUST_DOCKER_ENTRYPOINT_LINKS[@]}-2; x>=0; x-=2)); do
-      if [ "${JUST_DOCKER_ENTRYPOINT_LINKS[$x]}" == "${link_destinations[$y]}" ]; then
+      if [ "${link_destinations[$y]+set}" == "set" ] && [ "${JUST_DOCKER_ENTRYPOINT_LINKS[$x]}" == "${link_destinations[$y]}" ]; then
         mkdir -p "$(dirname "${JUST_DOCKER_ENTRYPOINT_LINKS[$x]}")" && \
         ln -T -s ${options-} "${JUST_DOCKER_ENTRYPOINT_LINKS[$((x+1))]}" "${JUST_DOCKER_ENTRYPOINT_LINKS[$x]}" || : # \
         # This gosu version only covers a small corner case. It was deemed not worth


### PR DESCRIPTION
quick fix for the "link_destination [$y]: unbound variable" error. as elements are removed from this array they leave holes which must be skipped over on the next pass. not sure how we've never seen this before.