### PR TITLE
Now the pipenv run stage runs as not root

### DIFF
--- a/linux/new_just
+++ b/linux/new_just
@@ -757,11 +757,9 @@ if [ ! -e "${JUSTFILE}" ]; then
                     ;;
               ' >> "${JUSTFILE}"
     if [ "${USE_PIPENV}" = "1" ]; then
-      uwecho '    pipenv_install) # Install/update pipenv packages
-                    Just-docker-compose run example_pipenv bash -c \
-                      '"'"'pipenv install ${@+"${@}"}
-                      chown ${DOCKER_UID}:${DOCKER_GIDS%% *} "${PIPENV_PIPFILE}" "${PIPENV_PIPFILE}.lock" || :'"'"' \
-                      bash ${@+"${@}"} # Pass the arguments to pipenv, starting with $0
+      uwecho '    pipenv) # Run pipenv commands in pipenv conatainer. Useful for \
+                          # installing/updating pipenv packages
+                    Just-docker-compose run example_pipenv pipenv ${@+"${@}"}
                     extra_args=$#
                     ;;
                   clean_all) # Delete all local volumes
@@ -901,7 +899,7 @@ if [ "${USE_DOCKER}" = "1" ]; then
 
               ###############################################################################
 
-              FROM dep_stage as dep_pipenv
+              FROM dep_stage as pipenv_cache
 
               # # Uncomment for GDAL
               # # Install any build dependencies
@@ -924,8 +922,6 @@ if [ "${USE_DOCKER}" = "1" ]; then
               #     scipy = "*"
               # - Rebuiling the image
               #     just build
-
-              FROM dep_pipenv as pipenv_cache
 
               # GDAL, for example, is a more complicated example
               # - GDAL has extra build dependencies. The apt-get pattern above will install
@@ -971,6 +967,17 @@ if [ "${USE_DOCKER}" = "1" ]; then
                   pipenv sync; \
                   # Cleanup and make way for the real /src that will be mounted at runtime
                   rm -rf /src/* /tmp/pip*
+
+              ###############################################################################
+
+              FROM pipenv_cache as pipenv_run
+
+              COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
+              COPY --from=vsi /vsi /vsi
+
+              ENTRYPOINT ["/usr/bin/env", "bash", "/vsi/linux/just_entrypoint.sh"]
+
+              CMD ["bash"]
 
               ###############################################################################
 
@@ -1128,7 +1135,7 @@ if [ "${USE_DOCKER}" = "1" ]; then
                   <<: *'"${APP_NAME}"'
                   build:
                     <<: *'"${APP_NAME}"'_build
-                    target: dep_pipenv
+                    target: pipenv_run
                   image: ${'"${PROJECT_PREFIX}"'_DOCKER_REPO}:'"${APP_NAME}"'_pipenv_${'"${PROJECT_PREFIX}"'_USERNAME}
               volumes:
                 venv:

--- a/linux/new_just
+++ b/linux/new_just
@@ -1060,6 +1060,10 @@ if [ "${USE_DOCKER}" = "1" ]; then
                     exec "${@}"
                     ;;
 
+                  pipenv) # Run pipenv command
+                    exec "${cmd}" ${@+"${@}"}
+                    ;;
+
                   *) # Default: Run command in pipenv
                     exec pipenv run "${cmd}" ${@+"${@}"}
                     ;;


### PR DESCRIPTION
The new pipenv pattern has a few rough edges

1. Running in the `dep_pipenv` stage didn't have `/venv` populated, so if this was done before the volume was created, it was created with nothing, creating awful synchronization issues.
1. The `dep_pipenv` stage was root. So running anything in there created Root files that had to be patched. This kept growing to the point where it made more sense just to use the vsi just entrypoint instead and run as user.

So now the stage is moved after the `pipenv sync` command, and add the vsi entrypoint, solving both of these problems. It is done afterwards to save on docker build cache time when vsi common changes.