### PR TITLE
Cleanup

### DIFF
--- a/.winbashrc
+++ b/.winbashrc
@@ -1,2 +1,2 @@
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)/env.bsh"
-. /etc/bash.bashrc
+source "$(dirname "${BASH_SOURCE[0]}")/env.bsh"
+source /etc/bash.bashrc

--- a/Justfile
+++ b/Justfile
@@ -4,12 +4,16 @@ if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then #If being sourced
   set -euE
 fi
 
-source "$(\cd "$(\dirname "${BASH_SOURCE[0]}")"; \pwd)/linux/just_env" "$(dirname "${BASH_SOURCE[0]}")"/vsi_common.env
+# VSI_COMMON_DIR is a special var, handle is carefully.
+if [ -z ${VSI_COMMON_DIR+set} ]; then
+  VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
+fi
+source "${VSI_COMMON_DIR}/linux/just_env" "${VSI_COMMON_DIR}/vsi_common.env"
 
 source "${VSI_COMMON_DIR}/linux/just_docker_functions.bsh"
 source "${VSI_COMMON_DIR}/linux/just_docs_functions.bsh"
 
-cd "$(\dirname "${BASH_SOURCE[0]}")"
+cd "${VSI_COMMON_DIR}"
 
 function caseify()
 {

--- a/Justfile
+++ b/Justfile
@@ -78,7 +78,7 @@ function caseify()
     test_wine) # Run unit tests using wine
       justify run wine -c "
         cd /z/vsi_common
-        . setup.env
+        source setup.env
         just test ${*}"'
         rv=$?
         read -p "Press any key to close" -r -e -n1

--- a/docker-compose-docs.yml
+++ b/docker-compose-docs.yml
@@ -10,6 +10,7 @@ services:
       - DOCKER_GIDS=${VSI_COMMON_GIDS-1000}
       - DOCKER_GROUP_NAMES=user
       - DOCKER_USERNAME=user
+      - JUST_PROJECT_FILE
     volumes:
       - type: bind
         source: ${VSI_COMMON_DIR}

--- a/docs/docker/Pipfile.lock
+++ b/docs/docker/Pipfile.lock
@@ -236,10 +236,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
+                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
             ],
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         }
     },
     "develop": {}

--- a/docs/docker/docs_entrypoint.bsh
+++ b/docs/docker/docs_entrypoint.bsh
@@ -2,9 +2,11 @@
 
 set -eu
 
