### PR TITLE
Restruct possible fails testlib

### DIFF
--- a/docker/vsi_common/bashcov.Justfile
+++ b/docker/vsi_common/bashcov.Justfile
@@ -9,7 +9,7 @@ function caseify()
   shift 1
 
   : ${TESTLIB_PARALLEL=$(nproc)}
-  export TESTLIB_NO_PS4=1
+  export TESTLIB_PS4='+'
   export TESTLIB_REDIRECT_OUTPUT=0
 
   case "${cmd}" in

--- a/linux/just
+++ b/linux/just
@@ -198,8 +198,8 @@ function print_error()
   #       ;;
   #
   #     # More example values
-  #     25      # Only 25 is ignore
-  #     24$|^25 # 24 or 25 is ignored ^ is implied at the beginning, and $ at the end
+  #     25      # Only 25 is ignored
+  #     24$|^25 # 24 or 25 is ignored; ^ is implied at the beginning, and $ at the end. So it is really: "^24$|^25$"
   #     2.      # 20-29
   #     .*      # All exit codes
   #     3.$|^72 # 30-39 or 72

--- a/linux/new_just
+++ b/linux/new_just
@@ -633,10 +633,10 @@ function write_dockerfile()
 
   uwecho   '
             COPY --from=vsi /vsi /vsi
-            ADD ["'"$(docker_add_quote_escape "${PROJECT_NAME}.env")"'", "/src/"]
+            ADD ["'"$(docker_add_quote_escape "${PROJECT_NAME}.env")"'", "Pipfile", "Pipfile.lock", "/src/"]
             ADD ["'"$(docker_add_quote_escape docker/"${APP_NAME}.Justfile")"'", "/src/docker/"]
 
-            ENV JUSTFILE="/src/'"$(docker_env_quote_escape "${APP_NAME}.Justfile")"'" \
+            ENV JUSTFILE="/src/docker/'"$(docker_env_quote_escape "${APP_NAME}.Justfile")"'" \
                 JUST_SETTINGS="/src/'"$(docker_env_quote_escape "${PROJECT_NAME}.env")"'"
 
             ENTRYPOINT ["/usr/local/bin/tini", "--", "/usr/bin/env", "bash", "/vsi/linux/just_entrypoint.sh"]

--- a/tests/quiz-testlib.bsh
+++ b/tests/quiz-testlib.bsh
@@ -73,3 +73,33 @@ begin_expected_fail_test "Test expected to fail, but succeeds in end_fail_zone"
   true
 )
 end_test
+
+begin_required_fail_test "Test required to fail, succeeds, not setup right"
+(
+  setup_test
+
+  true
+)
+end_test
+
+begin_required_fail_test "Test required to fail, but succeeds"
+(
+  setup_test
+
+  begin_fail_zone
+  true
+)
+end_test
+
+begin_test "Test required to fail, but fails in the wrong spot"
+(
+  setup_test
+
+  begin_fail_zone
+  true
+  end_fail_zone
+
+  false
+  begin_fail_zone
+)
+end_test

--- a/tests/quiz-testlib.bsh
+++ b/tests/quiz-testlib.bsh
@@ -32,13 +32,13 @@ begin_required_fail_test "Test failed required fail"
 )
 end_test
 
-begin_expected_fail_test "Test expected to fail, succeeds, not setup right"
+begin_expected_fail_test "Test expected to fail, it succeeds, but no fail zone setup"
 (
   setup_test
 )
 end_test
 
-begin_expected_fail_test "Test expected to fail, fail in wrong area"
+begin_expected_fail_test "Test expected to fail, but it fails outside fail zone"
 (
   setup_test
 

--- a/tests/quiz-testlib.bsh
+++ b/tests/quiz-testlib.bsh
@@ -31,3 +31,45 @@ begin_required_fail_test "Test failed required fail"
   echo "Not failing when I should pass ${@+${@}}"
 )
 end_test
+
+begin_expected_fail_test "Test expected to fail, succeeds, not setup right"
+(
+  setup_test
+)
+end_test
+
+begin_expected_fail_test "Test expected to fail, fail in wrong area"
+(
+  setup_test
+
+  begin_fail_zone
+  true
+  end_fail_zone
+
+  false
+
+  begin_fail_zone
+  false
+)
+end_test
+
+begin_expected_fail_test "Test expected to fail, but succeeds"
+(
+  setup_test
+
+  begin_fail_zone
+  true
+)
+end_test
+
+begin_expected_fail_test "Test expected to fail, but succeeds in end_fail_zone"
+(
+  setup_test
+
+  begin_fail_zone
+  true
+  end_fail_zone
+
+  true
+)
+end_test

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -97,7 +97,7 @@ function run_all_tests_atexit()
     env
   fi
 
-  local sum=(-1 -1 -1 -1 -1)
+  local sum=(-1 -1 -1 -1 -1 -1)
   if ! is_dir_empty "${TESTLIB_SUMMARY_DIR}"; then
     sum=($(awk '
       {
@@ -125,18 +125,25 @@ function run_all_tests_atexit()
     echo -n "${TESTLIB_BAD_COLOR}"
   fi
   printf "%d failures${TESTLIB_RESET_COLOR}, " ${sum[1]}
+
   if [ "${sum[2]}" -ne 0 ]; then
+    echo -n "${TESTLIB_BOLD_COLOR}"
+  fi
+  printf "%d unexpected successes${TESTLIB_RESET_COLOR}, " ${sum[2]}
+
+
+  if [ "${sum[3]}" -ne 0 ]; then
     echo -n "${TESTLIB_WARN_COLOR}"
   else
     echo -n "${TESTLIB_BOLD_COLOR}"
   fi
-  printf "%d expected failures${TESTLIB_RESET_COLOR}, " ${sum[2]}
+  printf "%d expected failures${TESTLIB_RESET_COLOR}, " ${sum[3]}
 
-  printf "%d required failures, and " ${sum[3]}
-  if [ "${sum[4]}" -eq 0 ]; then
+  printf "%d required failures, and " ${sum[4]}
+  if [ "${sum[5]}" -eq 0 ]; then
     echo -n "${TESTLIB_BOLD_COLOR}"
   fi
-  printf "%d skipped${TESTLIB_RESET_COLOR}\n\n" ${sum[4]}
+  printf "%d skipped${TESTLIB_RESET_COLOR}\n\n" ${sum[5]}
 
   run_all_tests_cleanup
 

--- a/tests/test-docker_compose_override.bsh
+++ b/tests/test-docker_compose_override.bsh
@@ -345,6 +345,7 @@ begin_expected_fail_test "Issue #7 Scenario 1"
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
 
+  begin_fail_zone
   [ "${override}" = "${ans}" ]
 )
 end_test
@@ -396,6 +397,7 @@ begin_expected_fail_test "Issue #7 Scenario 3"
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
 
+  begin_fail_zone
   [ "${override}" = "${ans}" ]
 )
 end_test

--- a/tests/test-docker_functions.bsh
+++ b/tests/test-docker_functions.bsh
@@ -582,6 +582,7 @@ begin_required_fail_test "Just docker compose required project prefix"
   unset JUST_PROJECT_PREFIX
   echo "${compose_file_hay}" > "${TESTDIR}/dc.yml"
   set -eu
+  begin_fail_zone
   Just-docker-compose -f "${TESTDIR}/dc.yml" run test_hay > /dev/null
 )
 end_test

