### PR TITLE
sphinx cross-reference

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           command: |
             . setup.env
             tar c . | docker run -i --rm -v /root/repo:/src -w /src alpine:3.11 tar x
-            SPHINXOPTS='-W' just sphinx build compile -n --all
+            SPHINXOPTS='-W  --keep-going' just sphinx build compile -n --all
             docker run --rm -v /root/repo:/src -w /src alpine:3.11 tar c ./docs/_build/html | tar x
 
       - persist_to_workspace:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 * text=auto
 *.bsh text eol=lf
+*.env eol=lf
 *.sh text eol=lf
 *.Justfile text eol=lf
 linux/* eol=lf

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,8 +46,17 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
+    'sphinx.ext.intersphinx',
     'vsi_domains'
 ]
+
+# Link to other documentation (e.g., numpy, python, etc.)
+intersphinx_mapping = {
+    'ipython': ('https://ipython.readthedocs.io/en/stable/', None),
+    'matplotlib': ('https://matplotlib.org/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'python': ('https://docs.python.org/3.7', None),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -88,55 +97,26 @@ napoleon_include_special_with_doc = True
 
 # Autodoc parameters
 
-# from sphinx.autodoc.importer import import_object
-# import_object('IPython', )
+autodoc_mock_imports = [
+    "numpy",
+    "matplotlib",
+    "rpdb",
+    "rpdb2",
+    "mpl_toolkits",
+    "IPython",
+    "brl_init",
+    "boxm2_adaptor",
+    "boxm2_scene_adaptor",
+    "vpgl_adaptor_boxm2_batch",
+    "yaml",
+]
 
-autodoc_mock_imports = ["pyopencl", "vtk", "numpy", "matplotlib",
-                        "rpdb", "rpdb2", "PIL", "skimage", "mpl_toolkits",
-                        "scipy", "IPython",
-                        "brl_init", "boxm2_adaptor", "boxm2_scene_adaptor",
-                        "vpgl_adaptor_boxm2_batch", "yaml"]
-
-
-# Remove warnings due to a bug in the Python docs with nitpick_ignore
-nitpick_ignore = [('py:class', 'bool'),
-                  ('py:class', 'object'),
-                  ('py:class', 'str'),
-                  ('py:class', 'int'),
-                  ('py:class', 'float'),
-                  ('py:class', 'func'),
-                  ('py:class', 'dict'),
-                  ('py:class', 'iterable'),
-                  ('py:class', 'mapping'),
-                  ('py:class', 'list'),
-                  ('py:class', 'class'),
-                  ('py:class', 'tuple'),
-                  ('py:class', 'module'),
-                  ('py:class', 'file_like'),
-                  ('py:class', 'frame'), # watch dog
-                  ('py:class', 'Exception'),
-
-                  ('py:class', 'numpy.array'), # numpy
-                  ('py:class', 'array_like'),
-
-                  ('py:class', 'figure'), # Matplotlib
-                  ('py:class', 'axes'),
-
-                  ('py:class', 'subprocess.Popen'),
-                  ('py:class', 'rpdb2.CDebuggerCoreThread'),
-                  ('py:class', 'IPython.core.debugger.Tracer'),
-                  ('py:class', 'IPython.core.debugger.Pdb'),
-                  ('py:class', 'threading.Thread'),
-                  ('py:class', 're.Pattern'),
-
-                  ('py:class', 'BasicDecorator'), # Using decorator currently blocks sphinx
-
-                  ('py:exc', 'OSError'),
-                  ('py:exc', 'Exception'),
-                  ('py:exc', 'ValueError'),
-                  ('py:exc', 'SystemExit'),
-                  ('py:exc', 'AttributeError'),
-                  ('py:exc', 'KeyboardInterrupt')]
+nitpick_ignore = [
+    ('py:class', 'frame'), # watch dog
+    ('py:class', 'rpdb2.CDebuggerCoreThread'),
+    ('py:class', 're.Pattern'),
+    ('py:class', 'BasicDecorator'), # Using decorator currently blocks sphinx
+]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/python/vsi/iglob.py
+++ b/python/vsi/iglob.py
@@ -68,7 +68,7 @@ def glob(pathname, case=None):
 
   Returns
   -------
-  array_like
+  list
       A list of paths matching a pathname pattern
 
 
@@ -162,7 +162,7 @@ def glob0(dirname, basename, case=None):
   
   Returns
   -------
-  array_like
+  list
       A list of basenames
   """
   if dirname == '':
@@ -185,7 +185,7 @@ def glob1(dirname, pattern, case=None):
   
   Returns
   -------
-  array_like
+  list
       A list of basenames
   """
   if not dirname:
@@ -210,7 +210,7 @@ def fnmatch_filter(names, pat, casesensitive):
 
   Parameters
   ----------
-  names : array_like
+  names : :obj:`list` or :obj:`tuple`
       A list of names
   pat : str
       A pattern
@@ -219,7 +219,7 @@ def fnmatch_filter(names, pat, casesensitive):
 
   Returns
   -------
-  array_like
+  list
       The subset of the list NAMES that match PAT
   """
   result=[]

--- a/python/vsi/tools/dir_util.py
+++ b/python/vsi/tools/dir_util.py
@@ -295,7 +295,7 @@ def copytree(src, dst, symlinks=False, ignore=None):
 
   Parameters
   ----------
-  src : array_like
+  src : :term:`path-like object`
       The Source Tree
   dst : str
       The Destination Directory may not already exist. If exception(s) occur,
@@ -306,7 +306,7 @@ def copytree(src, dst, symlinks=False, ignore=None):
       Optional. True if the symbolic links in the source tree result in
       symbolic links in the destination tree. False if the contents of the
       files pointed to by symbolic links are copied.
-  ignore : array_like
+  ignore : :term:`function`
       The optional ignore argument is a callable. If given, it is called with
       the `src` parameter, which is the directory being visited by
       copytree(), and `names` which is the list of `src` contents, as
@@ -375,7 +375,7 @@ def root_dir(directory):
 
       Parameters
       ----------
-      directory : array_like
+      directory : str
           The Directory
 
       Returns

--- a/python/vsi/tools/file_util.py
+++ b/python/vsi/tools/file_util.py
@@ -6,7 +6,7 @@ def lncp(source, dest):
 
       Parameters
       ----------
-      source : array_like
+      source : str
         The Source
       dest : str
           The Destination

--- a/python/vsi/tools/iter.py
+++ b/python/vsi/tools/iter.py
@@ -8,7 +8,7 @@ def sub_block(data, block=3, overlap=0, subok=False):
 
       Parameters
       ----------
-      data : array_like
+      data : numpy.ndarray
           N-dimensional array
       block : int
           The block size of the final blocks. Should have length N or be a
@@ -22,7 +22,7 @@ def sub_block(data, block=3, overlap=0, subok=False):
 
       Returns
       -------
-      array_like
+      numpy.ndarray
           windows - N + N dimensional array where the first N dimensions are
           the window indexes, and the next N dimension are the data dimensions.
           Keep in mind, all the data is linked to the original data array.

--- a/python/vsi/tools/mpl_zoom.py
+++ b/python/vsi/tools/mpl_zoom.py
@@ -7,14 +7,14 @@ import matplotlib.pyplot as plt
 def zoom_factory(ax=None,base_scale=1.5):
     ''' Parameters
         ----------
-        ax : axes
+        ax : :mod:`matplotlib.axes`
             The Axes
         base_scale : float
             The Base Scale
 
         Returns
         -------
-        func
+        :term:`function`
             The Zoom Function
 
     '''
@@ -80,7 +80,7 @@ def figure_with_zoom(*args, **kwargs):
 
         Returns
         -------
-        figure
+        :mod:`matplotlib.figure`
             The Zoomed Figure
     '''
     # add zooming capabilities to figures

--- a/python/vsi/tools/natural_sort.py
+++ b/python/vsi/tools/natural_sort.py
@@ -7,9 +7,9 @@ def natural_sorted(iterable, key=None, *args, **kwargs):
 
     Parameters
     ----------
-    iterable : iterable
+    iterable : :term:`iterable`
         The data to be sorted.
-    key : func
+    key : :term:`function`
         The sorting function.
     *args
         Variable length argument list.

--- a/python/vsi/tools/python.py
+++ b/python/vsi/tools/python.py
@@ -114,7 +114,7 @@ def get_file(fid, mode='rb'):
 
   Returns
   -------
-  file_like
+  :term:`file-like object`
       The opened file object
   '''
 
@@ -155,14 +155,14 @@ def update_wrapper_class(wrapper, wrapped):
 
   Parameters
   ----------
-  wrapper : class
+  wrapper : :term:`class`
       The class to be updated
-  wrapped : class
+  wrapped : :term:`class`
       The original function/class
 
   Returns
   -------
-  class
+  :term:`class`
       A subclass of ``wrapper`` that has the updated attributes. If ``wrapped``
       was a function, ``wrapper`` is still a class.
   '''
@@ -191,7 +191,7 @@ def _meta_generate_class(cls, *args, **kwargs):
 
   Parameters
   ----------
-  cls : class
+  cls : :term:`class`
       The class of the decorator type
   args : tuple
       The arguments passed to the decorate, when decorating a class
@@ -262,12 +262,12 @@ class _BasicDecorator(object):
 
   Parameters
   ----------
-  fun : func
+  fun : :term:`function`
       The function that gets wrapped
 
   Attributes
   ----------
-  fun : func
+  fun : :term:`function`
       The function that is being wrapped
 
   Examples
@@ -326,7 +326,7 @@ class _BasicArgumentDecorator(object):
 
         Parameters
         ----------
-        fun : func
+        fun : :term:`function`
           The Function
     '''
 
@@ -472,7 +472,7 @@ def args_to_kwargs(function, args=tuple(), kwargs={}):
 
      Parameters
      ----------
-     function : func
+     function : :term:`function`
          The Function
      args : tuple
      kwargs : dict
@@ -602,8 +602,6 @@ def args_to_kwargs_easy(*args, **kwargs):
   '''
      Parameters
      ----------
-     function : func
-          Function being parsed
      *args : tuple
           Variable length argument list.
      **kwargs : dict
@@ -611,7 +609,7 @@ def args_to_kwargs_easy(*args, **kwargs):
 
      Returns
      -------
-     array_like
+     dict
   '''
   return args_to_kwargs(args[0], args[1:], kwargs)
 
@@ -627,7 +625,7 @@ def args_to_kwargs_unbound_easy(*args, **kwargs):
 
      Returns
      -------
-     array_like
+     dict
   '''
   return args_to_kwargs_unbound(args[0], args[1], args[2:], kwargs)
 
@@ -728,13 +726,13 @@ def nested_patch(obj, condition, patch, _spare_key = None):
 
   Parameters
   ----------
-  obj: mapping or iterable or object
+  obj: :term:`mapping` or :term:`iterable` or object
       The python object to be patched. Typically a dict, but can be a list,
       etc... or even a normal object, but that kind of defeats the purpose
-  condition: func
+  condition: :term:`function`
       The condition function to decide if each value should be patched.
       ``condition`` takes two arguments, ``(key, value)``
-  patch: func
+  patch: :term:`function`
       Callable that should return a patched version of the value. ``patch``
       takes two arguments, ``(key, value)``
 

--- a/python/vsi/tools/redirect.py
+++ b/python/vsi/tools/redirect.py
@@ -177,9 +177,9 @@ class PopenRedirect(FileRedirect):
 
         Parameters
         ----------
-        stdout : file_like
+        stdout : :term:`file-like object`
             Stdout File like object, must have .write method
-        stderr : file_like
+        stderr : :term:`file-like object`
             Stderr File like object, must have .write method
     '''
     self.stdout_output = stdout
@@ -294,7 +294,7 @@ class Redirect(RedirectBase): #Version 2
 
         Parameters
         ----------
-        file_like : :class:`file_like`, optional
+        file_like : :term:`file-like object`, optional
             File Output Argument. All File output arguments should use File
             like Python objects that have a .write call. Many of the arguments
             override the other argument for ease of use
@@ -310,15 +310,15 @@ class Redirect(RedirectBase): #Version 2
             Output stdout_py and stderr_py to the py file.
         stdout_c : :class:`str`, optional
         stderr_c : :class:`str`, optional
-        stdout_py : :class:`file_like`, optional
-        stderr_py : :class:`file_like`, optional
+        stdout_py : :term:`file-like object`, optional
+        stderr_py : :term:`file-like object`, optional
             Output to each individual stream for maximum customization.
         stdout_c_fd : :class:`int`, optional
         stderr_c_fd : :class:`int`, optional
              The default file number used for stdout (1) and stderr (2). There
              should be no reason to override this
-        stdout_py_module : :class:`module`, optional
-        stderr_py_module : :class:`module`, optional
+        stdout_py_module : :term:`module`, optional
+        stderr_py_module : :term:`module`, optional
         stdout_py_name : :class:`str`, optional
         stderr_py_name : :class:`str`, optional
             Because of the nature of python, in order to replace and restore
@@ -586,10 +586,10 @@ class Capture(RedirectBase): #version 1
             The fd to be replaced, usually 2 will work, but change it in case
             this is not right in your case (default: 2)
             None means to not redirect
-        stdout_py : :class:`file_like`, optional
+        stdout_py : :term:`file-like object`, optional
             The file object to be replaced (default: sys.stdout)
             None means to not redirect
-        stderr_py : :class:`file_like`, optional
+        stderr_py : :term:`file-like object`, optional
             The file object to be replaced (default: sys.stderr)
             None means to not redirect
         group : :class:`bool`, optional

--- a/python/vsi/tools/stdout_profile.py
+++ b/python/vsi/tools/stdout_profile.py
@@ -20,7 +20,7 @@ def argumet_parser():
 def main(args=sys.argv[1:]):
   ''' Parameters
       ----------
-      args : array_like
+      args : list
           An array of arguments
 '''
   parser = argumet_parser()

--- a/python/vsi/tools/vdb.py
+++ b/python/vsi/tools/vdb.py
@@ -149,7 +149,7 @@ class RunningTrace():
 
         Parameters
         ----------
-        debugger_cls : class
+        debugger_cls : :term:`class`
             Bdb based Debugger class to be mixed in
 
         Returns
@@ -263,7 +263,7 @@ class DbStopIfErrorGeneric(object):
   def get_post_mortem(self):
     ''' Returns
         -------
-        func
+        :term:`function`
             Should return a function that takes a traceback as the first
             argument and any additional args/kwargs sent to __init__ after that
 
@@ -295,13 +295,13 @@ def dbstop_exception_hook(type, value, tb,
                           interactive=False):
     ''' Parameters
         ----------
-        type : class
+        type : :term:`class`
           sys.excepthook variable
         value : object
           sys.excepthook variable
         tb : object
           sys.excepthook variable
-        post_mortem : func
+        post_mortem : :term:`function`
           The Post Mortem Handler Function
         Interactive : bool
             True if interactive. False if not.

--- a/python/vsi/tools/vdb_ipdb.py
+++ b/python/vsi/tools/vdb_ipdb.py
@@ -99,7 +99,7 @@ def runpdb(lines, debugger=None):
 
   Arguments
   ---------
-  lines : array_like
+  lines : :obj:`str` or :obj:`list` or :obj:`tuple`
       Collection of strings to be executed as if you were already in the
       debugger. Useful for setting breakpoints programatically.
 

--- a/python/vsi/vxl/generate_scene_xml.py
+++ b/python/vsi/vxl/generate_scene_xml.py
@@ -11,8 +11,8 @@ def generate_scene_xml(output_file, model_dir_rel, num_blocks, num_subblocks, su
   output_file : str
       The output file
   model_dir_rel :
-  num_blocks : array_like
-  num_subblocks : array_like
+  num_blocks : int
+  num_subblocks : int
   subblock_size : int
       The subblock size
 

--- a/python/vsi/windows/find_process.py
+++ b/python/vsi/windows/find_process.py
@@ -14,7 +14,7 @@ def findProcess(imageName, filterString):
 
   Returns
   -------
-  array_like
+  :term:`iterator`
       The Process
   """
   pid = Popen(['wmic', 'path', 'win32_process', 'where',

--- a/python/vsi/windows/named_pipes.py
+++ b/python/vsi/windows/named_pipes.py
@@ -35,7 +35,7 @@ def open(name, server=False):
 
   Returns
   -------
-  array_like
+  :class:`Pipe`
       The pipe
 
 
@@ -123,7 +123,7 @@ class Pipe(object):
 
     Returns
     -------
-    array_like
+    bool
     """
     return windll.kernel32.WaitNamedPipeA(PIPE_PREFIX+name, timeout__ms)
 

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -17,7 +17,7 @@ set_array_default VSI_COMMON_SPHINX_EXCLUDE_DIRS docs
 set_array_default VSI_COMMON_SPHINX_AUTODOC_DIRS python/vsi
 set_array_default VSI_COMMON_SPHINX_AUTODOC_OUTPUT_DIRS python
 set_array_default VSI_COMMON_SPHINX_AUTODOC_EXCLUDE_DIRS python/vsi/test python/vsi/utils
-: ${VSI_COMMON_SPHINX_PRECOMPILE_SCRIPT=/docs/custom_prebuild.bsh}
+: ${VSI_COMMON_SPHINX_PRECOMPILE_SCRIPT=${JUST_PATH_ESC}/docs/custom_prebuild.bsh}
 
 : ${VSI_COMMON_BASHCOV_SOURCE_DIR=${VSI_COMMON_DIR}}
 


### PR DESCRIPTION
Add intersphinx_mapping to sphinx docs conf.py, allowing documentation to appropriately cross-reference against other documentation. Note this drastically reduces the necessary nitpick_ignore list and should make future documentation have fewer errors.

Add --keep-going to circleci compile_docs to make visible all sphinx errors (not just the first one).

For windows compatibility, add `*.env eof=lf` to `.gitattributes` and `JUST_PATH_ESC` to `vsi_common.env`