+: ${VSI_COMMON_DIR:=/vsi}
+
 if [ "${ALREADY_RUN_ONCE+set}" != "set" ]; then
   (
-    source "${VSI_COMMON_DIR:-/vsi}/linux/just_env" "${JUST_PROJECT_FILE}"
+    source "${VSI_COMMON_DIR}/linux/just_env" "${JUST_PROJECT_FILE}"
 
     # create the user and associated groups and handle nfs symlinks
     /usr/bin/env bash /vsi/linux/docker_entrypoint.bsh
@@ -14,7 +16,7 @@ if [ "${ALREADY_RUN_ONCE+set}" != "set" ]; then
   ALREADY_RUN_ONCE=1 exec gosu ${DOCKER_USERNAME} /usr/bin/env bash $0 ${@+"${@}"}
 fi
 
-source "${VSI_COMMON_DIR:-/vsi}/linux/just_env" "${JUST_PROJECT_FILE}"
+source "${VSI_COMMON_DIR}/linux/just_env" "${JUST_PROJECT_FILE}"
 
 function sudo()
 {

--- a/docs/style.rst
+++ b/docs/style.rst
@@ -1,0 +1,51 @@
+
+===========
+Style Guide
+===========
+
+Bash
+----
+
+* Two spaces per indent
+
+* ``then`` and ``do`` on the same line
+
+.. code-block:: bash
+
+    for x in $(ls); do
+      :
+    done
+
+    while check_something; do
+      :
+    done
+
+We like to use `>&` for file descriptors (numbers), and `&>` for filenames
+
+* Redirecting to open file
+
+.. code-block:: bash
+
+    echo hi 1>&2 # No extra spaces, as bash doesn't allow that
+
+
+* Closing an open file
+
+.. code-block:: bash
+
+    exec 3>&-
+
+    exec 3&>- #Works, but wrong style. This is dealing with descriptors
+
+* Redirecing to a file
+
+.. code-block:: bash
+
+    run_some_command &> /dev/null # Spaced added arround &>
+
+    run_some_command >& /dev/null # Works, but wrong style
+
+Python
+------
+
+* Two spaces per indent

--- a/env.bsh
+++ b/env.bsh
@@ -6,11 +6,11 @@ if [[ "${BASH_VERSION+set}" == "set" ]]; then
   # Use the real shell not for babies
   export VSI_COMMON_DIR="$(\cd "$(\dirname "${BASH_SOURCE[0]}")"; \pwd)"
 
-  . "${VSI_COMMON_DIR}/linux/elements.bsh"
+  source "${VSI_COMMON_DIR}/linux/elements.bsh"
 
   IFS=: add_element_pre PATH "${VSI_COMMON_DIR}/linux"
 
-  . "${VSI_COMMON_DIR}"/linux/.just
+  source "${VSI_COMMON_DIR}"/linux/.just
 elif [[ "${ZSH_VERSION+set}" == "set" ]]; then #Zsh
   echo "NOTE zsh has limited functionality"
   export VSI_COMMON_DIR="$(\cd "$(\dirname "${0}")"; \pwd)"

--- a/env.bsh
+++ b/env.bsh
@@ -4,7 +4,7 @@
 
 if [[ "${BASH_VERSION+set}" == "set" ]]; then
   # Use the real shell not for babies
-  export VSI_COMMON_DIR="$(\cd "$(\dirname "${BASH_SOURCE[0]}")"; \pwd)"
+  export VSI_COMMON_DIR="$(\cd "$(dirname "${BASH_SOURCE[0]}")"; \pwd)"
 
   source "${VSI_COMMON_DIR}/linux/elements.bsh"
 
@@ -13,7 +13,7 @@ if [[ "${BASH_VERSION+set}" == "set" ]]; then
   source "${VSI_COMMON_DIR}"/linux/.just
 elif [[ "${ZSH_VERSION+set}" == "set" ]]; then #Zsh
   echo "NOTE zsh has limited functionality"
-  export VSI_COMMON_DIR="$(\cd "$(\dirname "${0}")"; \pwd)"
+  export VSI_COMMON_DIR="$(\cd "$(dirname "${0}")"; \pwd)"
 
   PATH="${VSI_COMMON_DIR}/linux":"${PATH}"
 else

--- a/linux/.just
+++ b/linux/.just
@@ -3,7 +3,9 @@
 
 source_once >&/dev/null && return
 
-: ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
+if [ -z ${VSI_COMMON_DIR+set} ]; then
+  VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
+fi
 source "${VSI_COMMON_DIR}/linux/just_common.bsh"
 source "${VSI_COMMON_DIR}/linux/isin"
 source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
@@ -59,7 +61,7 @@ _just()
   JUST_DRYRUN_SOURCE=: _just_load_justfile "${JUSTFILE-Justfile}"
   # 3. Emulate finding and adding plugins
   # The last JUST_HELP_FILES is the just file now
-  local just_dir="$(\dirname "${JUST_HELP_FILES[${#JUST_HELP_FILES[@]}-1]}")"
+  local just_dir="$(dirname "${JUST_HELP_FILES[${#JUST_HELP_FILES[@]}-1]}")"
   _just_get_plugins "${just_dir}"
   for just_plugin in ${JUST_PLUGINS+"${JUST_PLUGINS[@]}"}; do
     JUST_HELP_FILES+=("${just_plugin}")

--- a/linux/.just
+++ b/linux/.just
@@ -1,7 +1,7 @@
 #!/usr/bin/env false
 #This file should be sourced, NOT run!
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 if [ -z ${VSI_COMMON_DIR+set} ]; then
   VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"

--- a/linux/.just
+++ b/linux/.just
@@ -2,10 +2,10 @@
 #This file should be sourced, NOT run!
 
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
-. "${VSI_COMMON_DIR}/linux/just_common.bsh"
-. "${VSI_COMMON_DIR}/linux/isin"
-. "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
-. "${VSI_COMMON_DIR}/linux/elements.bsh"
+source "${VSI_COMMON_DIR}/linux/just_common.bsh"
+source "${VSI_COMMON_DIR}/linux/isin"
+source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
+source "${VSI_COMMON_DIR}/linux/elements.bsh"
 
 #*# just/just-tab.rst
 

--- a/linux/.just
+++ b/linux/.just
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 #This file should be sourced, NOT run!
 
+source_once >&/dev/null && return
+
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/just_common.bsh"
 source "${VSI_COMMON_DIR}/linux/isin"

--- a/linux/.just
+++ b/linux/.just
@@ -55,8 +55,16 @@ _just()
   if [ "${JUST_HELP_FILES+set}" != "set" ]; then
     JUST_HELP_FILES=("${VSI_COMMON_DIR}/linux/just_functions.bsh")
   fi
-  # 2. Find Justfile: just_functions.bsh/load_justfile
-  JUST_DRYRUN_SOURCE=: _just_load_justfile "${JUSTFILE-Justfile}"
+
+  # 2. Find Justfile, load it, and copy the JUST_HELP_FILES array
+  local just_files="$(
+    _just_load_justfile "${JUSTFILE-Justfile}" >& /dev/null
+    join_a just_files ${JUST_HELP_FILES+"${JUST_HELP_FILES[@]}"}
+    echo "${just_files}"
+  )"
+  split_s just_files "${just_files}"
+  JUST_HELP_FILES+=(${just_files+"${just_files[@]}"})
+
   # 3. Emulate finding and adding plugins
   # The last JUST_HELP_FILES is the just file now
   local just_dir="$(dirname "${JUST_HELP_FILES[${#JUST_HELP_FILES[@]}-1]}")"

--- a/linux/.just
+++ b/linux/.just
@@ -1,8 +1,6 @@
 #!/usr/bin/env false
 #This file should be sourced, NOT run!
 
-source_once &> /dev/null && return
-
 if [ -z ${VSI_COMMON_DIR+set} ]; then
   VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
 fi

--- a/linux/.just
+++ b/linux/.just
@@ -89,7 +89,7 @@ _just()
 
   # Call local .just if it exists
   if [ -f "${just_dir}/.just" ]; then
-    . "${just_dir}/.just"
+    source "${just_dir}/.just"
   fi
 
   # If the last word completed is a subcommand, only match subtargets

--- a/linux/Just_wrap
+++ b/linux/Just_wrap
@@ -100,7 +100,7 @@ fi
 
 # Source the environment
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
-. "${VSI_COMMON_DIR}/linux/just_env" "${1}"
+source "${VSI_COMMON_DIR}/linux/just_env" "${1}"
 shift 1 # Toss that argument away, you're done with it
 
 # This works as long as you don't name this script 'bash'... SO DON'T CALL YOUR SCRIPT BASH!!!

--- a/linux/Just_wrap
+++ b/linux/Just_wrap
@@ -47,7 +47,7 @@
 #
 #
 #   #!/usr/bin/env bash
-#   . "$(dirname "${BASH_SOURCE[0]}")"/external/vsi_common/linux/Just_wrap "${BASH_SOURCE[0]}" my_project.env ${@+"${@}"}
+#   source "$(dirname "${BASH_SOURCE[0]}")/external/vsi_common/linux/Just_wrap" "${BASH_SOURCE[0]}" my_project.env ${@+"${@}"}
 #
 # where my_project.env is the main project settings file.
 #
@@ -63,7 +63,7 @@
 #**
 
 if [ -x "${JUSTFILE-Justfile}" ]; then
-  . "$(dirname "${BASH_SOURCE[0]}")"/just_common.bsh
+  source "$(dirname "${BASH_SOURCE[0]}")/just_common.bsh"
   _just_load_justfile "${JUSTFILE-Justfile}"
 fi
 

--- a/linux/ask_question
+++ b/linux/ask_question
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Can be sourced
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/ask_question
 

--- a/linux/ask_question
+++ b/linux/ask_question
@@ -99,7 +99,7 @@ function ask_question()
   done
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   question="$1"
   shift 1
   ask_question "${question}" x "${@}"

--- a/linux/ask_question
+++ b/linux/ask_question
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Can be sourced
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/ask_question
 

--- a/linux/ask_question
+++ b/linux/ask_question
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Can be sourced
 
+source_once >&/dev/null && return
+
 #*# linux/ask_question
 
 #**

--- a/linux/bin_utils.bsh
+++ b/linux/bin_utils.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/bin_utils
 

--- a/linux/bin_utils.bsh
+++ b/linux/bin_utils.bsh
@@ -78,7 +78,7 @@ fi
 #
 # Searches for a library using the same ld resolution method as the OS. First ``LD_LIBRARY_PATH`` is searched, then ldconfig -p for a match to a filename.
 #
-# .. rubric:: Bugs 
+# .. rubric:: Bugs
 #
 # The purpose of this is to match from the beginning of basename (cf. the full pathname). This is done by using ``$2`` as a partial regex which can cause some undesired behavior. This can occur when using the or '|' operator. This is why the example has parentheses in the '(libSDL|libOpenGL)' expression, so that it works as expected.
 #
@@ -103,6 +103,7 @@ function lwhich()
   local filenames=()
   local files
   local case_insensitive=''
+  local IFS
   if [ "${LWHICH_INSENSITIVE-0}" != "0" ]; then
     case_insensitive='-i'
   fi

--- a/linux/bin_utils.bsh
+++ b/linux/bin_utils.bsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env false
 
+source_once >&/dev/null && return
+
 #*# linux/bin_utils
 
 #**

--- a/linux/bin_utils.bsh
+++ b/linux/bin_utils.bsh
@@ -41,7 +41,7 @@ function object_bits()
   nm -D "${1}" | sed -En '/^[0-9A-Fa-f]{8,}/ {p; q}' | awk '{print length($1)*4}'
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   arg=$1
   shift 1
 

--- a/linux/bin_utils.bsh
+++ b/linux/bin_utils.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env false
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/bin_utils
 

--- a/linux/colors.bsh
+++ b/linux/colors.bsh
@@ -98,24 +98,14 @@ function color_setup()
   RESET_HIDDEN=$'\e[28m'
   RESET_STRIKEOUT=$'\e[29m'
 
-  # Bash 3.2 can't declare globally, so must use eval :(
-  if [ "${BASH_VERSINFO[0]}" = "3" ]; then
-    for color in "${COLOR_NAMES[@]}"; do
-      eval "LIGHT_${color}=$'\e[$((${_light}+${!color}))m'"
-      eval "${color}_BG=$'\e[$((${_normal}+${_bg}+${!color}))m'"
-      eval "LIGHT_${color}_BG=$'\e[$((${_bg}+${_light}+${!color}))m'"
-      eval "${color}=$'\e[$((${_normal}+${!color}))m'"
-      COLORS+=(${!color})
-    done
-  else
-    for color in "${COLOR_NAMES[@]}"; do
-      declare -g "LIGHT_${color}="$'\e['"$((${_light}+${!color}))m"
-      declare -g "${color}_BG="$'\e['"$((${_normal}+${_bg}+${!color}))m"
-      declare -g "LIGHT_${color}_BG="$'\e['"$((${_bg}+${_light}+${!color}))m"
-      declare -g "${color}="$'\e['"$((${_normal}+${!color}))m"
-      COLORS+=(${!color})
-    done
-  fi
+  for color in "${COLOR_NAMES[@]}"; do
+    # export -n so that they are global, declare -g doesn't work in bash 3.2
+    export -n "LIGHT_${color}="$'\e['"$((${_light}+${!color}))m"
+    export -n "${color}_BG="$'\e['"$((${_normal}+${_bg}+${!color}))m"
+    export -n "LIGHT_${color}_BG="$'\e['"$((${_bg}+${_light}+${!color}))m"
+    export -n "${color}="$'\e['"$((${_normal}+${!color}))m"
+    COLORS+=(${!color})
+  done
 
   # Minimize the amount of color garbage on set -xv
   local color_fix

--- a/linux/colors.bsh
+++ b/linux/colors.bsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env false
 # Source this script for colors
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/colors
 

--- a/linux/colors.bsh
+++ b/linux/colors.bsh
@@ -5,6 +5,9 @@ source_once &> /dev/null && return
 
 #*# linux/colors
 
+: ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
+source "${VSI_COMMON_DIR}/linux/findin"
+
 #**
 # ================
 # Colors Utilities
@@ -169,11 +172,9 @@ declare -a COLOR_DB_NAMES=()
 declare -a COLOR_DB_COLORS=()
 _COLOR_INDEX=0
 
-_COLOR_SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
-
 function get_color()
 { #1 - colored_name
-  local color_index=$("${_COLOR_SCRIPT_DIR}/findin" $1 ${COLOR_DB_NAMES+"${COLOR_DB_NAMES[@]}"})
+  local color_index=$("findin" $1 ${COLOR_DB_NAMES+"${COLOR_DB_NAMES[@]}"})
   local this_color
 
   if [ "${color_index}" == "-1" ]; then

--- a/linux/colors.bsh
+++ b/linux/colors.bsh
@@ -1,7 +1,9 @@
 #!/usr/bin/env false
 # Source this script for colors
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/colors
 

--- a/linux/colors.bsh
+++ b/linux/colors.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 # Source this script for colors
 
+source_once >&/dev/null && return
+
 #*# linux/colors
 
 #**

--- a/linux/common_source.sh
+++ b/linux/common_source.sh
@@ -299,12 +299,12 @@ fi
 
 if [ -f /etc/os-release ]; then
   # Run in a sub-shell so I can source os-release
-  VSI_DISTRO=$( source /etc/os-release;
+  VSI_DISTRO=$( . /etc/os-release;
 
                 # Only Ubuntues have this file
                 # Fix bug https://bugs.launchpad.net/linuxmint/+bug/1641491
                 if [ -f "/etc/lsb-release" ]; then
-                  source /etc/lsb-release
+                  . /etc/lsb-release
                   DISTRIB_ID=$(echo ${DISTRIB_ID} | sed 's|.*|\L&|')
                   if [ "${DISTRIB_ID}" != "${ID}" ]; then
                     echo "Fixing" >&2

--- a/linux/common_source.sh
+++ b/linux/common_source.sh
@@ -1,6 +1,6 @@
 #*# linux/common_source
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #**
 # =============

--- a/linux/common_source.sh
+++ b/linux/common_source.sh
@@ -298,12 +298,12 @@ fi
 
 if [ -f /etc/os-release ]; then
   # Run in a sub-shell so I can source os-release
-  VSI_DISTRO=$( . /etc/os-release;
+  VSI_DISTRO=$( source /etc/os-release;
 
                 # Only Ubuntues have this file
                 # Fix bug https://bugs.launchpad.net/linuxmint/+bug/1641491
                 if [ -f "/etc/lsb-release" ]; then
-                  . /etc/lsb-release
+                  source /etc/lsb-release
                   DISTRIB_ID=$(echo ${DISTRIB_ID} | sed 's|.*|\L&|')
                   if [ "${DISTRIB_ID}" != "${ID}" ]; then
                     echo "Fixing" >&2

--- a/linux/common_source.sh
+++ b/linux/common_source.sh
@@ -1,6 +1,7 @@
 #*# linux/common_source
 
-source_once &> /dev/null && return
+# Use the sh POSIX compliant version of source_once
+source_once > /dev/null 2>&1 && return
 
 #**
 # =============
@@ -549,6 +550,9 @@ VSI_ARCH="$(uname -m)"
 
 case "${VSI_OS}" in
   darwin)
+    if [ "$(sw_vers -buildVersion)" = "Darling" ]; then
+      VSI_DISTRO=darling
+    fi
     if command -v sysctl >/dev/null 2>&1; then # Normal darwin
       VSI_NUMBER_CORES="$(\sysctl -n hw.ncpu)"
     elif [ -f /Volumes/SystemRoot/proc/cpuinfo ]; then # darling

--- a/linux/common_source.sh
+++ b/linux/common_source.sh
@@ -1,5 +1,7 @@
 #*# linux/common_source
 
+source_once >&/dev/null && return
+
 #**
 # =============
 # Common Source

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 # Source this file
 
+source_once >&/dev/null && return
+
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 
 #*# linux/cuda_info

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -1,7 +1,9 @@
 #!/usr/bin/env false
 # Source this file
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/cuda_info
 

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -1,9 +1,7 @@
 #!/usr/bin/env false
 # Source this file
 
-source_once >&/dev/null && return
-
-: ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
+source_once &> /dev/null && return
 
 #*# linux/cuda_info
 

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -71,7 +71,7 @@ function discover_cuda_versions()
 # :Parameter: ``CUDA_DISCOVER`` - Default is disabled, set to ``1`` to enable.
 #
 # Flag to enable the discovery of CUDA cards and capabilities
-# 
+#
 # Because the ``CUDA`` card discovery can be expensive (milliseconds on some computers, hundreds on others), it is disabled by default.
 #
 # There are two methods for CUDA device discovery (in order):

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env false
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/dir_tools
 

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/dir_tools
 

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -243,3 +243,29 @@ basenames()
 
   echo ${components+"${components[*]:${min}}"}
 }
+
+dirname()
+{
+  # Remove trailing slashes
+  local dn="${1%${1##*[!/]}}"
+  dn=${dn%/*}
+  # If no slashes were found
+  if [ "${dn}" = "${1}" ]; then
+    # must be .
+    echo -n .
+  # /abc should be /, not empty
+  elif [ -z "${dn}" ]; then
+    echo -n /
+  else
+    # else found
+    echo -n "${dn}"
+  fi
+}
+
+basename()
+{
+  # Remove trailing slashes
+  local bn="${1%${1##*[!/]}}"
+  bn=${bn##*/}
+  echo -n "${bn}"
+}

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env false
 
+source_once >&/dev/null && return
+
 #*# linux/dir_tools
 
 #**

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -38,23 +38,23 @@ parent_find_files()
   done
 
   \pushd . > /dev/null
-  # Search for the file until some match is found
-  while [ "${#file_matches[@]}" -eq 0 ]; do
-    for name in "${@}"; do
-      if [ -f "${name}" ]; then
-        file_matches+=("$(\cd "$(\dirname "${name}")"; \pwd)/$(\basename "${name}")")
+    # Search for the file until some match is found
+    while [ "${#file_matches[@]}" -eq 0 ]; do
+      for name in "${@}"; do
+        if [ -f "${name}" ]; then
+          file_matches+=("$(\cd "$(dirname "${name}")"; \pwd)/$(basename "${name}")")
+        fi
+      done
+
+      pwd_before="${PWD}"
+
+      \cd ..
+
+      # This works both when PWD starts with / and //
+      if [ "${PWD}" == "${pwd_before}" ]; then
+        break
       fi
     done
-
-    pwd_before="${PWD}"
-
-    cd ..
-
-    # This works both when PWD starts with / and //
-    if [ "${PWD}" == "${pwd_before}" ]; then
-      break
-    fi
-  done
   \popd > /dev/null
 }
 

--- a/linux/docker_compose_override
+++ b/linux/docker_compose_override
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/mount_tools.bsh"

--- a/linux/docker_compose_override
+++ b/linux/docker_compose_override
@@ -399,7 +399,7 @@ function generate_docker_compose_override()
   done
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   set -eu
   generate_docker_compose_override ${@+"${@}"}
 fi

--- a/linux/docker_compose_override
+++ b/linux/docker_compose_override
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/mount_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/set_flags.bsh"

--- a/linux/docker_compose_override
+++ b/linux/docker_compose_override
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/mount_tools.bsh"

--- a/linux/docker_entrypoint.bsh
+++ b/linux/docker_entrypoint.bsh
@@ -285,7 +285,7 @@ function docker_setup_data_volumes()
   fi
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   set -eu
   docker_setup_user ${@+"${@}"} && \
   docker_link_mounts ${@+"${@}"} && \

--- a/linux/docker_entrypoint.bsh
+++ b/linux/docker_entrypoint.bsh
@@ -215,9 +215,8 @@ function docker_link_mounts()
         if [ -d "${JUST_DOCKER_ENTRYPOINT_LINKS[$((x+1))]}" ] && \
            [ ! -L "${JUST_DOCKER_ENTRYPOINT_LINKS[$((x+1))]}" ] && \
            [ "$(mount_point "${JUST_DOCKER_ENTRYPOINT_LINKS[$((x+1))]}")" = "/" ]; then
-        
-           rm -rf "${JUST_DOCKER_ENTRYPOINT_LINKS[$((x+1))]}"
-	fi
+          rm -rf "${JUST_DOCKER_ENTRYPOINT_LINKS[$((x+1))]}"
+        fi
 
         # Don't overwrite an existing file unless explicitly requested
         if ! retry_as_user test -e "${JUST_DOCKER_ENTRYPOINT_LINKS[$((x+1))]}" || \

--- a/linux/docker_functions.bsh
+++ b/linux/docker_functions.bsh
@@ -1,7 +1,9 @@
 #!/usr/bin/env false
 # Source this script for docker specific helper functions for just or other
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/mount_tools.bsh"

--- a/linux/docker_functions.bsh
+++ b/linux/docker_functions.bsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env false
 # Source this script for docker specific helper functions for just or other
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/mount_tools.bsh"

--- a/linux/docker_functions.bsh
+++ b/linux/docker_functions.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 # Source this script for docker specific helper functions for just or other
 
+source_once >&/dev/null && return
+
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/mount_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/docker_compose_override"

--- a/linux/elements.bsh
+++ b/linux/elements.bsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env false
 # Source this file
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/elements
 

--- a/linux/elements.bsh
+++ b/linux/elements.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 # Source this file
 
+source_once >&/dev/null && return
+
 #*# linux/elements
 
 #**

--- a/linux/elements.bsh
+++ b/linux/elements.bsh
@@ -82,15 +82,25 @@ function dynamic_set_a()
 # Slightly safer indirect clear array
 #
 # .. note::
-#   Still uses eval, but makes sure the variable name appears valid
+#   Still uses eval on older versions of bash, but makes sure the variable name appears valid
 #**
 function clear_a()
 {
-  # https://stackoverflow.com/a/2821201/4166604
-  if [[ ! ${1} =~ [a-zA-Z_]+[a-zA-Z0-9_]* ]]; then
-    return 1
+  if [ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -ge "44" ]; then
+    local -n localarray="${1}"
+    localarray=()
+  else
+    # https://stackoverflow.com/a/2821201/4166604
+    if [[ ! ${1} =~ [a-zA-Z_]+[a-zA-Z0-9_]* ]]; then
+      return 1
+    fi
+
+    # Do NOT use unset here. If you do that, you will lose "local" status if the
+    # variable that $1 points to has it. This can have MANY unintended
+    # consequences which is generally BAD! Gotta eval :(
+    # https://stackoverflow.com/questions/10497425/is-it-possible-to-use-array-in-bash#comment74842477_10497539
+    eval "${1}=()"
   fi
-  eval "${1}=()"
 }
 
 #**
@@ -132,11 +142,7 @@ function remove_element_a()
     fi
   done
 
-  # Do NOT use unset here. If you do that, you will lose "local" status if the
-  # variable that $1 points to has it. This can have MANY unintended
-  # consequences which is generally BAD! Gotta eval :(
-  # https://stackoverflow.com/questions/10497425/is-it-possible-to-use-array-in-bash#comment74842477_10497539
-  eval "${1}=()"
+  clear_a "${1}"
 
   # You can't use ${t+"${t[@]}"} notation when there is a chance that the first
   # element of an array has been unset. This will falsely trigger ${t} as not

--- a/linux/elements.bsh
+++ b/linux/elements.bsh
@@ -1,7 +1,9 @@
 #!/usr/bin/env false
 # Source this file
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/elements
 

--- a/linux/example_just
+++ b/linux/example_just
@@ -1,32 +1,25 @@
 #!/usr/bin/env bash
 # J.U.S.T. - J.U.S.T. useful simple tasking
 
-set -euE
+# Load environment variables
+source "${VSI_COMMON_DIR}/linux/just_env" "$(dirname "${BASH_SOURCE[0]}")/example.env"
 
-export CWD="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
-
-## Externally accessed variables, accessible via environment
-# I decided not to go with executing blind evals, for security reasons. Instead
-# variables need to be added to example.env.
-# local.env, example.env, local_post.env are sourced in that order
-source_environment_files "${CWD}/example.env"
 # # Example of example.env
-# : ${MY_UID=$(id -u)
-# : ${MY_GID=$(id -g)
-# : ${MAGIC_THRESHOLD=3.141592653}
-
-
-###### Default variables used in only just commands ######
-: ${JUST_A_FILE=tmp.txt}
-: ${JUST_A_NAME=$(basename "$(pwd)")}
+# : ${EXAMPLE_CWD="${CWD-"$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"}"}
+# : ${EXAMPLE_UID=$(id -u)
+# : ${EXAMPLE_GID=$(id -g)
+# : ${EXAMPLE_MAGIC_THRESHOLD=3.141592653}
+# : ${EXAMPLE_FILE=tmp.txt}
+# : ${EXAMPLE_NAME=$(basename "$(pwd)")}
 
 ### Functions
 # Put functions here
 function just_a_function()
 {
-  echo $JUST_A_FILE $1 $2
+  echo $EXAMPLE_FILE $1 $2
 }
 
+cd "${EXAMPLE_CWD}"
 ## Just modules
 
 function caseify()

--- a/linux/example_just
+++ b/linux/example_just
@@ -57,20 +57,14 @@ function caseify()
       extra_args+=2
       ;;
     d) #Show example on how to use .justfile
-      echo "JUST_A_FILE" > .justfile
+      echo "EXAMPLE_FILE" > .justfile
       echo "blah.txt" >> .justfile
       ;;
     f1) #Show what happens when a command is false
       echo "Attempting to fail"
       false
       ;;
-    f2) #Show how not to call caseify For example try "./just_example f2 111"
-      echo "Don't do this, this is the wrong way to use justify and consume an"
-      echo "argument ($1). See f3 for the correct way"
-      justify c $1 $1
-      extra_args+=1
-      ;;
-    f3) #Show how to call caseify For example try "./just_example f3 111"
+    f2) #Show how to call caseify (via justify). For example try "./just_example f2 111"
       echo "Argument $1 being consumed correctly"
       justify c $1 $1
       extra_args+=1

--- a/linux/file_tools.bsh
+++ b/linux/file_tools.bsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env false
 
+source_once >&/dev/null && return
+
 #*# linux/file_tools
 
 #**

--- a/linux/file_tools.bsh
+++ b/linux/file_tools.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/file_tools
 

--- a/linux/file_tools.bsh
+++ b/linux/file_tools.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env false
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/file_tools
 

--- a/linux/findin
+++ b/linux/findin
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 #*# linux/findin
 
 #**

--- a/linux/findin
+++ b/linux/findin
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/findin
 

--- a/linux/findin
+++ b/linux/findin
@@ -56,7 +56,7 @@ function findin()
   echo -1
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   findin "${@}"
   exit $?
 fi

--- a/linux/findin
+++ b/linux/findin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/findin
 

--- a/linux/findinpaths
+++ b/linux/findinpaths
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/findinpaths
 

--- a/linux/findinpaths
+++ b/linux/findinpaths
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/findinpaths
 

--- a/linux/findinpaths
+++ b/linux/findinpaths
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 #*# linux/findinpaths
 
 #**

--- a/linux/findinpaths
+++ b/linux/findinpaths
@@ -50,7 +50,7 @@ function findinpaths()
   done
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   findinpaths "${@}"
   exit $?
 fi

--- a/linux/inisin
+++ b/linux/inisin
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/inisin
 

--- a/linux/inisin
+++ b/linux/inisin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/inisin
 

--- a/linux/inisin
+++ b/linux/inisin
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 #*# linux/inisin
 
 #**

--- a/linux/inisin
+++ b/linux/inisin
@@ -56,7 +56,7 @@ function inisin()
   return 1
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   inisin "${@}"
   exit $?
 fi

--- a/linux/isin
+++ b/linux/isin
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 #*# linux/isin
 
 #**

--- a/linux/isin
+++ b/linux/isin
@@ -56,7 +56,7 @@ function isin()
   return 1
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   isin "${@}"
   exit $?
 fi

--- a/linux/isin
+++ b/linux/isin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/isin
 

--- a/linux/isin
+++ b/linux/isin
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/isin
 

--- a/linux/just
+++ b/linux/just
@@ -209,6 +209,7 @@ trap 'print_error "${BASH_SOURCE[0]}" "${LINENO}"' ERR
 JUST_IN_SCRIPT=1
 
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
+source "${VSI_COMMON_DIR}/linux/source_once.bsh"
 source "${VSI_COMMON_DIR}/linux/just_functions.bsh"
 
 #**

--- a/linux/just
+++ b/linux/just
@@ -207,8 +207,9 @@ trap 'print_error "${BASH_SOURCE[0]}" "${LINENO}"' ERR
 # Currently one use of this is dual purposing a file, so that it behaves differently when sourced by just or by a user on the prompts
 #**
 JUST_IN_SCRIPT=1
-
-: ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
+if [ -z ${VSI_COMMON_DIR+set} ]; then
+  VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+fi
 source "${VSI_COMMON_DIR}/linux/source_once.bsh"
 source "${VSI_COMMON_DIR}/linux/just_functions.bsh"
 

--- a/linux/just
+++ b/linux/just
@@ -210,6 +210,9 @@ JUST_IN_SCRIPT=1
 if [ -z ${VSI_COMMON_DIR+set} ]; then
   VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 fi
+# Speed up dirname/basename
+source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
+# Activate source_once
 source "${VSI_COMMON_DIR}/linux/source_once.bsh"
 source "${VSI_COMMON_DIR}/linux/just_functions.bsh"
 

--- a/linux/just_common.bsh
+++ b/linux/just_common.bsh
@@ -113,7 +113,7 @@ unset _last_just_version
 #
 # .. function:: _just_commands_from_file
 #
-# :Arguments: ``$1`` - Filename of Justfile to be parsed
+# :Arguments: ``$1``... - Filename(s) of Justfile to be parsed
 #
 # Parses Justfile for help comments on targets. It looks for all case statements with a comment at the end. It will also parse
 # commented case statements that exist for the purpose of populating the help
@@ -158,7 +158,7 @@ function _just_commands_from_file()
             # Continue processing until no matches
             t processloop
             p
-            :noprint' "${1}"
+            :noprint' ${@+"${@}"}
 }
 
 #**
@@ -235,11 +235,8 @@ function _just_parse_helps()
   local i
   local target
   local target_array
-  parsed_help_a=()
 
-  for filename in ${@+"${@}"}; do
-    parsed_help_a+=($(_just_commands_from_file "${filename}"))
-  done
+  parsed_help_a=($(_just_commands_from_file ${@+"${@}"}))
 
   # Target expansion magic
   for i in "${!parsed_help_a[@]}"; do

--- a/linux/just_common.bsh
+++ b/linux/just_common.bsh
@@ -25,7 +25,7 @@
 source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
 
 _last_just_version=${JUST_VERSION-}
-export JUST_VERSION=0.0.14
+export JUST_VERSION=0.1.0
    # If last just version was set and different
 if [ -n "${_last_just_version:+set}" ] && \
    [ "${_last_just_version}" != "${JUST_VERSION}" ]; then

--- a/linux/just_docker_functions.bsh
+++ b/linux/just_docker_functions.bsh
@@ -1,4 +1,4 @@
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 JUST_DEFAULTIFY_FUNCTIONS+=(docker_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")

--- a/linux/just_docker_functions.bsh
+++ b/linux/just_docker_functions.bsh
@@ -1,3 +1,5 @@
+source_once >&/dev/null && return
+
 JUST_DEFAULTIFY_FUNCTIONS+=(docker_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 

--- a/linux/just_docker_functions.bsh
+++ b/linux/just_docker_functions.bsh
@@ -1,4 +1,6 @@
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 JUST_DEFAULTIFY_FUNCTIONS+=(docker_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")

--- a/linux/just_docker_functions.bsh
+++ b/linux/just_docker_functions.bsh
@@ -224,7 +224,8 @@ function _docker_clean_actions()
       if [[ ${volume_inspect} =~ $pattern ]]; then
         # Parse \" to "
         setup_cmd="${BASH_REMATCH[1]//\\\"/\"}"
-        # Evaluate this string into arguments
+        # Evaluate this string into arguments. By definition this is arbitrary
+        # code execution, so eval is acceptable.
         eval "setup_cmd=(${setup_cmd})"
         # Run the just target
         justify "${setup_cmd[@]}"

--- a/linux/just_docs_functions.bsh
+++ b/linux/just_docs_functions.bsh
@@ -1,3 +1,5 @@
+source_once >&/dev/null && return
+
 JUST_DEFAULTIFY_FUNCTIONS+=(docs_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 

--- a/linux/just_docs_functions.bsh
+++ b/linux/just_docs_functions.bsh
@@ -1,4 +1,6 @@
-source_once &> /dev/null && return
+if command -v source_once &> /dev/null; then
+  source_once && return
+fi
 
 JUST_DEFAULTIFY_FUNCTIONS+=(docs_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
@@ -107,6 +109,7 @@ function _docs_docker_compose()
       DOCS_DIR="${docs_dir}" \
       VSI_COMMON_UID="${uid}" \
       VSI_COMMON_GID="${gid}" \
+      JUST_PROJECT_FILE="${VSI_PATH_ESC}/src/$(basename "${JUST_PROJECT_FILE}")" \
       Docker-compose \
          -f "${VSI_COMMON_DIR}/docker-compose-docs.yml" ${@+"${@}"}
 }
@@ -255,10 +258,44 @@ function docs_defaultify()
       docker cp ${image_name}:/venv/Pipfile.lock "${VSI_COMMON_DIR}/docs/docker/Pipfile.lock"
       docker rm ${image_name}
       ;;
+    # docs_run)
+    #   # For debugging only
+    #   _docs_docker_compose run pipenv-update bash
+    #   ;;
+    # docs_pipenv-update) Update docs Pipenv file
+    #   local container="$(_docs_docker_compose ps -q)"
+
+    #   if [ "${container}" != "" ]; then
+    #     echo "Docs containers (${container}) are already running, please remove containers and try again"
+    #   fi
+
+    #   _docs_docker_compose up --no-start \
+    #     pipenv-update
+
+    #   container="$(_docs_docker_compose ps -q)"
+
+    #   image_name=$(Docker create vsiri/sphinxdocs:compile pipenv update)
+    #   Docker start -a "${container}"
+    #   Docker cp ${container}:/venv/Pipfile.lock "${VSI_COMMON_DIR}/docs/docker/Pipfile.lock"
+    #   Docker rm ${container}
+    #   ;;
+
+    docs_pipenv-update) # Update docs Pipenv file
+      local secs="$(date +%s)" #Get a random (enough) number
+
+      # Invalidate the lock file
+      sed -i 's|"sha256": ".*"|"sha256": "'"${secs}"'"|' "${VSI_COMMON_DIR}/docs/docker/Pipfile.lock"
+
+      justify docs build
+
+      # _docs_docker_compose run docs bash -c '
+      #   gosu root pipenv update
+      #   gosu root chown user:user "${PIPENV_PIPFILE}.lock"'
+      ;;
+
     docs_setup) # Setup a new sphinx project
       mkdir -p "${docs_dir}"
-      _docs_docker_compose \
-          -f "${VSI_COMMON_DIR}/docker-compose-docs.yml" run \
+      _docs_docker_compose run \
           docs bash -c "cd /docs; sphinx-quickstart"
       ;;
     docs_compile) # Compile spinx documents
@@ -272,10 +309,8 @@ function docs_defaultify()
       set_temp_array "${JUST_PROJECT_PREFIX}_DOCS_AUTODOC_OUTPUT_DIRS"
       local autodoc_output_dirs=(${JUST_TEMP_ARRAY+"${JUST_TEMP_ARRAY[@]}"})
 
-      _docs_docker_compose \
-          -f "${VSI_COMMON_DIR}/docker-compose-docs.yml" run \
+      _docs_docker_compose run \
           -e SPHINXOPTS \
-          -e JUST_PROJECT_FILE="${VSI_PATH_ESC}/src/$(basename "${JUST_PROJECT_FILE}")" \
           -e DOCS_EXCLUDE_DIRS="$(_docs_serialize_dirs "${exclude_dirs[@]}")" \
           -e DOCS_AUTODOC_EXCLUDE_DIRS="$(_docs_serialize_dirs "${autodoc_exclude_dirs[@]}")" \
           -e DOCS_AUTODOC_DIRS="$(_docs_serialize_dirs "${autodoc_dirs[@]}")" \

--- a/linux/just_docs_functions.bsh
+++ b/linux/just_docs_functions.bsh
@@ -275,7 +275,7 @@ function docs_defaultify()
       _docs_docker_compose \
           -f "${VSI_COMMON_DIR}/docker-compose-docs.yml" run \
           -e SPHINXOPTS \
-          -e JUST_PROJECT_FILE="${VSI_PATH_ESC}/src/${JUST_PROJECT_FILE##*/}" \
+          -e JUST_PROJECT_FILE="${VSI_PATH_ESC}/src/$(basename "${JUST_PROJECT_FILE}")" \
           -e DOCS_EXCLUDE_DIRS="$(_docs_serialize_dirs "${exclude_dirs[@]}")" \
           -e DOCS_AUTODOC_EXCLUDE_DIRS="$(_docs_serialize_dirs "${autodoc_exclude_dirs[@]}")" \
           -e DOCS_AUTODOC_DIRS="$(_docs_serialize_dirs "${autodoc_dirs[@]}")" \
@@ -296,7 +296,7 @@ function docs_defaultify()
         # "open" is for macos
         browsers=(xdg-open google-chrome chromium-browser firefox open)
         for browser in "${browsers[@]}"; do
-          if command -v "${browser}" >& /dev/null; then
+          if command -v "${browser}" &> /dev/null; then
             "${browser}" "${html_file}"
             found=1
             break

--- a/linux/just_docs_functions.bsh
+++ b/linux/just_docs_functions.bsh
@@ -1,4 +1,4 @@
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 JUST_DEFAULTIFY_FUNCTIONS+=(docs_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")

--- a/linux/just_docs_functions.bsh
+++ b/linux/just_docs_functions.bsh
@@ -243,7 +243,7 @@ function docs_defaultify()
       ;;
     docs_build) # Build the sphinx docker images
       if [ "${DOCS_COMPILE_IMAGE-vsiri/sphinxdocs:compile}" != "vsiri/sphinxdocs:compile" ]; then
-        . "${VSI_COMMON_DIR}/linux/colors.bsh"
+        source "${VSI_COMMON_DIR}/linux/colors.bsh"
         echo "${RED}ERROR${NC}: You should use your own Justfile to build \"${DOCS_COMPILE_IMAGE}\"" >&2
         false
       fi

--- a/linux/just_env
+++ b/linux/just_env
@@ -17,6 +17,8 @@
 #   If another file is needed to load the project environment successfully,
 #   then it should be added to the just_plugins
 #
+# :Outputs: ``VSI_PATH_ESC`` - Sets :env:`VSI_PATH_ESC`
+#
 # Source the project environment. Loads the core components of just needed to load the project environment
 # successfully.
 #
@@ -27,5 +29,10 @@
 # Source the environment
 source "${VSI_COMMON_DIR}/env.bsh"
 source "${VSI_COMMON_DIR}/linux/just_functions.bsh"
-source "${VSI_COMMON_DIR}/linux/common_source.sh"
+# source "${VSI_COMMON_DIR}/linux/common_source.sh"
+if [[ ${OS} == Windows_NT && ! ${OSTYPE-} =~ cygwin.* ]]; then
+  VSI_PATH_ESC='/'
+else
+  VSI_PATH_ESC=''
+fi
 source_environment_files "${1}"

--- a/linux/just_env
+++ b/linux/just_env
@@ -12,6 +12,7 @@
 # .. file:: just_env
 #
 # :Inputs: ``$1`` - The project environment filename. Argument to source_environment_files
+#          ``VSI_COMMON_DIR`` - :env:`VSI_COMMON_DIR` should already be set to the vsi_common source directory
 #
 #   If another file is needed to load the project environment successfully,
 #   then it should be added to the just_plugins
@@ -24,7 +25,6 @@
 #**
 
 # Source the environment
-: ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/env.bsh"
 source "${VSI_COMMON_DIR}/linux/just_functions.bsh"
 source "${VSI_COMMON_DIR}/linux/common_source.sh"

--- a/linux/just_env
+++ b/linux/just_env
@@ -30,7 +30,7 @@
 source "${VSI_COMMON_DIR}/env.bsh"
 source "${VSI_COMMON_DIR}/linux/just_functions.bsh"
 # source "${VSI_COMMON_DIR}/linux/common_source.sh"
-if [[ ${OS} == Windows_NT && ! ${OSTYPE-} =~ cygwin.* ]]; then
+if [[ ${OS-} == Windows_NT && ! ${OSTYPE-} =~ cygwin.* ]]; then
   VSI_PATH_ESC='/'
 else
   VSI_PATH_ESC=''

--- a/linux/just_env
+++ b/linux/just_env
@@ -25,7 +25,7 @@
 
 # Source the environment
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
-. "${VSI_COMMON_DIR}/env.bsh"
-. "${VSI_COMMON_DIR}/linux/just_functions.bsh"
-. "${VSI_COMMON_DIR}/linux/common_source.sh"
+source "${VSI_COMMON_DIR}/env.bsh"
+source "${VSI_COMMON_DIR}/linux/just_functions.bsh"
+source "${VSI_COMMON_DIR}/linux/common_source.sh"
 source_environment_files "${1}"

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -342,9 +342,12 @@ function source_environment_files()
   # macOS case sh somehow get invoked by python on start, and thus complains if
   # a function name with a hyphen in it has been exported. Again, this is
   # harmless but annoying
-  for x in $(declare -Fx | awk '{print $3}'); do
-    export -fn "${x}"
-  done
+  while IFS= read -r x || [[ -n ${x} ]] ; do
+    x=${x##* }
+    if [[ ${x} = *-* ]]; then
+      export -fn $x
+    fi
+  done < <(declare -Fx)
 }
 
 #**

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -1,7 +1,9 @@
 #!/usr/bin/env false
 # Source this script to access just functionality
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -336,7 +336,7 @@ function source_environment_files()
            "${1}" \
            "${JUST_LOCAL_SETTINGS_POST}"; do
     if [ -f "${x}" ]; then
-      . "${x}"
+      source "${x}"
     fi
   done
   reset_flag a

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -950,7 +950,7 @@ function _justify()
             defaultify "${target}${@}"
           fi
           if (( $extra_args+1 > $# )); then
-            . "${VSI_COMMON_DIR}/linux/colors.bsh"
+            source "${VSI_COMMON_DIR}/linux/colors.bsh"
             echo "${RED}JUST ERROR${NC}: Not enough arguments for \"${target}${1-}\" target" >&2
           fi
           shift $extra_args
@@ -974,7 +974,7 @@ function _justify()
       fi
     fi
     if (( $extra_args+1 > $# )); then
-      . "${VSI_COMMON_DIR}/linux/colors.bsh"
+      source "${VSI_COMMON_DIR}/linux/colors.bsh"
       echo "${RED}JUST ERROR${NC}: Not enough arguments for \"${target}${1-}\" target" >&2
     fi
     shift $extra_args

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -19,16 +19,12 @@ source_once &> /dev/null && return
 # A few functions are defined in a common. Sourced here for DRY
 #**
 
-source "${VSI_COMMON_DIR}/linux/just_common.bsh"
-
-#**
 # Preload some files
-#**
-
+source "${VSI_COMMON_DIR}/linux/just_common.bsh"
 source "${VSI_COMMON_DIR}/linux/isin"
 source "${VSI_COMMON_DIR}/linux/set_flags.bsh"
 source "${VSI_COMMON_DIR}/linux/elements.bsh"
-
+source "${VSI_COMMON_DIR}/linux/findin"
 
 #**
 # .. env:: DRYRUN
@@ -516,13 +512,17 @@ function print_help()
 
   local OLD_IFS="${IFS}"
   IFS=$'\n'
-  # Print non-flag first and non-subcommand_subtargets
-  ( grep -E -v '^-|^[?*a-zA-Z0-9\-]+_[?*a-zA-Z0-9_\-]+' |
-    sort |
-    pretty_print_help ) <<< "${parsed_help_a[*]}"
+  {
+    # Print non-flag first and non-subcommand_subtargets
+    {
+      grep -E -v '^-|^[?*a-zA-Z0-9\-]+_[?*a-zA-Z0-9_\-]+' | sort
+    } <<< "${parsed_help_a[*]}"
 
-  # Print flags second
-  ( grep -E '^-[?*a-zA-Z0-9\|\-]+( |$)' | sort | pretty_print_help ) <<< "${parsed_help_a[*]}"
+    # Print flags second
+    {
+      grep -E '^-[?*a-zA-Z0-9\|\-]+( |$)' | sort
+    } <<< "${parsed_help_a[*]}"
+  } | pretty_print_help
   IFS="${OLD_IFS}"
 
   echo
@@ -1048,11 +1048,6 @@ declare -i get_args_args_used
 function get_args()
 {
   local next_break
-
-  # Since this is not used often, only source in this function
-  if ! decalre -f findin &> /dev/null; then
-    source "${VSI_COMMON_DIR-"$(dirname "${BASH_SOURCE[0]}")/.."}/linux/findin"
-  fi
 
   args=()
   : ${extra_args=0}

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env false
 # Source this script to access just functionality
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 # Source this script to access just functionality
 
+source_once >&/dev/null && return
+
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 
 #*# just/just_functions

--- a/linux/just_git_functions.bsh
+++ b/linux/just_git_functions.bsh
@@ -1,4 +1,6 @@
-source_once >&/dev/null && return
+#!/usr/bin/env false
+
+source_once &> /dev/null && return
 
 JUST_DEFAULTIFY_FUNCTIONS+=(git_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")

--- a/linux/just_git_functions.bsh
+++ b/linux/just_git_functions.bsh
@@ -1,3 +1,5 @@
+source_once >&/dev/null && return
+
 JUST_DEFAULTIFY_FUNCTIONS+=(git_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 

--- a/linux/just_git_functions.bsh
+++ b/linux/just_git_functions.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 JUST_DEFAULTIFY_FUNCTIONS+=(git_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")

--- a/linux/just_robodoc_functions.bsh
+++ b/linux/just_robodoc_functions.bsh
@@ -1,3 +1,5 @@
+source_once >&/dev/null && return
+
 JUST_DEFAULTIFY_FUNCTIONS+=(robodoc_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 

--- a/linux/just_robodoc_functions.bsh
+++ b/linux/just_robodoc_functions.bsh
@@ -1,4 +1,6 @@
-source_once >&/dev/null && return
+#!/usr/bin/env false
+
+source_once &> /dev/null && return
 
 JUST_DEFAULTIFY_FUNCTIONS+=(robodoc_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")

--- a/linux/just_robodoc_functions.bsh
+++ b/linux/just_robodoc_functions.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 JUST_DEFAULTIFY_FUNCTIONS+=(robodoc_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")

--- a/linux/linux_accounts.bsh
+++ b/linux/linux_accounts.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/file_tools.bsh"

--- a/linux/linux_accounts.bsh
+++ b/linux/linux_accounts.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/file_tools.bsh"

--- a/linux/linux_accounts.bsh
+++ b/linux/linux_accounts.bsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/file_tools.bsh"
 

--- a/linux/lwhich
+++ b/linux/lwhich
@@ -46,7 +46,7 @@ function usage()
   echo
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   if (( $# )); then
     bits=64
     while (( $# )); do

--- a/linux/mount_tools.bsh
+++ b/linux/mount_tools.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/false
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/mount_tools
 

--- a/linux/mount_tools.bsh
+++ b/linux/mount_tools.bsh
@@ -1,5 +1,7 @@
 #!/usr/bin/false
 
+source_once >&/dev/null && return
+
 #*# linux/mount_tools
 
 #**

--- a/linux/mount_tools.bsh
+++ b/linux/mount_tools.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/false
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/mount_tools
 

--- a/linux/multibook
+++ b/linux/multibook
@@ -42,7 +42,7 @@ done
 
 # Activate virtualenv
 set +u
-. "${venv_dir}/bin/activate"
+source "${venv_dir}/bin/activate"
 set -u
 
 # Install key components

--- a/linux/new_just
+++ b/linux/new_just
@@ -992,11 +992,13 @@ if [ "${USE_DOCKER}" = "1" ]; then
 
               set -eu
 
+              : ${VSI_COMMON_DIR:=/vsi}
+
               if [ "${ALREADY_RUN_ONCE+set}" != "set" ]; then
                 # create the user and associated groups and handle nfs symlinks
 
                 (
-                  source "${VSI_COMMON_DIR:-/vsi}/linux/just_env" "${'"${PROJECT_PREFIX}"'_SOURCE_DIR-/src}/'"${PROJECT_NAME}"'.env"
+                  source "${VSI_COMMON_DIR}/linux/just_env" "${'"${PROJECT_PREFIX}"'_SOURCE_DIR-/src}/'"${PROJECT_NAME}"'.env"
                   # Setup the container to be more friendly to non-root users and
                   # add other advanced J.U.S.T. features
                   JUST_DOCKER_ENTRYPOINT_CHOWN_DIRS="${JUST_DOCKER_ENTRYPOINT_INTERNAL_VOLUMES-}" \
@@ -1019,7 +1021,7 @@ if [ "${USE_DOCKER}" = "1" ]; then
                 ALREADY_RUN_ONCE=1 exec gosu ${DOCKER_USERNAME} /usr/bin/env bash $0 ${@+"${@}"}
               fi
 
-              source "${VSI_COMMON_DIR:-/vsi}/linux/just_env" "${'"${PROJECT_PREFIX}"'_SOURCE_DIR-/src}/'"${PROJECT_NAME}"'.env"
+              source "${VSI_COMMON_DIR}/linux/just_env" "${'"${PROJECT_PREFIX}"'_SOURCE_DIR-/src}/'"${PROJECT_NAME}"'.env"
 
               function sudo()
               {

--- a/linux/new_just
+++ b/linux/new_just
@@ -605,6 +605,7 @@ if [ ! -e "${PROJECT_NAME}.env" ]; then
             : ${'"${PROJECT_PREFIX}"'_SOURCE_DIR_DOCKER="${VSI_PATH_ESC}/src"}
             : ${'"${PROJECT_PREFIX}"'_SOURCE_DIR_TYPE=bind}
 
+            source "${VSI_COMMON_DIR}/linux/common_source.sh" # define VSI_OS
             if [ "${VSI_OS}" = "linux" ]; then
               '"${PROJECT_PREFIX}"'_VOLUMES=("/tmp/.X11-unix:/tmp/.X11-unix:ro"
                   ${'"${PROJECT_PREFIX}"'_VOLUMES+"${'"${PROJECT_PREFIX}"'_VOLUMES[@]}"})
@@ -630,7 +631,7 @@ if [ ! -e "${PROJECT_NAME}.env" ]; then
             # important when multiple users are using this docker-compose project on a
             # single host. This way all of the docker resources are prefixed with a unique
             # name and do not collide
-            source "${VSI_COMMON_DIR}/linux/docker_functions.bsh"
+            source "${VSI_COMMON_DIR}/linux/docker_functions.bsh" # define docker_compose_sanitize_project_name
             : ${COMPOSE_PROJECT_NAME=$(docker_compose_sanitize_project_name "${'"${PROJECT_PREFIX}"'_CWD}" "${'"${PROJECT_PREFIX}"'_USERNAME}")}
             ' >> "${PROJECT_NAME}.env"
   fi

--- a/linux/new_just
+++ b/linux/new_just
@@ -567,9 +567,9 @@ if [ "${USE_VSI_COMMON}" = "1" ]; then
   #################
 
   if [ ! -e "${SETUPFILE}" ]; then
-    uwecho 'export JUST_SETUP_SCRIPT="$(\basename "${BASH_SOURCE[0]}")"
+    uwecho 'export JUST_SETUP_SCRIPT="$(basename "${BASH_SOURCE[0]}")"
             unset JUST_VERSION
-            source "$(\cd "$(\dirname "${BASH_SOURCE[0]}")"; \pwd)/"'"$(quote_escape "${RELATIVE_PATH}")"'/env.bsh' > "${SETUPFILE}"
+            source "$(dirname "${BASH_SOURCE[0]}")/"'"$(quote_escape "${RELATIVE_PATH}/env.bsh")" > "${SETUPFILE}"
     if [ "${JUSTFILE}" != "Justfile" ]; then
       echo "export JUSTFILE=$(quote_escape "${JUSTFILE}")" >> "${SETUPFILE}"
     else

--- a/linux/picker
+++ b/linux/picker
@@ -88,7 +88,7 @@ function picker()
 }
 
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   picker my_choice ${@+"${@}"}
   echo ${my_choice}
   exit $((${my_choice_index--1}+1))

--- a/linux/picker
+++ b/linux/picker
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 #*# linux/picker
 
 #**

--- a/linux/picker
+++ b/linux/picker
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/picker
 

--- a/linux/picker
+++ b/linux/picker
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/picker
 

--- a/linux/postisin
+++ b/linux/postisin
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 #*# linux/postisin
 
 #**

--- a/linux/postisin
+++ b/linux/postisin
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/postisin
 

--- a/linux/postisin
+++ b/linux/postisin
@@ -56,7 +56,7 @@ function postisin()
   return 1
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   postisin "${@}"
   exit $?
 fi

--- a/linux/postisin
+++ b/linux/postisin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/postisin
 

--- a/linux/preisin
+++ b/linux/preisin
@@ -56,7 +56,7 @@ function preisin()
   return 1
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   preisin "${@}"
   exit $?
 fi

--- a/linux/preisin
+++ b/linux/preisin
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/preisin
 

--- a/linux/preisin
+++ b/linux/preisin
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 #*# linux/preisin
 
 #**

--- a/linux/preisin
+++ b/linux/preisin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/preisin
 

--- a/linux/print_command
+++ b/linux/print_command
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/print_command
 

--- a/linux/print_command
+++ b/linux/print_command
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/print_command
 

--- a/linux/print_command
+++ b/linux/print_command
@@ -69,6 +69,6 @@ function print_command()
   # fi
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   print_command ${@+"${@}"}
 fi

--- a/linux/print_command
+++ b/linux/print_command
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 #*# linux/print_command
 
 #**

--- a/linux/quotemire
+++ b/linux/quotemire
@@ -83,6 +83,6 @@ function quotemire()
   echo "${args}"
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   quotemire ${@+"${@}"}
 fi

--- a/linux/quotemire
+++ b/linux/quotemire
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/print_command"
 

--- a/linux/quotemire
+++ b/linux/quotemire
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/print_command"

--- a/linux/quotemire
+++ b/linux/quotemire
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 : ${VSI_COMMON_DIR="$(dirname "${BASH_SOURCE[0]}")/.."}
 source "${VSI_COMMON_DIR}/linux/print_command"

--- a/linux/real_path
+++ b/linux/real_path
@@ -35,7 +35,7 @@ function real_path_manual()
     do
       target="$(readlink "$target")"
       cd "$(dirname "${target}")"
-      target="$(basename "${target/}")"
+      target="$(basename "${target}")"
     done
 
     local physical_dir="$(pwd -P)"

--- a/linux/real_path
+++ b/linux/real_path
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/real_path
 

--- a/linux/real_path
+++ b/linux/real_path
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/real_path
 
@@ -28,23 +28,24 @@ source_once >&/dev/null && return
 #**
 function real_path_manual()
 { # Mainly for Darwin
-  cd "$(dirname "$1")"
-  local target="$(basename "$1")"
+  pushd "$(dirname "${1}")" &> /dev/null
+    local target="$(basename "${1}")"
 
-  while [ -L "$target" ]
-  do
-    target="$(readlink "$target")"
-    cd "$(dirname "$target")"
-    target="$(basename "$target")"
-  done
+    while [ -L "$target" ]
+    do
+      target="$(readlink "$target")"
+      cd "$(dirname "${target}")"
+      target="$(basename "${target/}")"
+    done
 
-  local physical_dir="$(pwd -P)"
+    local physical_dir="$(pwd -P)"
 
-  if [ "${target}" = "." ]; then
-    target=""
-  else
-    target="/${target}"
-  fi
+    if [ "${target}" = "." ]; then
+      target=""
+    else
+      target="/${target}"
+    fi
+  popd &> /dev/null
 
   if [ "${physical_dir}" = "/" ]; then
     # Special case: because pwd and basename are both /, it became // because
@@ -59,7 +60,7 @@ function real_path_manual()
   fi
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   if ! cmd=$(command -v realpath); then
     cmd="readlink -f"
     if ! ${cmd} / > /dev/null 2>&1; then

--- a/linux/real_path
+++ b/linux/real_path
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 #*# linux/real_path
 
 #**

--- a/linux/relpath
+++ b/linux/relpath
@@ -77,7 +77,7 @@ function relpath()
   echo "$relative"
 }
 
-if [[ ${BASH_SOURCE[0]} == ${0} ]] || [[ $(basename "${BASH_SOURCE[0]}") == ${0} ]]; then
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   relpath ${@+"${@}"}
   exit $?
 fi

--- a/linux/relpath
+++ b/linux/relpath
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/relpath
 

--- a/linux/relpath
+++ b/linux/relpath
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/relpath
 

--- a/linux/relpath
+++ b/linux/relpath
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source_once >&/dev/null && return
+
 #*# linux/relpath
 
 #**

--- a/linux/set_flags.bsh
+++ b/linux/set_flags.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/false
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/set_flags
 

--- a/linux/set_flags.bsh
+++ b/linux/set_flags.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/false
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/set_flags
 

--- a/linux/set_flags.bsh
+++ b/linux/set_flags.bsh
@@ -1,5 +1,7 @@
 #!/usr/bin/false
 
+source_once >&/dev/null && return
+
 #*# linux/set_flags
 
 #**

--- a/linux/source_once.bsh
+++ b/linux/source_once.bsh
@@ -1,12 +1,24 @@
 #!/usr/bin/env false
 
-# How you use source_once
-source_once &> /dev/null && return
-
-# For old sh implementations like dash, use
-# source_once > /dev/null 2>&1 && return
-
 # Needs documentation
+
+# How you use source_once
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
+
+# A simpler version, that should not be used for files inteded to be source
+# by the user from command line, as packagekit will be triggered, and have
+# undesired time delays
+#
+# source_once &> /dev/null &&  return
+
+# # For old sh implementations like dash, use
+# # source_once > /dev/null 2>&1 && return
+# # Of course, souce_once.bsh is not dash compatible, but at least the line that
+# # attempts to call source_once will be dash compatible
+
+
 function source_once()
 {
   if [ "${BASH_VERSINFO[0]}" -gt 3 ]; then
@@ -31,6 +43,6 @@ function source_once()
   return 0
 }
 
-# Only the ``source_once`` file itself needs to call this at the end. Set's up
+# Only the source_once file itself needs to call this at the end. Set's up
 # the already sourced variable for this file
 source_once || :

--- a/linux/source_once.bsh
+++ b/linux/source_once.bsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env false
 
 # How you use source_once
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 # Needs documentation
 function source_once()

--- a/linux/source_once.bsh
+++ b/linux/source_once.bsh
@@ -3,6 +3,9 @@
 # How you use source_once
 source_once &> /dev/null && return
 
+# For old sh implementations like dash, use
+# source_once > /dev/null 2>&1 && return
+
 # Needs documentation
 function source_once()
 {
@@ -18,8 +21,10 @@ function source_once()
     # Create an indirect variable using the calling file's name
     local SOURCE_VAR="_VSI_ALREADY_SOURCED_${BASH_SOURCE[1]//[^a-zA-Z0-9_]/_}"
     if [ -z "${!SOURCE_VAR+set}" ]; then
-      # Have to use eval in bash 3.2, declare won't be global
-      eval "${SOURCE_VAR}=1"
+      # Declare global, but make sure it's not exported. This works as intended
+      # in case set -a is turned on. No need for an if statement, as this just
+      # sets it exactly how we want it and is faster than anything else.
+      export -n "${SOURCE_VAR}=1"
       return 1
     fi
   fi

--- a/linux/source_once.bsh
+++ b/linux/source_once.bsh
@@ -1,3 +1,4 @@
+#!/usr/bin/env false
 
 # How you use source_once
 source_once >&/dev/null && return

--- a/linux/string_tools.bsh
+++ b/linux/string_tools.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/string_tools
 

--- a/linux/string_tools.bsh
+++ b/linux/string_tools.bsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env false
 
+source_once >&/dev/null && return
+
 #*# linux/string_tools
 
 #**

--- a/linux/string_tools.bsh
+++ b/linux/string_tools.bsh
@@ -15,6 +15,9 @@ source_once &> /dev/null && return
 #
 #**
 
+
+# https://stackoverflow.com/a/3352015/4166604
+
 #**
 # .. function:: ltrim
 #

--- a/linux/string_tools.bsh
+++ b/linux/string_tools.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env false
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/string_tools
 

--- a/linux/time_tools.bsh
+++ b/linux/time_tools.bsh
@@ -1,3 +1,6 @@
+#!/usr/bin/env false
+
+source_once >&/dev/null && return
 
 #*# linux/time_tools
 

--- a/linux/time_tools.bsh
+++ b/linux/time_tools.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env false
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/time_tools
 

--- a/linux/time_tools.bsh
+++ b/linux/time_tools.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/time_tools
 

--- a/linux/uwecho.bsh
+++ b/linux/uwecho.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env false
 
-source_once >&/dev/null && return
+source_once &> /dev/null && return
 
 #*# linux/uwecho
 

--- a/linux/uwecho.bsh
+++ b/linux/uwecho.bsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env false
 
-source_once &> /dev/null && return
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return
+fi
 
 #*# linux/uwecho
 

--- a/linux/uwecho.bsh
+++ b/linux/uwecho.bsh
@@ -1,3 +1,6 @@
+#!/usr/bin/env false
+
+source_once >&/dev/null && return
 
 #*# linux/uwecho
 

--- a/setup.env
+++ b/setup.env
@@ -1,3 +1,3 @@
 export JUST_SETUP_SCRIPT="$(basename "${BASH_SOURCE[0]}")"
 unset JUST_VERSION
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)/env.bsh"
+source "$(dirname "${BASH_SOURCE[0]}")/env.bsh"

--- a/tests/int/test-common_source.bsh
+++ b/tests/int/test-common_source.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/../testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/../test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"

--- a/tests/int/test-common_source.bsh
+++ b/tests/int/test-common_source.bsh
@@ -10,7 +10,7 @@ VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
 OSES=(
   clearlinux@sha256:2cf6333893ae5e28ab1645d9f448430f06167c791a9f9aee5976f81c573e3791
   amazonlinux@sha256:b852ce504670f604074bb0a0285849c95541453c39da4a6abe19c096695ccfca
-  debian:7
+  debian:8
   debian:9
   ubuntu:14.04
   ubuntu:18.04
@@ -40,7 +40,7 @@ OSES=(
 ANSWERS=(
   "clearlinux - 19150, clearlinux - 19150, clearlinux - 19150 -1"
   "amzn - 2017.09, rhel - 2017.09, fedora - 2017.09 0"
-  "debian - 7, debian - 7, debian - 7 0"
+  "debian - 8, debian - 8, debian - 8 0"
   "debian - 9, debian - 9, debian - 9 0"
   "ubuntu - 14.04, debian - 8, debian - 8 0"
   "ubuntu - 18.04, debian - 10, debian - 10 0"

--- a/tests/int/test-docker_compose_override.bsh
+++ b/tests/int/test-docker_compose_override.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/../testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
 . "${VSI_COMMON_DIR}/linux/docker_functions.bsh" # Need to be sourced for docker_compose_override

--- a/tests/int/test-docker_functions.bsh
+++ b/tests/int/test-docker_functions.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/../testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
 . "${VSI_COMMON_DIR}/linux/docker_functions.bsh"

--- a/tests/int/test-new_just.bsh
+++ b/tests/int/test-new_just.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/../testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
 . uwecho.bsh

--- a/tests/quiz-testlib.bsh
+++ b/tests/quiz-testlib.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 # This is in another file so that they can fail for real, and the summary
 # file is used to verify the right number of failures. If you add a failing

--- a/tests/run_tests.bsh
+++ b/tests/run_tests.bsh
@@ -56,7 +56,17 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 #
 # .. note::
 #   In certain complicated scenarios (either race conditions or just TMI), it is beneficial to set :envvar:`TESTS_PARALLEL` =1 just to simplify debugging
+#
+# .. note::
+#   Since ``darling`` is prone to panicking the kernel, if TESTS_PARALLEL is unset, it will be set to 4 by default.
 #**
+
+if [ "${VSI_DISTRO}" = "darling" ] && [ -z "${TESTS_PARALLEL+set}" ]; then
+  echo "${TEST_WARN_COLOR}Warning${TEST_RESET_COLOR}: TESTS_PARALLEL is unset on \"darling\"." \
+       "Setting to 4 to prevent kernel panic." >&2
+  TESTS_PARALLEL=4
+fi
+
 : ${TESTS_PARALLEL=${VSI_NUMBER_CORES}}
 
 #**

--- a/tests/run_tests.bsh
+++ b/tests/run_tests.bsh
@@ -85,7 +85,7 @@ fi
 #
 # Directory where all the test-\*\.bsh files are stored.
 #
-# If relative path, it is relative to :file:`testlib.sh`.
+# If relative path, it is relative to :file:`testlib.bsh`.
 #**
 
 export summary_log_dir="$(mktemp -d)"

--- a/tests/test-.just.bsh
+++ b/tests/test-.just.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-.just.bsh
+++ b/tests/test-.just.bsh
@@ -12,7 +12,14 @@ begin_test "just tab complete"
 
   JUST_HELP_SEPARATOR='#@#'
 
-  echo ' a) # A' > Justfile
+  echo 'JUST_HELP_FILES+=("${BASH_SOURCE[0]}")' > plugin1
+  echo ' d) # Plugin target' >> plugin1
+  echo ' e_f) # Plugin subtarget' >> plugin1
+
+  echo 'set -xv' > Justfile
+  echo 'source plugin1' >> Justfile
+
+  echo ' a) # A' >> Justfile
   echo ' b) # b' >> Justfile
   echo ' c) ' >> Justfile # Hidden
 
@@ -45,10 +52,11 @@ begin_test "just tab complete"
   _just just '' just
   # Manually parse defaultify targets, so I quit breaking this test
   ans1=($(sed -En '/^ *-[a-z|-]+\) *#.*/{s:^ *(-[a-z|-]+)\) *#.*:\1:; s/\|/'$'\\\n/g; p;}' "${VSI_COMMON_DIR}/linux/just_functions.bsh"))
-  ans=(a -a apple b cat dog -flag foo -jump -ocean -rope -sea snake -water "${ans1[@]}")
+  ans=(a -a apple b cat d dog -flag foo -jump -ocean -rope -sea snake -water "${ans1[@]}")
   # Resort it because macOS sorts weird. I mean REALLY weird. Must be the locale
   ans=($(IFS=$'\n'; sort <<< "${ans[*]}"))
-  check_a COMPREPLY "${ans[@]}" read run stop
+  sub_ans=(e read run stop)
+  check_a COMPREPLY "${ans[@]}" "${sub_ans[@]}"
 
   # Simple case
   COMP_WORDS=(just f)
@@ -90,7 +98,7 @@ begin_test "just tab complete"
   # Subsequent subcommand case
   COMP_WORDS=(just run car)
   _just just "" car
-  check_a COMPREPLY "${ans[@]}" car house garage read run stop
+  check_a COMPREPLY "${ans[@]}" car house garage "${sub_ans[@]}"
 
   echo 'if [ "${3}" = "-jump" ]; then
           just_commands+=("rope")
@@ -104,7 +112,7 @@ begin_test "just tab complete"
 
   COMP_WORDS=(just -jump)
   _just just "" -jump
-  check_a COMPREPLY "${ans[@]}" rope read run stop
+  check_a COMPREPLY "${ans[@]}" rope "${sub_ans[@]}"
 
 )
 end_test

--- a/tests/test-colors.bsh
+++ b/tests/test-colors.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-common_source.bsh
+++ b/tests/test-common_source.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-common_source.bsh
+++ b/tests/test-common_source.bsh
@@ -29,7 +29,11 @@ begin_test "Distribution name for Darwin"
 
   . "${VSI_COMMON_DIR}/linux/common_source.sh"
 
-  [ "${VSI_DISTRO}" = "darwin" ]
+  if [ "$(sw_vers -buildVersion | tr '[A-Z]' '[a-z]')" = "darling" ]; then
+    [ "${VSI_DISTRO}" = "darling" ]
+  else
+    [ "${VSI_DISTRO}" = "darwin" ]
+  fi
   [ "${VSI_DISTRO_CORE}" = "darwin" ]
   [ "${VSI_DISTRO_LIKE}" = "darwin" ]
   [ "${VSI_DISTRO_VERSION:0:3}" = "10." ]

--- a/tests/test-cuda_info.bsh
+++ b/tests/test-cuda_info.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-dir_tools.bsh
+++ b/tests/test-dir_tools.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-dir_tools.bsh
+++ b/tests/test-dir_tools.bsh
@@ -147,3 +147,27 @@ begin_test "basenames"
   [ "$(basenames 2 /aaa//test)" = "aaa/test" ]
 )
 end_test
+
+begin_test "dirname"
+(
+  setup_test
+
+  [ "$(command dirname /a/b/c)" = "$(dirname /a/b/c)" ]
+  [ "$(command dirname /a/b/c/)" = "$(dirname /a/b/c/)" ]
+  [ "$(command dirname a)" = "$(dirname a)" ]
+  [ "$(command dirname a/b)" = "$(dirname a/b)" ]
+  [ "$(command dirname /a)" = "$(dirname /a)" ]
+)
+end_test
+
+begin_test "basename"
+(
+  setup_test
+
+  [ "$(command basename /a/b/c)" = "$(basename /a/b/c)" ]
+  [ "$(command basename /a/b/c/)" = "$(basename /a/b/c/)" ]
+  [ "$(command basename a)" = "$(basename a)" ]
+  [ "$(command basename a/b)" = "$(basename a/b)" ]
+  [ "$(command basename /a)" = "$(basename /a)" ]
+)
+end_test

--- a/tests/test-docker_compose_override.bsh
+++ b/tests/test-docker_compose_override.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 . "${VSI_COMMON_DIR}/linux/docker_functions.bsh" # Need to be sourced for docker_compose_override

--- a/tests/test-docker_entrypoint.bsh
+++ b/tests/test-docker_entrypoint.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-docker_functions.bsh
+++ b/tests/test-docker_functions.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 . "${VSI_COMMON_DIR}/linux/docker_functions.bsh"

--- a/tests/test-elements.bsh
+++ b/tests/test-elements.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/../linux/elements.bsh"
 

--- a/tests/test-elements.bsh
+++ b/tests/test-elements.bsh
@@ -34,6 +34,54 @@ begin_test "Dynamic Set Array"
 )
 end_test
 
+begin_test "Clear Array"
+(
+  setup_test
+  function foo()
+  {
+    local x=(12 101 15 23 49) # global being shadowed by local
+    local y=(12 101 15 23 49) # local only
+    z=(12 101 15 23 49)       # global set in function only
+
+    clear_a x
+    clear_a y
+    clear_a z
+
+    check_a x
+    check_a y
+    check_a z
+  }
+
+  x=(11 22 33)
+
+  foo
+  not declare -p y
+  declare -p z
+
+  clear_a x
+  check_a x
+)
+end_test
+
+begin_test "Remove from Local Array"
+(
+  setup_test
+  function foo()
+  {
+    local x=(12 101 15 23 49)
+
+    remove_element_a x 15
+    check_a x 12 101 23 49
+    contiguous_a x
+  }
+
+  foo
+
+  not declare -p x
+
+)
+end_test
+
 begin_test "Remove from Array"
 (
   setup_test

--- a/tests/test-file_tools.bsh
+++ b/tests/test-file_tools.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-findin.bsh
+++ b/tests/test-findin.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/test-findinpaths.bsh
+++ b/tests/test-findinpaths.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/test-group_names.bsh
+++ b/tests/test-group_names.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/test-inisin.bsh
+++ b/tests/test-inisin.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/test-isin.bsh
+++ b/tests/test-isin.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/test-just_common.bsh
+++ b/tests/test-just_common.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-just_docker_functions.bsh
+++ b/tests/test-just_docker_functions.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-just_functions.bsh
+++ b/tests/test-just_functions.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-just_wrap.bsh
+++ b/tests/test-just_wrap.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-linux_accounts.bsh
+++ b/tests/test-linux_accounts.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-lwhich.bsh
+++ b/tests/test-lwhich.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-mount_tools.bsh
+++ b/tests/test-mount_tools.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-picker.bsh
+++ b/tests/test-picker.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/test-postisin.bsh
+++ b/tests/test-postisin.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/test-preisin.bsh
+++ b/tests/test-preisin.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/test-print_command.bsh
+++ b/tests/test-print_command.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/test-quotemire.bsh
+++ b/tests/test-quotemire.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/test-real_path.bsh
+++ b/tests/test-real_path.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-relpath.bsh
+++ b/tests/test-relpath.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/test-set_flags.bsh
+++ b/tests/test-set_flags.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/../linux/elements.bsh"
 

--- a/tests/test-source_once.bsh
+++ b/tests/test-source_once.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${YASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${YASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${YASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/test-string_tools.bsh
+++ b/tests/test-string_tools.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"

--- a/tests/test-testlib-touch.bsh
+++ b/tests/test-testlib-touch.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 setup()
 {

--- a/tests/test-testlib.bsh
+++ b/tests/test-testlib.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 begin_test "Test Success"
 (

--- a/tests/test-time_tools.bsh
+++ b/tests/test-time_tools.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 . "${VSI_COMMON_DIR}/linux/time_tools.bsh"

--- a/tests/test-uwecho.bsh
+++ b/tests/test-uwecho.bsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -9,13 +9,13 @@
 #
 # .. default-domain:: bash
 #
-# .. file:: testlib.sh
+# .. file:: testlib.bsh
 #
 # Simple shell command language test library
 #
 # .. rubric:: Usage
 #
-# . testlib.sh
+# . testlib.bsh
 #
 # .. rubric:: Example
 #
@@ -23,7 +23,7 @@
 #
 #   Tests must follow the basic form:
 #
-#   source testlib.sh
+#   source testlib.bsh
 #
 #   begin_test "the thing"
 #   (

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -61,9 +61,7 @@
 #              * Added custom PS4
 #**
 
-# The above must be the first command executed, or else it won't work. Use this
-# instead of BASH_SOURCE to maintain sh compatibility
-: ${VSI_COMMON_DIR="$(cd "$(dirname "$_")/.."; pwd)"}
+: ${VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"}
 
 set -e
 
@@ -267,7 +265,7 @@ _begin_common_test ()
     ttouch "${track_touched_file}"
   fi
 
-  if [ "${TESTLIB_SHOW_TIMING-0}" == "1" ]; then
+  if [ "${TESTLIB_SHOW_TIMING-0}" = "1" ]; then
     _time_0=$(get_time_seconds)
   fi
 
@@ -405,7 +403,7 @@ end_test ()
   popd &> /dev/null
 
   local time_e=''
-  if [ "${TESTLIB_SHOW_TIMING-0}" == "1" ]; then
+  if [ "${TESTLIB_SHOW_TIMING-0}" = "1" ]; then
     time_e=$(awk "BEGIN {print \"\t\" $(get_time_seconds)-${_time_0}}")
   fi
 
@@ -468,7 +466,7 @@ end_test ()
 #
 #   For example, skip if docker command not found
 #
-#     command -v docker &>/dev/null && skip_next_test
+#     command -v docker &> /dev/null && skip_next_test
 #     begin_test "My test"
 #     (
 #       setup_test
@@ -675,15 +673,12 @@ cleanup_touched_files()
   # This will normally get called an extra time at exit, so the existence of
   # the file acts as a check.
   if [ -f "${track_touched_file}" ]; then
-    while IFS='' read -r -d '' line 2>/dev/null || [ -n "$line" ]; do
-      touched_files+=("$line")
-      line='' #Have to clear it, in case the timeout times out
-    done < "${track_touched_file}"
-
-    for touched_file in ${touched_files+"${touched_files[@]}"}; do
+    while IFS='' read -r -d '' touched_file 2>/dev/null || [ -n "$touched_file" ]; do
       if [ -e "${touched_file}" ] && [ ! -d "${touched_file}" ]; then
         \rm "${touched_file}"
       fi
-    done
+
+      touched_file='' #Have to clear it, in case the timeout times out
+    done < "${track_touched_file}"
   fi
 }

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -2,7 +2,6 @@ JUST_PROJECT_PREFIX=VSI_COMMON
 
 : ${VSI_COMMON_DOCKER_REPO=vsiri/common}
 
-: ${VSI_COMMON_USERNAME="$(id -u -n)"}
 : ${VSI_COMMON_UID=$(id -u)}
 : ${VSI_COMMON_GIDS=$(id -g)}
 

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -2,6 +2,7 @@ JUST_PROJECT_PREFIX=VSI_COMMON
 
 : ${VSI_COMMON_DOCKER_REPO=vsiri/common}
 
+: ${VSI_COMMON_USERNAME=$(id -u -n)}
 : ${VSI_COMMON_UID=$(id -u)}
 : ${VSI_COMMON_GIDS=$(id -g)}
 

--- a/wrap
+++ b/wrap
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-: "$(dirname "${BASH_SOURCE[0]}")"
-. "${_}"/linux/Just_wrap "${_}"/vsi_common.env ${@+"${@}"}


### PR DESCRIPTION
A general cleanup and optimization of vsi_common to improve `just` load and run time, especially on windows (load time well under a second now)"

- `just_env` usage was changed. This will have a breaking affect (although easily fixed) on just 0.0.x projects. They need to update how VSI_COMMON_DIR is set in the entrypoint.
- Source once is implemented. Now all files are sourced only once.
  - An obvious trade-off to this would be a very confused user/developer, changing a file/checking it out and 
trying to resource it in a running shell.
  - A hidden trade-off was discovered that if you source a file in your terminal, and it attempts to run a command that does not exist, packagekit will trigger and attempt to find what package you are missing, adding large time delay.
  - Rather then trying to disable packagekit, `source_once` is only trigger in non-interactive bash sessions, cleanly fixing both of these issues.
- (With the exception of unit tests and `common_source.sh), the `.` notation was replaced with the `source` notation, to allow for easier refactoring.
- A contributing style guidelines document was added to cover this and more.
- Some dash compatibility strengthened (`common_source.sh`) while other abandoned (`testlib.sh`)
- Added pure bash `dirname` and `basename` implementations to `dir_utils.bsh`
- Added a few Pipenv,lock ideas to the docs plugin, settled on the `build` method being the most robust and DRY.