--- a/tests/test-elements.bsh
+++ b/tests/test-elements.bsh
@@ -970,6 +970,8 @@ begin_expected_fail_test "Special characters to array"
   x=$'11 "2\n2" "3 \t 3 "'
   # x="$(printf '%q' "${x}")"
   to_array x
+
+  begin_fail_zone
   check_a x 11 $'2\n 2' $'3 \t 3 '
 )
 end_test

--- a/tests/test-just_functions.bsh
+++ b/tests/test-just_functions.bsh
@@ -778,6 +778,7 @@ end_test
 begin_required_fail_test "get_additional_args called without get_args"
 (
   setup_test
+  begin_fail_zone
   get_additional_args 11 -- 22 -- 33
 )
 end_test

--- a/tests/test-just_wrap.bsh
+++ b/tests/test-just_wrap.bsh
@@ -186,7 +186,7 @@ begin_test "Unwrapped test source"
   # Uncomment these if there is a need to debug here.
   # set +xv
   # echo ------------------------------------ >&2
-  # if [ -z "${TESTLIB_NO_PS4+set}" ]; then
+  # if [ -z "${TESTLIB_PS4+set}" ]; then
   #   export PS4="$'+${0##*/}:${LINENO})\t'"
   # fi
   # and add x to euc

--- a/tests/test-new_just.bsh
+++ b/tests/test-new_just.bsh
@@ -231,9 +231,9 @@ pe shell"
   grep -q '"develop": {}' Pipfile.lock
   # Dockerfile
   grep -q 'COPY --from=vsi /vsi /vsi' docker/example.Dockerfile
-  grep -q "ADD \[\"${project_name}.env\", \"/src/\"]" docker/example.Dockerfile
+  grep -q "ADD \[\"${project_name}.env\", \"Pipfile\", \"Pipfile.lock\", \"/src/\"]" docker/example.Dockerfile
   grep -q "ADD \[\"docker/example.Justfile\", \"/src/docker/\"]" docker/example.Dockerfile
-  grep -q "ENV JUSTFILE=\"/src/example.Justfile\"" docker/example.Dockerfile
+  grep -q "ENV JUSTFILE=\"/src/docker/example.Justfile\"" docker/example.Dockerfile
   grep -q "JUST_SETTINGS=\"/src/${project_name}.env\"" docker/example.Dockerfile
   # docker-compose.yml
   grep -q -e "- DOCKER_UID=\${${project_prefix}_UID}" docker-compose.yml

--- a/tests/test-python_tools.bsh
+++ b/tests/test-python_tools.bsh
@@ -43,6 +43,7 @@ begin_expected_fail_test "Array to python ast literal eval list of strings lose 
   }
   foo
   # This line should fail, but doesn't
+  begin_fail_zone
   not [ "${x-}" = '["11", "22", "33"]' ]
 )
 end_test

--- a/tests/test-testlib.bsh
+++ b/tests/test-testlib.bsh
@@ -90,7 +90,7 @@ begin_test "Run actual failing tests"
 
   summary_file="${TESTDIR}/quiz-testlib.bsh"
 
-  # There should be 5 failures and 2 unexpected successes!
+  # There should be 8 failures and 2 unexpected successes!
   [ "$(awk '{print $2" "$3}' "${summary_file}")" = "8 2" ]
 )
 end_test
@@ -106,11 +106,11 @@ begin_test "Test TESTLIB_STOP_AFTER_FAILS"
   # Zero already tested above
 
   TESTLIB_STOP_AFTER_FAILS=1 TESTLIB_SUMMARY_DIR=${TESTDIR} "${THIS_TEST_DIR}/quiz-testlib.bsh" 2>&1 || :
-  # There should be 1 failure, 2 skips!
+  # There should be 1 failure, 9 skips
   [ "$(awk '{print $2" "$6}' "${summary_file}")" = "1 9" ]
 
   TESTLIB_STOP_AFTER_FAILS=2 TESTLIB_SUMMARY_DIR=${TESTDIR} "${THIS_TEST_DIR}/quiz-testlib.bsh" 2>&1 || :
-  # There should be 2 failure, 1 skips!
+  # There should be 2 failure, 8 skips
   [ "$(awk '{print $2" "$6}' "${summary_file}")" = "2 8" ]
 )
 end_test

--- a/tests/test-testlib.bsh
+++ b/tests/test-testlib.bsh
@@ -104,10 +104,10 @@ begin_test "Test TESTLIB_STOP_AFTER_FAILS"
 
   TESTLIB_STOP_AFTER_FAILS=1 TESTLIB_SUMMARY_DIR=${TESTDIR} "${THIS_TEST_DIR}/quiz-testlib.bsh" 2>&1 || :
   # There should be 1 failure, 2 skips!
-  [ "$(awk '{print $2" "$5}' "${summary_file}")" = "1 2" ]
+  [ "$(awk '{print $2" "$6}' "${summary_file}")" = "1 2" ]
 
   TESTLIB_STOP_AFTER_FAILS=2 TESTLIB_SUMMARY_DIR=${TESTDIR} "${THIS_TEST_DIR}/quiz-testlib.bsh" 2>&1 || :
   # There should be 2 failure, 1 skips!
-  [ "$(awk '{print $2" "$5}' "${summary_file}")" = "2 1" ]
+  [ "$(awk '{print $2" "$6}' "${summary_file}")" = "2 1" ]
 )
 end_test

--- a/tests/test-testlib.bsh
+++ b/tests/test-testlib.bsh
@@ -27,6 +27,7 @@ begin_required_fail_test "Test Required Fail"
 
   echo "Required fail test ${@+${@}}"
 
+  begin_fail_zone
   false
 )
 end_test
@@ -90,7 +91,7 @@ begin_test "Run actual failing tests"
   summary_file="${TESTDIR}/quiz-testlib.bsh"
 
   # There should be 5 failures and 2 unexpected successes!
-  [ "$(awk '{print $2" "$3}' "${summary_file}")" = "5 2" ]
+  [ "$(awk '{print $2" "$3}' "${summary_file}")" = "8 2" ]
 )
 end_test
 
