### PR TITLE
A few singularity fixes

### DIFF
--- a/linux/just_common.bsh
+++ b/linux/just_common.bsh
@@ -276,7 +276,7 @@ function _just_load_justfile()
 
   if [ "${#file_matches[@]}" -gt 0 ] && [ -f "${file_matches[0]}" ]; then
     # Put the Justfile first, this is important for tab complete
-    JUST_HELP_FILES=("${file_matches[0]}" ${JUST_HELP_FILES+"${JUST_HELP_FILES[@]}"})
+    JUST_HELP_FILES=("$(real_path "${file_matches[0]}")" ${JUST_HELP_FILES+"${JUST_HELP_FILES[@]}"})
     ${JUST_DRYRUN_SOURCE-source} "${file_matches[0]}"
     return 0
   fi

--- a/linux/just_singularity_functions.bsh
+++ b/linux/just_singularity_functions.bsh
@@ -193,19 +193,26 @@ function singular_defaultify()
           ### Setup _Singularity call ###
           ###############################
 
-          # Generate binds
           local subcommand_args=()
-          if [ -n "${singular_volumes+set}" ]; then
-            for (( i=0; i<${#singular_volumes[@]}; i++ )); do
-              subcommand_args+=(-B "${singular_volumes[${i}]}")
-            done
-          fi
 
           # When -c is used, $HOME, /tmp, /proc, /sys, and /dev are not mounted
           # in directly. The internal /tmp is very limited and quickly starts
           # having problems. So it is best to just mount it in by default.
           if [ "${SINGULARITY_ADD_TMP_DIR-1}" = "1" ]; then
             subcommand_args+=(-B "$(get_mktemp_dir):/tmp:rw")
+          fi
+          # /tmp needs to be mounted in BEFORE singular_volumes, incase
+          # something tries to mount inside of tmp, like /tmp/.X11-unix. This
+          # does not make sense, that you can't mount into the tmpfs /tmp, but
+          # for some reason it creates a fatal error, and this works around it.
+          # It has nothing to do with "The dir exising before being mounted to"
+
+
+          # Generate binds
+          if [ -n "${singular_volumes+set}" ]; then
+            for (( i=0; i<${#singular_volumes[@]}; i++ )); do
+              subcommand_args+=(-B "${singular_volumes[${i}]}")
+            done
           fi
 
           # Make Singularity call
@@ -277,6 +284,7 @@ function singular_defaultify()
           local instance="$1"
           local mount_point_args=()
           local mount_point
+          local image_dir
 
           singular_load_env "${instance}"
 
@@ -284,11 +292,14 @@ function singular_defaultify()
             mount_point_args+=(--mount "${mount_point}")
           done
 
-          justify singularity import \
-            --name "$(basename "${singular_image}")" \
-            ${mount_point_args[@]+"${mount_point_args[@]}"} \
-            "${2}"
-
+          image_dir="$(dirname "${singular_image}")"
+          mkdir -p "${image_dir}"
+          pushd "${image_dir}" &> /dev/null
+            justify singularity import \
+              --name "$(basename "${singular_image}")" \
+              ${mount_point_args[@]+"${mount_point_args[@]}"} \
+              "${2}"
+          popd &> /dev/null
           extra_args+=2
           ;;
         *)

--- a/tests/test-just_singularity_functions.bsh
+++ b/tests/test-just_singularity_functions.bsh
@@ -59,7 +59,7 @@ begin_test "singular-compose"
     if [ "${OS-}" = "Windows_NT" ]; then
       [ "${SINGULARITYENV_JUST_HOST_WINDOWS}" = "1" ]
     fi
-    check_a args run -B "${TESTDIR}/foo:/bar:ro" -B "$(get_mktemp_dir):/tmp:rw" -c -e "${TESTDIR}/my_image.simg"
+    check_a args run -B "$(get_mktemp_dir):/tmp:rw" -B "${TESTDIR}/foo:/bar:ro" -c -e "${TESTDIR}/my_image.simg"
   )
 
   # Disable SINGULARITY_ADD_TMP_DIR
@@ -97,7 +97,7 @@ begin_test "singular-compose"
     if [ "${OS-}" = "Windows_NT" ]; then
       [ "${SINGULARITYENV_JUST_HOST_WINDOWS}" = "1" ]
     fi
-    check_a args run -B "${TESTDIR}/foo:/bar:ro" -B "$(get_mktemp_dir):/tmp:rw" -c -e "${TESTDIR}/image.simg"
+    check_a args run -B "$(get_mktemp_dir):/tmp:rw" -B "${TESTDIR}/foo:/bar:ro" -c -e "${TESTDIR}/image.simg"
   )
 
   # container_environment_override
@@ -123,14 +123,14 @@ begin_test "singular-compose"
     if [ "${OS-}" = "Windows_NT" ]; then
       [ "${SINGULARITYENV_JUST_HOST_WINDOWS}" = "1" ]
     fi
-    check_a args run -B "${TESTDIR}/foo:/bar:ro" -B "$(get_mktemp_dir):/tmp:rw" -c -e "${TESTDIR}/my_image.simg"
+    check_a args run -B "$(get_mktemp_dir):/tmp:rw" -B "${TESTDIR}/foo:/bar:ro" -c -e "${TESTDIR}/my_image.simg"
   )
 
   # Instance_start special sub-sub-command
   (
     singular_defaultify singular-compose instance_start foo3
     source "${TESTDIR}/tappoint.txt"
-    check_a args instance start -B "${TESTDIR}/foo:/bar:ro" -B "$(get_mktemp_dir):/tmp:rw" -c -e "${TESTDIR}/my_image.simg"
+    check_a args instance start -B "$(get_mktemp_dir):/tmp:rw" -B "${TESTDIR}/foo:/bar:ro" -c -e "${TESTDIR}/my_image.simg"
   )
 )
 end_test


### PR DESCRIPTION
- Add /tmp first in singular run, so subsequent. Closes #208
- Add full path of `Justfile` in `JUST_HELP_FILES` so that just works
  in other directories
- Fix singular import always writes to base directory, instead of
  correct subdirectory

Signed-off-by: Andy Neff <andy@visionsystemsinc.com>