### PR TITLE
Debug support

### DIFF
--- a/docker/tests/bash_test.Dockerfile
+++ b/docker/tests/bash_test.Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache \
 
 ENV JUSTFILE=/vsi/docker/tests/bash_test.Justfile \
     JUST_SETTINGS=/vsi/vsi_common.env
-COPY --from=tini /usr/local/bin/tini /usr/local/bin/tini
+COPY --from=tini /usr/local /usr/local
 COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
 COPY --from=jq /usr/local/bin/jq /usr/local/bin/jq
 COPY --from=docker /usr/local/bin /usr/local/bin

--- a/docker/vsi_common/bashcov.Dockerfile
+++ b/docker/vsi_common/bashcov.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update; \
     rm -r /var/lib/apt/lists/*
 
 ENV JUSTFILE=/vsi/docker/vsi_common/bashcov.Justfile
-COPY --from=tini /usr/local/bin/tini /usr/local/bin/tini
+COPY --from=tini /usr/local /usr/local
 COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
 COPY --from=jq /usr/local/bin/jq /usr/local/bin/jq
 COPY --from=docker /usr/local/bin /usr/local/bin

--- a/docker/vsi_common/sphinx.Dockerfile
+++ b/docker/vsi_common/sphinx.Dockerfile
@@ -27,7 +27,7 @@ RUN pipenv sync; \
     ln -s /vsi/docs/vsi_domains.py "$(pipenv --venv)/lib/python3.7/site-packages/"; \
     rm -rf "${PIPENV_PIPFILE}*" /tmp/pip*
 
-COPY --from=tini /usr/local/bin/tini /usr/local/bin/tini
+COPY --from=tini /usr/local /usr/local
 COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
 # Allow non-privileged to run gosu (remove this to take root away from user)
 RUN chmod u+s /usr/local/bin/gosu

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -265,8 +265,9 @@ basename()
 #
 # :Arguments: ``$1`` - The directory to search, must have permissions, or else it may give false results
 # :Returns: 0 for empty, 1 for not empty
+# :Uses: ``find`` to search the directory
 #
-# Uses ``find`` to search a directory, and stops as soon as something is found. You can write your own version of this to modify the conditions the ``find`` use. Other versions include ``find "${1}" -type f -printf '1\n' -quit`` which requires that a file specifically (not a directory) be in the tree somewhere. Add ``-maxdepth 1`` for saying a file must be in the initial directory, not the entire tree.
+# Searches a directory and stops as soon as something is found. You can write your own version of this to modify the conditions the ``find`` use. Other versions include ``find "${1}" -type f -printf '1\n' -quit`` which requires that a file specifically (not a directory) be in the tree somewhere. Add ``-maxdepth 1`` for saying a file must be in the initial directory, not the entire tree.
 #**
 function is_dir_empty()
 {

--- a/linux/docker_functions.bsh
+++ b/linux/docker_functions.bsh
@@ -54,7 +54,7 @@ fi
 #
 # Regex pattern for matching docker volume short form
 #
-# .. Note::
+# .. note::
 #   Works on:
 #     C:\*, c:/* .* /* - '^(([a-zA-Z]:[/\])?[^:]*)'
 #
@@ -196,7 +196,7 @@ function is_readonly_docker_compose_long_volume()
 #
 # Get a label value from a docker container
 #
-# .. Note::
+# .. note::
 #   Requires perl be installed
 # .. rubric:: Bugs
 #
@@ -229,7 +229,7 @@ function container_get_label()
 # has a label or not when the label is blank. The go template filter does not
 # differentiate. This will verify that a blank label is set or unset.
 #
-# .. Note::
+# .. note::
 #   Requires jq be installed
 #**
 
@@ -256,7 +256,7 @@ function container_has_label()
 # When the argument is a docker volume, nothing should happen. Docker auto
 # creates those just fine.
 #
-# .. Note::
+# .. note::
 #   Always creates the directory with 777 permission. This is to maximize the
 #   chances that it works. If you don't want this, the easiest solution is to
 #   create the directory yourself. This is more of a last resort. For this
@@ -325,7 +325,7 @@ function docker_host_dir()
 # or ``POSIX`` operating systems, have different rules, etc... This function will
 # universally split the string up.
 #
-# .. Note::
+# .. note::
 #   Based off of docker 17.12 syntax. If new flags are added, the regex must be
 #   updated.
 #
@@ -591,7 +591,7 @@ function _Docker()
 #
 # Currently only works on volume short format
 #
-# .. Note::
+# .. note::
 #   Useful for working around docker/compose#4728
 #**
 
@@ -679,12 +679,12 @@ function docker-compose-volumes-old()
 #                                     [2]="lsource: /home/user/src"
 #                                     [3]="ltarget: /src" [4]="Stest:/opt")'
 #
-# .. Note::
+# .. note::
 #   Useful for working around docker/compose#4728
 #
 #   Supports both short and long format
 #
-# .. Seealso::
+# .. seealso::
 #   docker-compose-volumes
 #**
 
@@ -743,6 +743,64 @@ function parse-docker-compose-volumes()
                x
                # Print out that pretty pattern!
                p'))
+}
+
+#**
+# .. function:: docker-compose-list-internal-volumes
+#
+# :Input: **stdin** - Docker-compose yaml file
+# :Output: ``DOCKER_INTERNAL_VOLUMES`` - Array of the docker volumes
+#
+# Parses the output from ``docker-compose config`` to get the list of all internal volumes
+#
+# .. rubric:: Example
+#
+# .. code-block:: bash
+#
+#  docker-compose.yml
+#    version: "3.2"
+#    services:
+#      nb:
+#        image : some_image
+#        volumes:
+#        - test:/opt
+#    volumes:
+#      test:
+#      stuff:
+#
+#  docker-compose-list-internal-volumes < <(docker-compose config)
+#  # Or
+#  # docker-compose-list-internal-volumes <<< "$(docker-compose config)"
+#
+#  declare -p DOCKER_INTERNAL_VOLUMES
+#  > declare -a DOCKER_INTERNAL_VOLUMES='([0]="test" [1]="stuff")'
+#
+# .. note::
+#
+#    Both ``test`` and ``stuff`` will be returned, even though stuff is not used.
+#**
+function docker-compose-list-internal-volumes()
+{
+  local IFS=$'\n'
+  DOCKER_INTERNAL_VOLUMES=(\
+    $(sed -nE '/^volumes:/b volumes
+               # Delete lines until I find the "^volumes:" line
+               d
+               :volumes
+               # read the next line, immediate after volumes: it should be a volume name
+               n
+               # Search for the volume entry, two space, name (starting with not a space) then colon
+               /^  [^ ].*:/b found
+               # If I found another unindented line, then I am done parsing, quit
+               /^[^ #]/q
+               # keep scanning for the next volume
+               b volumes
+               :found
+               # clean up the volume name, so only the name is left
+               s/^ *//
+               s/:.*$//
+               p
+               b volumes'))
 }
 
 #**