@@ -106,11 +107,11 @@ begin_test "Test TESTLIB_STOP_AFTER_FAILS"
 
   TESTLIB_STOP_AFTER_FAILS=1 TESTLIB_SUMMARY_DIR=${TESTDIR} "${THIS_TEST_DIR}/quiz-testlib.bsh" 2>&1 || :
   # There should be 1 failure, 2 skips!
-  [ "$(awk '{print $2" "$6}' "${summary_file}")" = "1 6" ]
+  [ "$(awk '{print $2" "$6}' "${summary_file}")" = "1 9" ]
 
   TESTLIB_STOP_AFTER_FAILS=2 TESTLIB_SUMMARY_DIR=${TESTDIR} "${THIS_TEST_DIR}/quiz-testlib.bsh" 2>&1 || :
   # There should be 2 failure, 1 skips!
-  [ "$(awk '{print $2" "$6}' "${summary_file}")" = "2 5" ]
+  [ "$(awk '{print $2" "$6}' "${summary_file}")" = "2 8" ]
 )
 end_test
 

--- a/tests/test-testlib.bsh
+++ b/tests/test-testlib.bsh
@@ -16,6 +16,7 @@ begin_expected_fail_test "Test Expected Fail"
 
   echo "Failing test ${@+${@}}"
 
+  begin_fail_zone
   false
 )
 end_test
@@ -88,10 +89,11 @@ begin_test "Run actual failing tests"
 
   summary_file="${TESTDIR}/quiz-testlib.bsh"
 
-  # There should be three failures!
-  [ "$(awk '{print $2}' "${summary_file}")" -eq 3 ]
+  # There should be 5 failures and 2 unexpected successes!
+  [ "$(awk '{print $2" "$3}' "${summary_file}")" = "5 2" ]
 )
 end_test
+
 
 begin_test "Test TESTLIB_STOP_AFTER_FAILS"
 (
@@ -104,10 +106,25 @@ begin_test "Test TESTLIB_STOP_AFTER_FAILS"
 
   TESTLIB_STOP_AFTER_FAILS=1 TESTLIB_SUMMARY_DIR=${TESTDIR} "${THIS_TEST_DIR}/quiz-testlib.bsh" 2>&1 || :
   # There should be 1 failure, 2 skips!
-  [ "$(awk '{print $2" "$6}' "${summary_file}")" = "1 2" ]
+  [ "$(awk '{print $2" "$6}' "${summary_file}")" = "1 6" ]
 
   TESTLIB_STOP_AFTER_FAILS=2 TESTLIB_SUMMARY_DIR=${TESTDIR} "${THIS_TEST_DIR}/quiz-testlib.bsh" 2>&1 || :
   # There should be 2 failure, 1 skips!
-  [ "$(awk '{print $2" "$6}' "${summary_file}")" = "2 1" ]
+  [ "$(awk '{print $2" "$6}' "${summary_file}")" = "2 5" ]
+)
+end_test
+
+begin_expected_fail_test "Test expected to fail end_fail_zone"
+(
+  setup_test
+
+  begin_fail_zone
+  true
+  end_fail_zone
+
+  true
+
+  begin_fail_zone
+  false
 )
 end_test

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -20,22 +20,25 @@
 #
 # ## Writing unit tests
 #
-# Test Lib gives you are number of basic unit test functionality from bash, including:
+# Test Lib gives you a number of basic unit test functionality from bash, including:
 #
 # - Running tests in subshells to prevent environment variable pollution.
 # - An automatically self deleting :envvar:`TRASHDIR` for all the tests
-# - An automatically self deleting :envvar:`TESTDIR` for each individual test
-# - A tally of successful run and failed tests, and additionally expected failures, unexpected successes, required failures, and skipped tests
-# - Individual est times :envvar:`TESTLIB_SHOW_TIMING`
+# - An automatically self deleting :envvar:`TESTDIR` for each individual test (in the :envvar:`TRASHDIR`)
+# - A tally of successfully run and failed tests, and additionally expected failures, unexpected successes, required failures, and skipped tests
+# - Individual est times: :envvar:`TESTLIB_SHOW_TIMING`
 # - A user defined :func:`setup` function run before the first test in a file
 # - A user defined :func:`teardown` function run after the last test in a file
-# - Keep temporary directories for debugging :envvar:`TESTLIB_KEEP_TEMP_DIRS`
-# - Pause before deleting temporary directories if there is is a failure, for inspection :envvar:`TESTLIB_KEEP_PAUSE_AFTER_ERROR`
-# - Run only a single test by it's description :envvar:`TESTLIB_RUN_SINGLE_TEST`
-# - Regular expression to skip tests by description :envvar:`TESTLIB_SKIP_TESTS`
+# - Keep temporary directories for debugging: :envvar:`TESTLIB_KEEP_TEMP_DIRS`
+# - Pause before deleting temporary directories if there is a failure for inspection: :envvar:`TESTLIB_KEEP_PAUSE_AFTER_ERROR`
+# - Run only a single test by its description: :envvar:`TESTLIB_RUN_SINGLE_TEST`
+# - Regular expression to skip tests by description: :envvar:`TESTLIB_SKIP_TESTS`
 # - Control stderr/stdout redirection :envvar:`TESTLIB_REDIRECT_OUTPUT`
 # - Stop testing after ``N`` failures :envvar:`TESTLIB_STOP_AFTER_FAILS`
 # - Disable custom PS4 in trace :envvar:`TESTLIB_NO_PS4`
+# - Ability to conditionally skip a test by calling :func:`skip_next_test` in any condition check
+# - Track files outside the :envvar:`TRASHDIR` with :func:`ttouch` so that they will be automatically deleted during cleanup.
+# - Other helper functions like :func:`not`, :func:`not_s`, :func:`test_utils.bsh check_a`, :func:`test_utils.bsh check_ra`, :func:`test_utils.bsh contiguous_a`
 #
 # .. rubric:: Example
 #
@@ -57,7 +60,7 @@
 #   )
 #   end_test
 #
-#   Any command that evaluates to false "fails" the test. When a test fails its stdout, stderr, and call trace are printed out.
+#   Any command that evaluates to false "fails" the test. When a test fails, its stdout, stderr, and call trace are printed out.
 #
 # .. rubric:: Bugs
 #
@@ -79,11 +82,11 @@
 # - ``SKIPPED`` - The test was not run.
 # - ``FAIL REQUIRED`` - A test successfully failed as it is required to.
 # - ``FAIL EXPECTED`` - A test successfully failed as it is expected to.
