### PR TITLE
windows shell expansion

### DIFF
--- a/linux/docker_functions.bsh
+++ b/linux/docker_functions.bsh
@@ -481,8 +481,8 @@ function Just-docker-compose()
     local f
     #mimic docker-compose's default behavior
     compose_file_override=
-    for f in docker-compose.yml docker-compose.yaml \
-             docker-compose.override.yml docker-compose.override.yaml; do
+    for f in ./docker-compose.yml ./docker-compose.yaml \
+             ./docker-compose.override.yml ./docker-compose.override.yaml; do
       [ -e "${f}" ] && compose_file_override+="${f}"
     done
   fi

--- a/linux/docker_functions.bsh
+++ b/linux/docker_functions.bsh
@@ -481,6 +481,12 @@ function Just-docker-compose()
     local f
     #mimic docker-compose's default behavior
     compose_file_override=
+    # The ./ is to fool MINGW64's path conversion[1]; On Windows, the ; path
+    # separator is expected; however, if used, MINGW64 does not attempt path
+    # conversion. Instead, use :, as expected by MINGW64, and specify all paths
+    # using POSIX style (e.g., ./docker-compose.yml instead of
+    # docker-compose.yml).
+    # [1] http://www.mingw.org/wiki/Posix_path_conversion
     for f in ./docker-compose.yml ./docker-compose.yaml \
              ./docker-compose.override.yml ./docker-compose.override.yaml; do
       [ -e "${f}" ] && compose_file_override+="${f}"


### PR DESCRIPTION
on Windows, docker-compose tries to expand this to .\\docker-compose.yml which errors out with "No Such File or Directory"