@@ -869,7 +927,7 @@ function docker-compose-volumes()
 #
 #   : ${JUST_DOCKER_COMPOSE_DIR="${PROJECT_CWD}/docker_dir"}
 #
-# .. Note::
+# .. note::
 #   Because the -f argument overrides all other forms of choosing the compose
 #   file, the ``docker_compose_args`` are updated to use this notation instead of
 #   other methods that may be used. This will not change the behavior of the

--- a/linux/just_docker_functions.bsh
+++ b/linux/just_docker_functions.bsh
@@ -149,9 +149,19 @@ function docker_defaultify()
       extra_args=1
       ;;
     docker-compose_clean) # Delete a docker-compose volume. The next container \
-                          # to use this volume will automatically copy any
-                          # content from the image.
-      justify docker_clean "${COMPOSE_PROJECT_NAME}_${1}"
+                          # to use this volume will automatically copy any \
+                          # content from the image. Use --all to clean all \
+                          # volumes listed in the docker-compose.yml file
+      if [ "${1}" = "--all" ]; then
+        local DOCKER_INTERNAL_VOLUMES
+        local volume
+        docker-compose-list-internal-volumes < <(Just-docker-compose config)
+        for volume in ${DOCKER_INTERNAL_VOLUMES[@]+"${DOCKER_INTERNAL_VOLUMES[@]}"}; do
+          justify docker_clean "${COMPOSE_PROJECT_NAME}_${volume}"
+        done
+      else
+        justify docker_clean "${COMPOSE_PROJECT_NAME}_${1}"
+      fi
       extra_args=1
       ;;
     docker-compose_enter) # Enter a running container, running an interactive

