### PR TITLE
avoid 'Error: No such volume'

### DIFF
--- a/linux/file_tools.bsh
+++ b/linux/file_tools.bsh
@@ -1,4 +1,4 @@
-#!/usr/bin/env false
+#!/usr/bin/env false bash
 
 if [[ $- != *i* ]]; then
   source_once &> /dev/null && return 0

--- a/linux/just_docker_functions.bsh
+++ b/linux/just_docker_functions.bsh
@@ -1,3 +1,5 @@
+#!/usr/bin/env false bash
+
 if [[ $- != *i* ]]; then
   source_once &> /dev/null && return 0
 fi
@@ -379,7 +381,12 @@ function docker_defaultify()
       local volume_inspect_rv=0
       # local foo="$(bar)" || rv=$? does not work as one line in bash 4.2 or older. Ues two lines
       local volume_inspect
-      volume_inspect="$(docker volume inspect "${1}")" 2>/dev/null || volume_inspect_rv=$?
+      # docker volume inspect causes a trap set by just and inherited by the
+      # subshell to execute when the volume is not found on bash 3.2.
+      # although redirecting the docker command catches inspect's error message,
+      # it doesn't catch the trap unless the entire subshell's stderr is
+      # redirected via exec 2>/dev/null. Disabling the trap felt cleaner
+      volume_inspect="$(trap -- ERR; docker volume inspect "${1}" 2>/dev/null)" || volume_inspect_rv=$?
 
       if [ "${volume_inspect_rv}" = "0" ]; then
         local rm_rv


### PR DESCRIPTION
avoid 'Error: No such volume' message when trying to inspect a volume that isn't found (it may have already been deleted)