### PR TITLE
Support git 2.11

### DIFF
--- a/linux/just_git_functions.bsh
+++ b/linux/just_git_functions.bsh
@@ -209,7 +209,8 @@ function safe_git_submodule_update()
           popd > /dev/null
           continue
         fi
-        if git ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch -- ':/*' >/dev/null 2>/dev/null; then
+        # if git ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch -- ':/*' >/dev/null 2>/dev/null; then Removed the -- to be compatible with slightly older git versions. Should work on newer
+        if git ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch ':/*' >/dev/null 2>/dev/null; then
           echo "Untracked files in ${sm_path}"
           _checkout_git_submodule ${name} "${sm_path}" \
             "You need to resolve any conflicts in the submodule: ${name}."


### PR DESCRIPTION
Git 2.11 was not happy with the `--`, we'll try using this without the `--` for now, and see how it works. 

This entire function needs a rewrite due to #186 anyways

Signed-off-by: Andy Neff <andy@visionsystemsinc.com>