-# - ``SHOULD HAVE FAILED ELSEWHERE`` - A required or expected failed test failed in an the wrong area of the code. There is something wrong with the test, and a trace is printed out for debugging.
-# - ``SHOULD HAVE FAILED`` - A required failed test did not fail. There is something wrong with the test, and a trace is printed out for debugging.
-# - ``UNEXPECTED SUCCESS`` - An expected failed test never actually failed. This doesn't count as a failure, but a middle ground in its own category.
-# - ``REQUIRED FAILURE SETUP ERROR`` - A required failed test did not call :func:`begin_fail_zone`, and is considered setup incorrectly.
-# - ``EXPECTED FAILURE SETUP ERROR`` - An expected failed test did not call :func:`begin_fail_zone`, and is considered setup incorrectly.
+# - ``SHOULD HAVE FAILED ELSEWHERE`` - A required or expected to fail test failed in an the wrong area of the code. There is something wrong with the test, and a trace is printed out for debugging.
+# - ``SHOULD HAVE FAILED`` - A required to fail test did not fail. There is something wrong with the test, and a trace is printed out for debugging.
+# - ``UNEXPECTED SUCCESS`` - An expected to fail test never actually failed. This doesn't count as a failure, but a middle ground in its own category.
+# - ``REQUIRED FAILURE SETUP ERROR`` - A required to fail test did not call :func:`begin_fail_zone` and is considered setup incorrectly.
+# - ``EXPECTED FAILURE SETUP ERROR`` - An expected to fail test did not call :func:`begin_fail_zone` and is considered setup incorrectly.
 #**
 
 if [ -z ${VSI_COMMON_DIR+set} ]; then
@@ -425,11 +428,13 @@ begin_test ()
 #**
 # .. function:: begin_expected_fail_test
 #
-# Beginning of expected fail test demarcation
+# Beginning of expected to fail test demarcation
 #
 # .. rubric:: Usage
 #
-# Define the beginning of a test that is expected to fail. Failures may only occur in "fail zones" denoted by :func:`begin_fail_zone` and :func:`end_fail_zone`
+# Define the beginning of a test that is expected to fail. Failures may only occur in "fail zones" denoted by :func:`begin_fail_zone` and :func:`end_fail_zone`. When a test fails in a fail zone, it is counted as a success. If a test that was expected to fail test never fails, it counts as an "unexpected success" rather than a normal success. If the test fails outside a fail zone, it is marked as a failure.
+#
+# The typical use case for expecting a failure, is a known bug is being tested, and has not or cannot be fixed yet. For this reason, a success is counted as an "unexpected success" rather than a normal success. While unexpected successes do not cause a non-zero exit code, they can easily be notices as something that should be updated.
 #**
 begin_expected_fail_test()
 {
@@ -439,11 +444,29 @@ begin_expected_fail_test()
 }
 
 #**
+# .. function:: begin_required_fail_test
+#
+# Beginning of required to fail test demarcation
+#
+# .. rubric:: Usage
+#
+# Define the beginning of a test that is required to fail. Failures may only occur in "fail zones" denoted by :func:`begin_fail_zone` and :func:`end_fail_zone`. When a test fails in a fail zone, it is counted as a success. If a required to fail test never fails, it counts as a failure. If the test fails outside a fail zone, it is marked as a failure.
+#
+# The typical use case for requiring a failure, is testing that an exception is raise under proper circumstances.
+#**
+begin_required_fail_test()
+{
+  test_status=$? # Must be first command
+  # Override _begin_common_test default
+  _required_fail=1 _begin_common_test ${@+"${@}"}
+}
+
+#**
 # .. function:: begin_fail_zone
 #
 # Start a fail zone
 #
-# In practice, having an expected fail or required fail leads to the possibility of a test failing somewhere you don't expect it to. For this reason, fail zones must be denoted in order for :func:`begin_expected_fail_test` and :func:`begin_required_fail_test` tests to succeed, and the the failures must only occur in a fail zone. If a test a failure happens outside the fail zone, the test will be marked as a failure, with the message ``SHOULD HAVE FAILED ELSEWHERE``.
+# In practice, having an test that is expected or required to fail leads to the possibility of a test failing somewhere you don't expect it to. For this reason, fail zones must be denoted in order for :func:`begin_expected_fail_test` and :func:`begin_required_fail_test` tests to succeed, and the the failures must only occur in a fail zone. If a test a failure happens outside the fail zone, the test will be marked as a failure, with the message ``SHOULD HAVE FAILED ELSEWHERE``.
 #
 # Typically this will be called right before the last last line of a test
 #
@@ -495,22 +518,6 @@ begin_fail_zone()
 end_fail_zone()
 {
   echo 0 > "${TRASHDIR}/.testlib_failure_zone"
-}
-
-#**
-# .. function:: begin_required_fail_test
-#
-# Beginning of required fail test demarcation
-#
-# .. rubric:: Usage
-#
-# Define the beginning of a test that is required to fail
-#**
-begin_required_fail_test()
-{
-  test_status=$? # Must be first command
-  # Override _begin_common_test default
-  _required_fail=1 _begin_common_test ${@+"${@}"}
 }
 
 #**
@@ -859,7 +866,7 @@ not_s()
 #
 # Start tracking touched files
 #
-# After running :func:`track_touched_files`, any call to touch will cause that file to be added to the internal list (touched_files). Just prior to the teardown phase, all of these files will be automatically removed for your convenience.
+# After running :func:`track_touched_files`, any call to :func:`ttouch` will cause that file to be added to the internal list (touched_files). Just prior to the teardown phase, all of these files will be automatically removed for your convenience.
 #
 # .. rubric:: Example
 #
@@ -871,7 +878,7 @@ not_s()
 #   }
 #   begin_test Testing
 #   (
-#     touch /tmp/hiya
+#     ttouch /tmp/hiya
 #   )
 #   end_test
 #

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -432,12 +432,12 @@ begin_expected_fail_test()
 
 begin_fail_zone()
 {
-  echo 1 > "${TRASHDIR}/.expected_failure"
+  echo 1 > "${TRASHDIR}/.testlib_failure_zone"
 }
 
 end_fail_zone()
 {
-  echo 0 > "${TRASHDIR}/.expected_failure"
+  echo 0 > "${TRASHDIR}/.testlib_failure_zone"
 }
 
 #**
@@ -548,35 +548,43 @@ end_test ()
     skipped=$((skipped+1))
   # Handle a required fail
   elif [ "${required_fail}" -eq 1 ]; then
