### PR TITLE
Break justify chains with separator

### DIFF
--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -890,6 +890,21 @@ function justify()
   just_subcommands=($(_just_subcommands_from_array <<< "${parsed_help_a[*]}"))
   IFS="${OLD_IFS}"
 
+  local index
+  while (( $# > 0 )); do
+    index=$(findin "${JUST_SEPARATOR}" "${@}")
+    if [ "${index}" == "-1" ]; then
+      _justify "${@}"
+      break
+    else
+      _justify "${@:1:$index}"
+      shift $((index+1))
+    fi
+  done
+}
+
+function _justify()
+{
   while (( $# > 0 )); do
     extra_args=0
 

--- a/tests/test-just_functions.bsh
+++ b/tests/test-just_functions.bsh
@@ -468,6 +468,8 @@ begin_test "justify calls"
   [ "$(justify bar tree park)" = $':bar: tree park' ] # Two args
   [ "$(justify bar tree park zoo)" = $':bar: tree park zoo\n!zoo!' ] # 3rd arg should be a new call
   [ "$(justify bar tree -- apple)" = $':bar: tree\n:apple:' ] # 2 args plus new call
+  [ "$(justify bar tree park --)" = $':bar: tree park' ] # 2 args
+  [ "$(justify bar tree --)" = $':bar: tree' ] # 1 args
 
   [ "$(justify bar tree -- bar tree -- apple)" = $':bar: tree\n:bar: tree\n:apple:' ] # 2 args * 2 plus new call
   [ "$(justify bar tree -- bar tree -- apple --)" = $':bar: tree\n:bar: tree\n:apple:' ] # with trailing --

--- a/tests/test-just_functions.bsh
+++ b/tests/test-just_functions.bsh
@@ -413,7 +413,8 @@ begin_test "justify calls"
   {
     echo "$1) # Blah" >> file1
     echo '  echo ":'"$1"':" ${@+"${@}"}' >> file1
-    echo "  extra_args+=${2-0}" >> file1
+    echo "  extra+=${2-0}" >> file1
+    echo '  extra_args+=$(( extra > $# ? $# : extra))' >> file1
     echo '  ;;' >> file1
   }
 
@@ -464,8 +465,14 @@ begin_test "justify calls"
   # Two args
   [ "$(justify bar)" = ":bar:" ] # Missing arg
   [ "$(justify bar tree)" = ":bar: tree" ] # One arg
-  [ "$(justify bar tree park)" = $':bar: tree park' ] # 2nd arg should be a new call
+  [ "$(justify bar tree park)" = $':bar: tree park' ] # Two args
   [ "$(justify bar tree park zoo)" = $':bar: tree park zoo\n!zoo!' ] # 3rd arg should be a new call
+  [ "$(justify bar tree -- apple)" = $':bar: tree\n:apple:' ] # 2 args plus new call
+
+  [ "$(justify bar tree -- bar tree -- apple)" = $':bar: tree\n:bar: tree\n:apple:' ] # 2 args * 2 plus new call
+  [ "$(justify bar tree -- bar tree -- apple --)" = $':bar: tree\n:bar: tree\n:apple:' ] # with trailing --
+  [ "$(justify bar tree -- -- bar tree -- --)" = $':bar: tree\n:bar: tree' ] # with multiple --
+  [ "$(justify bar tree -- bar tree -- --)" = $':bar: tree\n:bar: tree' ] # with two trailing --
 
   # All args
   [ "$(justify rope)" = ":rope:" ] # 0 args
@@ -473,6 +480,8 @@ begin_test "justify calls"
   [ "$(justify rope twine cord)" = ":rope: twine cord" ] # 2 args
   [ "$(justify rope twine sisal string thread yarn lace)" = \
     ":rope: twine sisal string thread yarn lace" ] # 6 args
+
+  [ "$(justify rope twine -- apple)" = $':rope: twine\n:apple:' ] # 2 args plus new call
 
   # Multiple of same target
   [ "$(justify -sea -ocean -water)" = \

--- a/tests/test-just_functions.bsh
+++ b/tests/test-just_functions.bsh
@@ -413,7 +413,7 @@ begin_test "justify calls"
   {
     echo "$1) # Blah" >> file1
     echo '  echo ":'"$1"':" ${@+"${@}"}' >> file1
-    echo "  extra+=${2-0}" >> file1
+    echo "  extra=${2-0}" >> file1
     echo '  extra_args+=$(( extra > $# ? $# : extra))' >> file1
     echo '  ;;' >> file1
   }


### PR DESCRIPTION
@scott-vsi Please check this and make sure I didn't break anything or miss any corner cases in the unit test. It's a core piece of `just`, and any 🐛 would be 😠 

---

Say `target1` takes multiple or all extra args, the separator can break this and continue to the next target

```
just target1 arg1 arg2 -- target2 arg3 arg4
```

This used to call `caseify target1 arg1 arg2 -- target2 arg3 arg4`, in which case, `target1` would use up all the args. 

But now its more `caseifty target1 arg1 arg2; caseify target2 arg3 arg4`. Making it equivalent to `justify target1 arg1 arg2; justify target2 arg3 arg4`

Addition test examples welcome

**NOTE:** Nothing to do with `get_args`