--- a/linux/just_entrypoint.sh
+++ b/linux/just_entrypoint.sh
@@ -85,6 +85,8 @@ if [ "${ALREADY_RUN_ONCE+set}" != "set" ]; then
     shell=sh
   fi
 
+  export shell
+
   (
     # TODO: This will not source local.env if the src directory were on an nfs
     # Not sure ADDing the local files in the Dockerfile is the "right" solution
@@ -143,6 +145,9 @@ for patch in /usr/local/share/just/user_run_patch/*; do
     ${shell} "${patch}"
   fi
 done
+
+# Unexport it
+unset shell
 
 if [ "${run_just}" = "1" ]; then
   exec /vsi/linux/just "${@}"

--- a/linux/just_entrypoint.sh
+++ b/linux/just_entrypoint.sh
@@ -29,6 +29,7 @@ set -eu
 # #. The entrypoint starts running as ``root``
 # #. Loads the just environment only for root according to :envvar:`JUST_SETTINGS`. These values will be removed by the time the entrypoint is executeds as the user below, to prevent unexpected variable corruption.
 # #. Runs :func:`just_entrypoint_functions docker_setup_user` to set up the user with the appropriate ids. This is superior to other methods that would build an image with a UID and GID embedded in it, since you do not need to rebuild the image to have it adapt to your ids. Furthermore, it will capture all your gids by default, working correctly in more corner cases.
+# #. Any files in :envvar:`JUST_ROOT_PATCH_DIR` will be executed (in alphabetical order) if they have the execute flag set, else they are sourced.
 # #. Runs :func:`just_entrypoint_functions docker_link_mounts` in conjuntion with :func:`docker_functions.bsh Just-docker-compose` to create symlinks where nfs mounts should appear, in the case that nfs is used. :func:`docker_functions.bsh Just-docker-compose` will identify nfs mounts, and mount the root of an nfs mount point in case squash_root is used and set ``JUST_DOCKER_ENTRYPOINT_LINKS``. :func:`just_entrypoint_functions docker_link_mounts` uses the information encoded in ``JUST_DOCKER_ENTRYPOINT_LINKS`` to create symlink where there were originally supposed to be mounted.
 # #. Runs :func:`just_entrypoint_functions docker_setup_data_volumes` to fix initial permission issues for internal data volumes. When an empty internal data is initially created by docker, the folder is owned and writeable by root. This changes it to match the desired user's permissions. :func:`docker_functions.bsh Just-docker-compose` automaticlly determines the list of internal data volumes and passes them in as ``JUST_DOCKER_ENTRYPOINT_INTERNAL_VOLUMES``, which is then passes into :func:`just_entrypoint_functions docker_setup_data_volumes` as ``JUST_DOCKER_ENTRYPOINT_CHOWN_DIRS`` and ``JUST_DOCKER_ENTRYPOINT_CHMOD_DIRS``
 #
@@ -36,10 +37,11 @@ set -eu
 #   * ``JUST_DOCKER_ENTRYPOINT_CHMOD_DIRS`` - non-recursively chmod the directories listed to 777 so that any initial ownership issues are avoided. Can also be customized/disabled by passing a value in for the ``JUST_DOCKER_ENTRYPOINT_CHMOD_DIRS`` line, but being non-recursive, this should never have a noticeable time penalty.
 #   * These two features give volumes a much more desirable default behavior for non-root users.
 #
-# 6. Next the entrypoint (and everything else from here on) is re-executed as the user that was created in :func:`just_entrypoint_functions docker_setup_user`. If you need to give the user root privliges, the suggested method is to use ``gosu``. Giving ``gosu`` ``chmod u+s /usr/local/bin/gosu`` permissions will accomplish this, but should not be suggested for deployment situations.
+# 7. Next the entrypoint (and everything else from here on) is re-executed as the user that was created in :func:`just_entrypoint_functions docker_setup_user`. If you need to give the user root privliges, the suggested method is to use ``gosu``. Giving ``gosu`` ``chmod u+s /usr/local/bin/gosu`` permissions will accomplish this, but should not be suggested for deployment situations.
 # #. Loads the just environment for the user accoring to :envvar:`JUST_SETTINGS`.
 # #. If :envvar:`JUSTFILE` is set, runs :func:`just_entrypoint_user_functions filter_docker_variables` to remove project variables ending in ``_DOCKER``
 # #. Replace ``//`` with `/` in project variables if running on windows using mingw or cygwin. Cygwin-like systems have a habit of `expanding variables <http://mingw.org/wiki/Posix_path_conversion>`_. Extra slashes are added in project environment files using :envvar:`JUST_PATH_ESC`, which cygwin-like systems evaluate as a ``/``, else empty. An unfortunate side effect of this is the `//` is still in the container. While this is usually harmeless, there are cases when the extra slash in the variables cause code to crash.
+# #. Any files in :envvar:`JUST_USER_PATCH_DIR` will be execcuted if they have the execute flag set, else they are sourced.
 # #. If :envvar:`JUSTFILE` was passed in, this signifies to the entrypoint that an internal just call will be used. This means ``just`` is prepended to the command to ``exec``, so you don't have to.
 # #. If :envvar:`JUSTFILE` is not set, the command arguments are run using ``exec``
 #
@@ -65,6 +67,18 @@ set -eu
 #              * ``DOCKER_USERNAME`` - Optional, username for new user, defaults to user
 # :Internal Use: * ``ALREADY_RUN_ONCE`` - Tracks if entrypoint has already sudoed to user.
 #                * ``JUST_DOCKER_ENTRYPOINT_INTERNAL_VOLUMES`` - Passed from :func:`docker_functions.bsh Just-docker-compose`
+#
+# .. envvar:: JUST_ROOT_PATCH_DIR
+#
+# :file:`just_entrypoint.sh` will source or execute (if the execute bit is set) every file in this directory as root on container start. In singularity, this step is skipped. The default is: ``/usr/local/share/just/root_run_patch``.
+#
+# .. envvar:: JUST_USER_PATCH_DIR
+#
+# :file:`just_entrypoint.sh` will source or execute (if the execute bit is set) every file in this directory as the user on container start. The default is: ``/usr/local/share/just/user_run_patch``
+#
+# .. note::
+#
+#    The intended use of :envvar:`JUST_ROOT_PATCH_DIR` and :envvar:`JUST_USER_PATCH_DIR` is to have files added to it from either docker recipes or in the Dockerfile. While you can mount a folder or volume to this location, that is not the intent. For example: On windows all files may appear to have execute permissions, which may not by what you want.
 #**
 
 : ${VSI_COMMON_DIR=/vsi}
@@ -79,13 +93,9 @@ if [ "${ALREADY_RUN_ONCE+set}" != "set" ]; then
 
   if [ -n "${BASH_SOURCE+set}" ]; then
     file="${BASH_SOURCE[0]}"
-    shell=bash
   else
     file="${0}" #sh compatibility
-    shell=sh
   fi
-
-  export shell
 
   (
     # TODO: This will not source local.env if the src directory were on an nfs
@@ -93,13 +103,13 @@ if [ "${ALREADY_RUN_ONCE+set}" != "set" ]; then
     source "${VSI_COMMON_DIR}/linux/just_env" "${JUST_SETTINGS-/dev/null}"
 
     # Sorted: https://serverfault.com/a/122743/321910
-    for patch in /usr/local/share/just/root_run_patch/*; do
+    for patch in "${JUST_ROOT_PATCH_DIR-/usr/local/share/just/root_run_patch}"/*; do
       if [ -x "${patch}" ]; then
         "${patch}"
             # https://www.endpoint.com/blog/2016/12/12/bash-loop-wildcards-nullglob-failglob
             # check -e incase glob doesn't expand
       elif [ -e "${patch}" ]; then
-        ${shell} "${patch}"
+        source "${patch}"
       fi
     done
 
@@ -136,13 +146,13 @@ if [ -n "${JUST_PROJECT_PREFIX+set}" ]; then
 fi
 docker_convert_paths
 
-for patch in /usr/local/share/just/user_run_patch/*; do
+for patch in "${JUST_USER_PATCH_DIR-/usr/local/share/just/user_run_patch}"/*; do
   if [ -x "${patch}" ]; then
     "${patch}"
           # https://www.endpoint.com/blog/2016/12/12/bash-loop-wildcards-nullglob-failglob
           # check -e incase glob doesn't expand
   elif [ -e "${patch}" ]; then
-    ${shell} "${patch}"
+    source "${patch}"
   fi
 done
 

--- a/linux/just_entrypoint.sh
+++ b/linux/just_entrypoint.sh
@@ -70,7 +70,7 @@ set -eu
 : ${VSI_COMMON_DIR=/vsi}
 : ${DOCKER_USERNAME=user}
 
-if [ -n "${SINGULARITY_NAME+set}" ]; then
+if [ -d "/.singularity.d" ]; then
   # Disable the special docker magic in singularity
   export ALREADY_RUN_ONCE=1
 fi

--- a/linux/just_entrypoint_functions
+++ b/linux/just_entrypoint_functions
@@ -87,7 +87,9 @@ function docker_setup_user()
     add_user ${DOCKER_USERNAME} ${DOCKER_UID} ${DOCKER_GIDS[0]} "${DOCKER_HOME}"
 
     mkdir -p "${DOCKER_HOME}"
-    chown ${DOCKER_UID}:${DOCKER_GIDS[0]} "${DOCKER_HOME}"
+    # This will fail when you are mount in your home dir as readonly, and
+    # that's ok, so silence and ignore the error
+    chown ${DOCKER_UID}:${DOCKER_GIDS[0]} "${DOCKER_HOME}" &> /dev/null || :
   fi
 
   if [ "${DOCKER_ACCOUNTS_CREATE_GROUPS}" == "1" ]; then

--- a/linux/just_singularity_functions.bsh
+++ b/linux/just_singularity_functions.bsh
@@ -40,7 +40,7 @@ function singular_defaultify()
     #              * ``SINGULARITY_DOCKER_SOCKET`` - An array to specify a custom docker socket to connect to docker. If SINGULARITY_DOCKER_SOCKET is not an array, it is converted to an array where whitespaces will be split. Default: ``(--mount source=/var/run/docker.sock,destination=/var/run/docker.sock,type=bind)``
     #              * ``DOCKER2SINGULARITY_VERSION`` - Version of singularity to use docker2singularity. Default: 2.6 for increased compatibility.
     #**
-    singularity_import) # Export docker image "$1" to singularity. The rest of the arguments are passed on to \
+    singularity_export) # Export docker image "$1" to singularity. The rest of the arguments are passed on to \
                         # docker2singularity. Mount a custom script into /custom/tosingularity to be executed as \
                         # step 8.5.
       local custom_script
@@ -63,7 +63,7 @@ function singular_defaultify()
           ${docker_socket[@]+"${docker_socket[@]}"} \
           --mount source="$(pwd)",destination=/output,type=bind \
           ${custom_script[@]+"${custom_script[@]}"} \
-          quay.io/singularity/docker2singularity:${DOCKER2SINGULARITY_VERSION-v2.6} bash -c "
+          quay.io/singularity/docker2singularity:${DOCKER2SINGULARITY_VERSION-v3.5.0} bash -c "
             sed -i 's|echo \"(9/10)|echo \"(8.5/10) Custom script\"; [[ -r /custom/tosingularity ]] \\&\\& source /custom/tosingularity; &|' /docker2singularity.sh &&
             /docker2singularity.sh \"\${@}\"" - "${@}"
       extra_args=$#

--- a/linux/just_singularity_functions.bsh
+++ b/linux/just_singularity_functions.bsh
@@ -40,7 +40,7 @@ function singular_defaultify()
     #              * ``SINGULARITY_DOCKER_SOCKET`` - An array to specify a custom docker socket to connect to docker. If SINGULARITY_DOCKER_SOCKET is not an array, it is converted to an array where whitespaces will be split. Default: ``(--mount source=/var/run/docker.sock,destination=/var/run/docker.sock,type=bind)``
     #              * ``DOCKER2SINGULARITY_VERSION`` - Version of singularity to use docker2singularity. Default: 2.6 for increased compatibility.
     #**
-    singularity_export) # Export docker image "$1" to singularity. The rest of the arguments are passed on to \
+    singularity_import) # Export docker image "$1" to singularity. The rest of the arguments are passed on to \
                         # docker2singularity. Mount a custom script into /custom/tosingularity to be executed as \
                         # step 8.5.
       local custom_script

--- a/linux/new_just
+++ b/linux/new_just
@@ -1022,7 +1022,7 @@ if [ "${USE_DOCKER}" = "1" ]; then
               #     DEBIAN_FRONTEND=noninteractive apt-get purge -y --autoremove ${build_deps}; \
               #     rm -rf /var/lib/apt/lists/*
 
-              COPY --from=tini /usr/local/bin/tini /usr/local/bin/tini
+              COPY --from=tini /usr/local /usr/local
 
               COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
               # Allow non-privileged to run gosu (remove this to take root away from user)

--- a/linux/singularity_functions.bsh
+++ b/linux/singularity_functions.bsh
@@ -194,7 +194,7 @@ function singular_load_env()
   ### Handle other flags ###
   ##########################
 
-  indirect="${1}_singularity_flags[@]"
+  indirect="${1}_singular_flags[@]"
   singular_flags=(${!indirect+"${!indirect}"})
 
   ####################

--- a/tests/test-docker_functions.bsh
+++ b/tests/test-docker_functions.bsh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 . "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
+. "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 . "${VSI_COMMON_DIR}/linux/docker_functions.bsh"
@@ -621,5 +622,43 @@ mock_docker: rm mock_container_name_my_image:foo" ]
   [ "$(docker_cp_image -L -a my_image:foo /bar/test.txt ${TESTDIR}/dst.txt)" = \
     "mock_docker: cp -L -a mock_container_name_my_image:foo:/bar/test.txt ${TESTDIR}/dst.txt
 mock_docker: rm mock_container_name_my_image:foo" ]
+)
+end_test
+
+begin_test "docker-compose list internal volumes"
+(
+  setup_test
+  docker-compose-list-internal-volumes <<< "${compose_file}"
+  check_a DOCKER_INTERNAL_VOLUMES test
+
+  unset DOCKER_INTERNAL_VOLUMES
+  docker-compose-list-internal-volumes <<< "${compose_file_long}"
+  check_a DOCKER_INTERNAL_VOLUMES test
+
+  # None case
+  unset DOCKER_INTERNAL_VOLUMES
+  docker-compose-list-internal-volumes <<< ""
+  check_a DOCKER_INTERNAL_VOLUMES
+
+  # Multiple case
+
+  file_test="volumes:
+  test1:
+  test2:
+    stuff:
+  test3:"
+
+  unset DOCKER_INTERNAL_VOLUMES
+  docker-compose-list-internal-volumes <<< "${file_test}"
+  declare -p DOCKER_INTERNAL_VOLUMES
+  check_a DOCKER_INTERNAL_VOLUMES test1 test2 test3
+
+  file_test+="
+notvolumes:
+  test4:"
+  unset DOCKER_INTERNAL_VOLUMES
+  docker-compose-list-internal-volumes <<< "${file_test}"
+  declare -p DOCKER_INTERNAL_VOLUMES
+  check_a DOCKER_INTERNAL_VOLUMES test1 test2 test3
 )
 end_test

--- a/tests/test-just_singularity_functions.bsh
+++ b/tests/test-just_singularity_functions.bsh
@@ -34,14 +34,14 @@ begin_test "singular-compose"
         foo3_environment=('FOO' 'BAR FAR  BOO '
                           'BAR' '12345')
         foo3_image=${TESTDIR}/my_image.simg
-        foo3_singularity_flags=(-c -e)
+        foo3_singular_flags=(-c -e)
 
         foo1_environment+=('DONT' 'USE')" > ${TESTDIR}/singular-compose.env
 
   echo "instances+=(foo1)
         foo1_volumes=('${TESTDIR}/foo:/bar:ro')
         foo1_image=${TESTDIR}/image.simg
-        foo1_singularity_flags=(-c -e)" > ${TESTDIR}/singular-compose2.env
+        foo1_singular_flags=(-c -e)" > ${TESTDIR}/singular-compose2.env
   echo "foo1_environment+=('FOO' 'BAR FAR  BOO '
                           'BAR' '12345')" > ${TESTDIR}/singular-compose3.env
 

--- a/tests/test-singularity_functions.bsh
+++ b/tests/test-singularity_functions.bsh
@@ -76,12 +76,12 @@ begin_test "Singular compose load environment"
   echo "instances+=(foo3)
         foo3_volumes=('${TESTDIR}/foo:/bar:ro')
         foo3_environment=('FOO' 'BAR FAR  BOO ')
-        foo3_singularity_flags=(-c -e)" > ${TESTDIR}/a/singular-compose.env
+        foo3_singular_flags=(-c -e)" > ${TESTDIR}/a/singular-compose.env
 
   echo "instances+=(foo4)
         foo4_volumes=('${TESTDIR}/bar:/bar:ro')
         foo4_environment=('OK' 'DOE')
-        foo4_singularity_flags=(-e -c)" > ${TESTDIR}/a/b/singular-compose.env
+        foo4_singular_flags=(-e -c)" > ${TESTDIR}/a/b/singular-compose.env
 
   # Using ${JUST_PROJECT_PREFIX}_SINGULAR_COMPOSE_FILES
   JUST_PROJECT_PREFIX=STUFF


### PR DESCRIPTION
- Added `docker-compose-list-internal-volumes`, which will list all declared internal volumes in the entire docker-compose file, not for any specific service, and lists them even if no service references it
- Added `docker-compose clean --all` target now, which will clean all the internal volumes in the entire docker-compose.yml file.
- Added `/usr/local/share/just/root_run_patch/` and `/usr/local/share/just/user_run_patch/` to the just entrypoint, overrideable with `JUST_ROOT_PATCH_DIR` and `JUST_USER_PATCH_DIR`