-    if [ "$test_status" -ne 0 ]; then
-      printf "%-80s ${TESTLIB_GOOD_COLOR}FAIL REQUIRED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
-      required_failures=$((required_failures+1))
-    else
-      failures=$(( failures + 1 ))
-      printf "%-80s ${TESTLIB_BAD_COLOR}SHOULD HAVE FAILED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
-      testlib_print_test_trace
-    fi
-  # Handle an expected fail
-  elif [ "${expected_failure}" -eq 1 ]; then
-    if [ -f "${TRASHDIR}/.expected_failure" ]; then
-      local expected_failure_state="$(<"${TRASHDIR}/.expected_failure")"
-      if [ "${expected_failure_state}" = "1" ]; then
-        if [ "${test_status}" = "0" ]; then
-          printf "%-80s ${TESTLIB_WARN_COLOR}UNEXPECTED SUCCESS T1${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
-          unexpected_successes=$(( unexpected_successes + 1 ))
-        else
-          printf "%-80s ${TESTLIB_GOOD_COLOR}FAIL EXPECTED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
-          expected_failures=$(( expected_failures + 1 ))
-        fi
-      else
-        if [ "${test_status}" = "0" ]; then
-          printf "%-80s ${TESTLIB_WARN_COLOR}UNEXPECTED SUCCESS T2${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
-          unexpected_successes=$(( unexpected_successes + 1 ))
+    if [ -f "${TRASHDIR}/.testlib_failure_zone" ]; then
+      local required_failure_state="$(<"${TRASHDIR}/.testlib_failure_zone")"
+      if [ "$test_status" != 0 ]; then
+        if [ "${required_failure_state}" = "1" ]; then
+          printf "%-80s ${TESTLIB_GOOD_COLOR}FAIL REQUIRED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+          required_failures=$((required_failures+1))
         else
           printf "%-80s ${TESTLIB_BAD_COLOR}SHOULD HAVE FAILED ELSEWHERE${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
           failures=$(( failures + 1 ))
           testlib_print_test_trace
         fi
+      else
+        failures=$(( failures + 1 ))
+        printf "%-80s ${TESTLIB_BAD_COLOR}SHOULD HAVE FAILED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+        testlib_print_test_trace
+      fi
+    else
+      # Handle missing call to begin_fail_zone
+      printf "%-80s ${TESTLIB_BAD_COLOR}REQUIRED FAILURE SETUP ERROR${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+      failures=$(( failures + 1 ))
+    fi
+  # Handle an expected fail
+  elif [ "${expected_failure}" -eq 1 ]; then
+    if [ -f "${TRASHDIR}/.testlib_failure_zone" ]; then
+      local expected_failure_state="$(<"${TRASHDIR}/.testlib_failure_zone")"
+      if [ "${test_status}" != "0" ]; then
+        if [ "${expected_failure_state}" = "1" ]; then
+          printf "%-80s ${TESTLIB_GOOD_COLOR}FAIL EXPECTED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+          expected_failures=$(( expected_failures + 1 ))
+        else
+          printf "%-80s ${TESTLIB_BAD_COLOR}SHOULD HAVE FAILED ELSEWHERE${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+          failures=$(( failures + 1 ))
+          testlib_print_test_trace
+        fi
+      else
+        printf "%-80s ${TESTLIB_WARN_COLOR}UNEXPECTED SUCCESS${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+        unexpected_successes=$(( unexpected_successes + 1 ))
       fi
     else
       # Handle missing call to begin_fail_zone
@@ -584,7 +592,7 @@ end_test ()
       failures=$(( failures + 1 ))
     fi
     # Remove account file
-    rm -f "${TRASHDIR}/.expected_failure"
+    rm -f "${TRASHDIR}/.testlib_failure_zone"
   elif [ "${required_fail}" -eq 0 ] && [ "$test_status" -eq 0 ]; then
     printf "%-80s ${TESTLIB_GOOD_COLOR}OK${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
   else

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -430,6 +430,16 @@ begin_expected_fail_test()
   _expected_failure=1 _begin_common_test ${@+"${@}"}
 }
 
+begin_fail_zone()
+{
+  echo 1 > "${TRASHDIR}/.expected_failure"
+}
+
+end_fail_zone()
+{
+  echo 0 > "${TRASHDIR}/.expected_failure"
+}
+
 #**
 # .. function:: begin_required_fail_test
 #
@@ -526,78 +536,61 @@ end_test ()
     time_e=$(awk "BEGIN {print \"\t\" $(get_time_seconds)-${_time_0}}")
   fi
 
+  # Handle missing call to setup_test
   if [ ! -e "${TRASHDIR}/.setup_test" ]; then
     # This is a "no matter what, failure". No expected/required failure work
     # around for this
     printf "%-80s ${TESTLIB_BAD_COLOR}SETUP FAILURE${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
     failures=$(( failures + 1 ))
+  # Handle a skipped test
   elif [ "${__testlib_skip_test-}" = "1" ] && [ "${test_status}" -eq 0 ]; then
     printf "%-80s ${TESTLIB_GOOD_COLOR}SKIPPED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
     skipped=$((skipped+1))
-  elif [ "${required_fail}" -eq 1 ] && [ "$test_status" -ne 0 ]; then
-    printf "%-80s ${TESTLIB_GOOD_COLOR}FAIL REQUIRED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
-    required_failures=$((required_failures+1))
+  # Handle a required fail
+  elif [ "${required_fail}" -eq 1 ]; then
+    if [ "$test_status" -ne 0 ]; then
+      printf "%-80s ${TESTLIB_GOOD_COLOR}FAIL REQUIRED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+      required_failures=$((required_failures+1))
+    else
+      failures=$(( failures + 1 ))
+      printf "%-80s ${TESTLIB_BAD_COLOR}SHOULD HAVE FAILED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+      testlib_print_test_trace
+    fi
+  # Handle an expected fail
+  elif [ "${expected_failure}" -eq 1 ]; then
+    if [ -f "${TRASHDIR}/.expected_failure" ]; then
+      local expected_failure_state="$(<"${TRASHDIR}/.expected_failure")"
+      if [ "${expected_failure_state}" = "1" ]; then
+        if [ "${test_status}" = "0" ]; then
+          printf "%-80s ${TESTLIB_WARN_COLOR}UNEXPECTED SUCCESS T1${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+          unexpected_successes=$(( unexpected_successes + 1 ))
+        else
+          printf "%-80s ${TESTLIB_GOOD_COLOR}FAIL EXPECTED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+          expected_failures=$(( expected_failures + 1 ))
+        fi
+      else
+        if [ "${test_status}" = "0" ]; then
+          printf "%-80s ${TESTLIB_WARN_COLOR}UNEXPECTED SUCCESS T2${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+          unexpected_successes=$(( unexpected_successes + 1 ))
+        else
+          printf "%-80s ${TESTLIB_BAD_COLOR}SHOULD HAVE FAILED ELSEWHERE${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+          failures=$(( failures + 1 ))
+          testlib_print_test_trace
+        fi
+      fi
+    else
+      # Handle missing call to begin_fail_zone
+      printf "%-80s ${TESTLIB_BAD_COLOR}EXPECTED FAILURE SETUP ERROR${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
+      failures=$(( failures + 1 ))
+    fi
+    # Remove account file
+    rm -f "${TRASHDIR}/.expected_failure"
   elif [ "${required_fail}" -eq 0 ] && [ "$test_status" -eq 0 ]; then
     printf "%-80s ${TESTLIB_GOOD_COLOR}OK${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
