### PR TITLE
default DOCKER_USERNAME in just_entrypoint

### DIFF
--- a/linux/just_entrypoint.sh
+++ b/linux/just_entrypoint.sh
@@ -62,7 +62,7 @@ set -eu
 #
 # :Parameters: * :envvar:`JUST_SETTINGS` - Location of project env settings file.
 #              * :envvar:`VSI_COMMON_DIR` - Optional, location of VSI dir, defaults to /vsi
-#              * :envvar:`DOCKER_USERNAME` - Optional, username for new user, defaults to user
+#              * ``DOCKER_USERNAME`` - Optional, username for new user, defaults to user
 # :Internal Use: * ``ALREADY_RUN_ONCE`` - Tracks if entrypoint has already sudoed to user.
 #                * ``JUST_DOCKER_ENTRYPOINT_INTERNAL_VOLUMES`` - Passed from :func:`docker_functions.bsh Just-docker-compose`
 #**

--- a/linux/just_entrypoint.sh
+++ b/linux/just_entrypoint.sh
@@ -62,11 +62,13 @@ set -eu
 #
 # :Parameters: * :envvar:`JUST_SETTINGS` - Location of project env settings file.
 #              * :envvar:`VSI_COMMON_DIR` - Optional, location of VSI dir, defaults to /vsi
+#              * :envvar:`DOCKER_USERNAME` - Optional, username for new user, defaults to user
 # :Internal Use: * ``ALREADY_RUN_ONCE`` - Tracks if entrypoint has already sudoed to user.
 #                * ``JUST_DOCKER_ENTRYPOINT_INTERNAL_VOLUMES`` - Passed from :func:`docker_functions.bsh Just-docker-compose`
 #**
 
 : ${VSI_COMMON_DIR=/vsi}
+: ${DOCKER_USERNAME=user}
 
 if [ -n "${SINGULARITY_NAME+set}" ]; then
   # Disable the special docker magic in singularity


### PR DESCRIPTION
While `docker_setup_user` in `just_entrypoint_function` provides a default value for `DOCKER_USERNAME` if not specified (`docker_setup_user` is called through line 87 in the quoted code), that default value is not available when attempting to rerun the entrypoint.  Provide a default value for `DOCKER_USERNAME` if left unspecified.

https://github.com/VisionSystemsInc/vsi_common/blob/1d3de09b2b7286aef9b6fb9871641b095a6a3d43/linux/just_entrypoint.sh#L76-L99