-  elif [ "${expected_failure}" -eq 1 ]; then
-    printf "%-80s ${TESTLIB_GOOD_COLOR}FAIL EXPECTED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
-    expected_failures=$(( expected_failures + 1 ))
   else
+    printf "%-80s ${TESTLIB_BAD_COLOR}FAILED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
     failures=$(( failures + 1 ))
-    if [ "${required_fail}" -eq 1 ]; then
-      printf "%-80s ${TESTLIB_BAD_COLOR}SHOULD HAVE FAILED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
-    else
-      printf "%-80s ${TESTLIB_BAD_COLOR}FAILED${TESTLIB_RESET_COLOR}%s\n" "${test_description}" "${time_e}"
-    fi
-
-    local test_output
-    # Darling has issue printing out too fast https://github.com/darlinghq/darling/issues/640
-    # This perl command can slow it down enough that it works on my computer
-    if command -v sw_vers &> /dev/null && [ "$(sw_vers -buildVersion)" = "Darling" ]; then
-      find_open_fd test_output
-      # Technically, the process substitution happens before the eval, but that
-      # doesn't matter in the end, still works correctly.
-      eval "exec ${test_output}> >(perl -e 'print && select undef,undef,undef,0.0001 while <>;' >&2 )"
-    elif [ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -ge "41" ]; then
-      exec {test_output}>&2
-    else
-      find_open_fd test_output
-      eval "exec ${test_output}>&2"
-    fi
-
-    (
-      if [ "${TESTLIB_REDIRECT_OUTPUT}" -ge "1" ]; then
-
-        if [ "${err}" = "${xtrace}" ]; then
-          echo "-- stderr --"
-        else
-          echo "-- xtrace --"
-        fi
-        grep -v -e $'^\+[^\t]*\tend_test' \
-                -e $'^\+[^\t]*\tset +x -e' <"${xtrace}" |
-          sed $'s|^[^+]| \t&|' |
-          column -c1 -s $'\t' -t |
-          sed 's/^/    /'
-      fi
-      if [ "${TESTLIB_REDIRECT_OUTPUT}" -ge "2" ]; then
-        if [ "${err}" != "${xtrace}" ]; then
-          echo "-- stderr --"
-          sed 's/^/    /' <"${err}"
-        fi
-      fi
-      if [ "${TESTLIB_REDIRECT_OUTPUT}" -ge "3" ]; then
-        echo "-- stdout --"
-        sed 's/^/    /' <"${out}"
-      fi
-      echo "-- EOF $test_description --"
-    ) 1>&${test_output}
-
-    # Close fd test_output, which will end perl if its running
-    if [ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -ge "41" ]; then
-      exec {test_output}>&-
-    else
-      eval "exec ${test_output}>&-"
-    fi
+    testlib_print_test_trace
   fi
 
   if [ "${tracking_touched_files-}" = "1" ]; then
@@ -612,6 +605,58 @@ end_test ()
   if [ "${TESTLIB_STOP_AFTER_FAILS-0}" != "0" ] && [ "${failures}" -ge "${TESTLIB_STOP_AFTER_FAILS}" ]; then
     # Skip the rest of the tests.
     TESTLIB_SKIP_TESTS='.*'
+  fi
+}
+
+function testlib_print_test_trace()
+{
+  local test_output
+  # Darling has issue printing out too fast https://github.com/darlinghq/darling/issues/640
+  # This perl command can slow it down enough that it works on my computer
+  if command -v sw_vers &> /dev/null && [ "$(sw_vers -buildVersion)" = "Darling" ]; then
+    find_open_fd test_output
+    # Technically, the process substitution happens before the eval, but that
+    # doesn't matter in the end, still works correctly.
+    eval "exec ${test_output}> >(perl -e 'print && select undef,undef,undef,0.0001 while <>;' >&2 )"
+  elif [ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -ge "41" ]; then
+    exec {test_output}>&2
+  else
+    find_open_fd test_output
+    eval "exec ${test_output}>&2"
+  fi
+
+  (
+    if [ "${TESTLIB_REDIRECT_OUTPUT}" -ge "1" ]; then
+
+      if [ "${err}" = "${xtrace}" ]; then
+        echo "-- stderr --"
+      else
+        echo "-- xtrace --"
+      fi
+      grep -v -e $'^\+[^\t]*\tend_test' \
+              -e $'^\+[^\t]*\tset +x -e' <"${xtrace}" |
+        sed $'s|^[^+]| \t&|' |
+        column -c1 -s $'\t' -t |
+        sed 's/^/    /'
+    fi
+    if [ "${TESTLIB_REDIRECT_OUTPUT}" -ge "2" ]; then
+      if [ "${err}" != "${xtrace}" ]; then
+        echo "-- stderr --"
+        sed 's/^/    /' <"${err}"
+      fi
+    fi
+    if [ "${TESTLIB_REDIRECT_OUTPUT}" -ge "3" ]; then
+      echo "-- stdout --"
+      sed 's/^/    /' <"${out}"
+    fi
+    echo "-- EOF $test_description --"
+  ) 1>&${test_output}
+
+  # Close fd test_output, which will end perl if its running
+  if [ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -ge "41" ]; then
+    exec {test_output}>&-
+  else
+    eval "exec ${test_output}>&-"
   fi
 }
 

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -86,6 +86,7 @@ TRASHDIR="$(mktemp -d -t $(basename "$0")-$$.XXXXXXXX)"
 tests=0
 failures=0
 expected_failures=0
+unexpected_successes=0
 required_failures=0
 skipped=0
 
@@ -274,11 +275,11 @@ atexit ()
     BOLD_COLOR="${TESTLIB_BAD_COLOR}"
   fi
 
-  printf "%s summary: %d tests, ${BOLD_COLOR}%d failures${TESTLIB_RESET_COLOR}, %d expected failures, %d required failures, %d skipped\n" \
-         "$0" "${tests}" "${failures}" "${expected_failures}" "${required_failures}" "${skipped}"
+  printf "%s summary: %d tests, ${BOLD_COLOR}%d failures${TESTLIB_RESET_COLOR}, %d unexpected successes, %d expected failures, %d required failures, %d skipped\n" \
+         "$0" "${tests}" "${failures}" "${unexpected_successes}" "${expected_failures}" "${required_failures}" "${skipped}"
 
   if [ -d "${TESTLIB_SUMMARY_DIR-}" ]; then
-    echo "${tests} ${failures} ${expected_failures} ${required_failures} ${skipped}" > "${TESTLIB_SUMMARY_DIR}/$(basename "$0")"
+    echo "${tests} ${failures} ${unexpected_successes} ${expected_failures} ${required_failures} ${skipped}" > "${TESTLIB_SUMMARY_DIR}/$(basename "$0")"
   fi
 
   if [ "${failures}" -gt 0 ]; then

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -454,7 +454,7 @@ begin_expected_fail_test()
 #
 # Define the beginning of a test that is required to fail. Failures may only occur in "fail zones" denoted by :func:`begin_fail_zone` and :func:`end_fail_zone`. When a test fails in a fail zone, it is counted as a success. If a required to fail test never fails, it counts as a failure. If the test fails outside a fail zone, it is marked as a failure.
 #
-# The typical use case for requiring a failure, is testing that an exception is raise under proper circumstances.
+# The typical use case for requiring a failure, is testing that an exception is raise under proper circumstances. :func:`end_fail_zone` is not typically needed.
 #**
 begin_required_fail_test()
 {

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -3,9 +3,9 @@
 #*# tests/testlib
 
 #**
-# ================
-# VSI Test Library
-# ================
+# ===========
+# VSI Testlib
+# ===========
 #
 # .. default-domain:: bash
 #
@@ -16,11 +16,10 @@
 # :Copyright: Original version: (c) 2011-13 by Ryan Tomayko <http://tomayko.com>
 #
 #             License: MIT
-# :Author: Ryan Tomayko
 #
 # ## Writing unit tests
 #
-# Test Lib gives you a number of basic unit test functionality from bash, including:
+# Testlib gives you a number of basic unit test functionality from bash, including:
 #
 # - Running tests in subshells to prevent environment variable pollution.
 # - An automatically self deleting :envvar:`TRASHDIR` for all the tests
@@ -35,10 +34,11 @@
 # - Regular expression to skip tests by description: :envvar:`TESTLIB_SKIP_TESTS`
 # - Control stderr/stdout redirection :envvar:`TESTLIB_REDIRECT_OUTPUT`
 # - Stop testing after ``N`` failures :envvar:`TESTLIB_STOP_AFTER_FAILS`
-# - Disable custom PS4 in trace :envvar:`TESTLIB_NO_PS4`
+# - Custom PS4 in trace using :envvar:`TESTLIB_PS4`
 # - Ability to conditionally skip a test by calling :func:`skip_next_test` in any condition check
 # - Track files outside the :envvar:`TRASHDIR` with :func:`ttouch` so that they will be automatically deleted during cleanup.
 # - Other helper functions like :func:`not`, :func:`not_s`, :func:`test_utils.bsh check_a`, :func:`test_utils.bsh check_ra`, :func:`test_utils.bsh contiguous_a`
+# - Auto discover and run tests script: :file:`run_tests`
 #
 # .. rubric:: Example
 #
@@ -229,9 +229,9 @@ skipped=0
 : ${TESTLIB_REDIRECT_OUTPUT=3}
 
 #**
-# .. envvar:: TESTLIB_NO_PS4
+# .. envvar:: TESTLIB_PS4
 #
-# If set, will disable the custom PS4 output. Useful for some coverage tools
+# Optionally set a custom PS4 output for trace output on test errors. If unset, the testlib default is use: ``+${BASH_SOURCE[0]##*/}:${LINENO})\t``
 #
 # :Default: *unset*
 #**
@@ -304,13 +304,15 @@ atexit ()
 trap_chain "atexit" EXIT
 
 
-if [ -z "${TESTLIB_NO_PS4+set}" ]; then
+if [ -z "${TESTLIB_PS4+set}" ]; then
   if declare -p BASH_SOURCE &> /dev/null; then
     PS4=$'+${BASH_SOURCE[0]##*/}:${LINENO})\t'
   else # Else sh probably
     # Not as accurate, but better than nothing
     PS4=$'+${0##*/}:${LINENO})\t'
   fi
+else
+  PS4="${TESTLIB_PS4}"
 fi
 
 # Common code for begin tests

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -3,9 +3,9 @@
 #*# tests/testlib
 
 #**
-# ============
-# Test Library
-# ============
+# ================
+# VSI Test Library
+# ================
 #
 # .. default-domain:: bash
 #
@@ -13,9 +13,29 @@
 #
 # Simple shell command language test library
 #
-# .. rubric:: Usage
+# :Copyright: Original version: (c) 2011-13 by Ryan Tomayko <http://tomayko.com>
 #
-# . testlib.bsh
+#             License: MIT
+# :Author: Ryan Tomayko
+#
+# ## Writing unit tests
+#
+# Test Lib gives you are number of basic unit test functionality from bash, including:
+#
+# - Running tests in subshells to prevent environment variable pollution.
+# - An automatically self deleting :envvar:`TRASHDIR` for all the tests
+# - An automatically self deleting :envvar:`TESTDIR` for each individual test
+# - A tally of successful run and failed tests, and additionally expected failures, unexpected successes, required failures, and skipped tests
+# - Individual est times :envvar:`TESTLIB_SHOW_TIMING`
+# - :func:`setup` - A user defined function run before the first test
+# - :func:`teardown` - A user defined function after the last test
+# - Keep temporary directories for debugging :envvar:`TESTLIB_KEEP_TEMP_DIRS`
+# - Pause before deleting temporary directories if there is is a failure, for inspection :envvar:`TESTLIB_KEEP_PAUSE_AFTER_ERROR`
+# - Run only a single test by it's description :envvar:`TESTLIB_RUN_SINGLE_TEST`
+# - Regular expression to skip tests by description :envvar:`TESTLIB_SKIP_TESTS`
+# - Control stderr/stdout redirection :envvar:`TESTLIB_REDIRECT_OUTPUT`
+# - Stop testing after ``N`` failures :envvar:`TESTLIB_STOP_AFTER_FAILS`
+# - Disable custom PS4 in trace :envvar:`TESTLIB_NO_PS4`
 #
 # .. rubric:: Example
 #
@@ -37,10 +57,7 @@
 #   )
 #   end_test
 #
-#   When a test fails its stdout and stderr are shown.
-#
-# .. note::
-#   Tests must 'set -e' within the subshell block or failed assertions will not cause the test to fail and the result may be misreported. While this is not required, most tests will have this on.
+#   Any command that evaluates to false "fails" the test. When a test fails its stdout, stderr, and call trace are printed out.
 #
 # .. rubric:: Bugs
 #
@@ -50,19 +67,23 @@
 #
 #     runtests 2>&1 | less -R
 #
-# :Copyright: Original version: (c) 2011-13 by Ryan Tomayko <http://tomayko.com>
+# ## Test status
 #
-#             License: MIT
-# :Author: Ryan Tomayko
-# :Modification History: Andy Neff
+# Every test will print out a line with its name, and the status of the test run.
 #
-#              * Added :func:`begin_expected_fail_test`
-#              * Added optional :func:`setup`/:func:`teardown` functions
-#              * Removed PATH
-#              * Added robodoc documentation
-#              * Use pushd/popd for each test instead of cd
-#              * Auto prepend filename to description
-#              * Added custom PS4
+# Possible results of a test:
+#
+# - ``OK`` - The test passed!
+# - ``FAILED`` - The test did not pass. Trace is printed out for debugging.
+# - ``SETUP FAILURE`` - Each test must call :func:`setup_test`, and it was not detected for this test.
+# - ``SKIPPED`` - The test was not run.
+# - ``FAIL REQUIRED`` - A test successfully failed as it is required to.
+# - ``FAIL EXPECTED`` - A test successfully failed as it is expected to.
+# - ``SHOULD HAVE FAILED ELSEWHERE`` - A required or expected failed test failed in an the wrong area of the code. There is something wrong with the test, and a trace is printed out for debugging.
+# - ``SHOULD HAVE FAILED`` - A required failed test did not fail. There is something wrong with the test, and a trace is printed out for debugging.
+# - ``UNEXPECTED SUCCESS`` - An expected failed test never actually failed. This doesn't count as a failure, but a middle ground in its own category.
+# - ``REQUIRED FAILURE SETUP ERROR`` - A required failed test did not call :func:`begin_fail_zone`, and is considered setup incorrectly.
+# - ``EXPECTED FAILURE SETUP ERROR`` - An expected failed test did not call :func:`begin_fail_zone`, and is considered setup incorrectly.
 #**
 
 if [ -z ${VSI_COMMON_DIR+set} ]; then
@@ -110,8 +131,6 @@ skipped=0
 #
 # .. seealso::
 #   :envvar:`TESTDIR`
-#
-# :Author: Ryan Tomayko
 #**
 
 #**
@@ -123,8 +142,6 @@ skipped=0
 #
 # .. seealso::
 #   :envvar:`TRASHDIR`
-#
-# :Author: Ryan Tomayko
 #**
 
 #**
@@ -233,14 +250,7 @@ skipped=0
 #
 # Automatically called on exit by trap.
 #
-# Checks to see if teardown is defined, and calls it. teardown is typically a function, alias, or something that makes sense to call.
-#
-# :Author: Ryan Tomaydo
-# :Modification History: Andy Neff
-#
-#             * Added :func:`setup` cleanup
-#             * Added :func:`teardown`
-#             * Added :envvar:`TESTLIB_KEEP_TEMP_DIRS` flags
+# Checks to see if :func:`teardown` is defined, and calls it. :func:`teardown` is typically a function, alias, or something that makes sense to call.
 #**
 atexit ()
 {
@@ -405,8 +415,6 @@ _begin_common_test ()
 #
 # .. seealso::
 #   :func:`end_test`
-#
-# :Author: Ryan Tomayko
 #**
 begin_test ()
 {
@@ -421,7 +429,7 @@ begin_test ()
 #
 # .. rubric:: Usage
 #
-# Define the beginning of a test that is expected to fail
+# Define the beginning of a test that is expected to fail. Failures may only occur in "fail zones" denoted by :func:`begin_fail_zone` and :func:`end_fail_zone`
 #**
 begin_expected_fail_test()
 {
@@ -430,11 +438,58 @@ begin_expected_fail_test()
   _expected_failure=1 _begin_common_test ${@+"${@}"}
 }
 
+#**
+# .. function:: begin_fail_zone
+#
+# Start a fail zone
+#
+# In practice, having an expected fail or required fail leads to the possibility of a test failing somewhere you don't expect it to. For this reason, fail zones must be denoted in order for :func:`begin_expected_fail_test` and :func:`begin_required_fail_test` test to to succeed, and the the failures must occur in them only. If a test a failure happens outside the fail zone, the test will be marked as a failure, with the message ``SHOULD HAVE FAILED ELSEWHERE``.
+#
+# .. rubric:: Example
+#
+# .. code-block:: bash
+#
+#   begin_expected_fail_test "Some test"
+#   (
+#     setup_test
+#     # Failing here would result in failure
+#     begin_fail_zone
+#     false is ok here
+#   )
+#**
 begin_fail_zone()
 {
   echo 1 > "${TRASHDIR}/.testlib_failure_zone"
 }
 
+#**
+# .. function:: end_fail_zone
+#
+# End a fail zone
+#
+# While not common, it might be possible to have a test that is likely to fail in one of many places, for this reason a fail zone can be turned off, before being turned on again.
+#
+# .. rubric:: Example
+#
+# .. code-block:: bash
+#
+#   begin_required_fail_test "Some test"
+#   (
+#     setup_test
+#     true something
+#
+#     begin_fail_zone
+#     maybe_false
+#     end_fail_zone
+#
+#     true again
+#
+#     begin_fail_zone
+#     false_if_other_was_not
+#     # end_fail_zone # not required at the end of the test, but won't hurt
+#   )
+#   end_test
+#**
 end_fail_zone()
 {
   echo 0 > "${TRASHDIR}/.testlib_failure_zone"
@@ -509,8 +564,6 @@ setup_test()
 #
 # .. seealso::
 #   :func:`begin_test`
-#
-# :Author: Ryan Tomayko
 #**
 end_test ()
 {

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -27,8 +27,8 @@
 # - An automatically self deleting :envvar:`TESTDIR` for each individual test
 # - A tally of successful run and failed tests, and additionally expected failures, unexpected successes, required failures, and skipped tests
 # - Individual est times :envvar:`TESTLIB_SHOW_TIMING`
-# - :func:`setup` - A user defined function run before the first test
-# - :func:`teardown` - A user defined function after the last test
+# - A user defined :func:`setup` function run before the first test in a file
+# - A user defined :func:`teardown` function run after the last test in a file
 # - Keep temporary directories for debugging :envvar:`TESTLIB_KEEP_TEMP_DIRS`
 # - Pause before deleting temporary directories if there is is a failure, for inspection :envvar:`TESTLIB_KEEP_PAUSE_AFTER_ERROR`
 # - Run only a single test by it's description :envvar:`TESTLIB_RUN_SINGLE_TEST`
@@ -443,7 +443,9 @@ begin_expected_fail_test()
 #
 # Start a fail zone
 #
-# In practice, having an expected fail or required fail leads to the possibility of a test failing somewhere you don't expect it to. For this reason, fail zones must be denoted in order for :func:`begin_expected_fail_test` and :func:`begin_required_fail_test` test to to succeed, and the the failures must occur in them only. If a test a failure happens outside the fail zone, the test will be marked as a failure, with the message ``SHOULD HAVE FAILED ELSEWHERE``.
+# In practice, having an expected fail or required fail leads to the possibility of a test failing somewhere you don't expect it to. For this reason, fail zones must be denoted in order for :func:`begin_expected_fail_test` and :func:`begin_required_fail_test` tests to succeed, and the the failures must only occur in a fail zone. If a test a failure happens outside the fail zone, the test will be marked as a failure, with the message ``SHOULD HAVE FAILED ELSEWHERE``.
+#
+# Typically this will be called right before the last last line of a test
 #
 # .. rubric:: Example
 #


### PR DESCRIPTION
Required failure and expected failure tests can only fail in designated fail zones now.