### PR TITLE
Unit test 2020 06 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ local_post.env
 docs/**/*.auto.*
 docs/**/*.auto
 docs/python
+docs/linux/python_scripts
 coverage

--- a/Justfile
+++ b/Justfile
@@ -59,7 +59,7 @@ function caseify()
         export VSI_COMMON_TEST_OS
         # sanitize tag name
         VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS//:/_}
-        VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME//"/"/_}
+        VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME////_}
         export VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME//@/_}
         Just-docker-compose build os
       done
@@ -72,7 +72,7 @@ function caseify()
         export VSI_COMMON_TEST_OS
         # sanitize tag name
         VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS//:/_}
-        VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME//"/"/_}
+        VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME////_}
         export VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME//@/_}
         Just-docker-compose run os ${@+"${@}"}
       done

--- a/Justfile
+++ b/Justfile
@@ -59,7 +59,7 @@ function caseify()
         export VSI_COMMON_TEST_OS
         # sanitize tag name
         VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS//:/_}
-        VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME////_}
+        VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME//"/"/_}
         export VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME//@/_}
         Just-docker-compose build os
       done
@@ -72,7 +72,7 @@ function caseify()
         export VSI_COMMON_TEST_OS
         # sanitize tag name
         VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS//:/_}
-        VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME////_}
+        VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME//"/"/_}
         export VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME//@/_}
         Just-docker-compose run os ${@+"${@}"}
       done

--- a/Justfile
+++ b/Justfile
@@ -58,12 +58,23 @@ function caseify()
         export VSI_COMMON_TEST_OS
         # sanitize tag name
         VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS//:/_}
+        VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME////_}
         export VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME//@/_}
         Just-docker-compose build os
       done
       ;;
-    test_os) # Run test in docker image on specific os
-
+    test_oses) # Run test in docker image on specific os
+      local VSI_COMMON_TEST_OS
+      local VSI_COMMON_TEST_OS_TAG_NAME
+      for VSI_COMMON_TEST_OS in ${VSI_COMMON_TEST_OSES[@]+"${VSI_COMMON_TEST_OSES[@]}"}; do
+        export VSI_COMMON_TEST_OS
+        # sanitize tag name
+        VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS//:/_}
+        VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME////_}
+        export VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME//@/_}
+        Just-docker-compose run os ${@+"${@}"}
+      done
+      extra_args+=$#
       ;;
     ci_load) # Load ci
       justify docker-compose_ci-load "${VSI_COMMON_DIR}/docker-compose.yml" "bash_test_${1}"

--- a/Justfile
+++ b/Justfile
@@ -27,6 +27,9 @@ function caseify()
 
   case ${just_arg} in
     test) # Run unit tests
+      # Exit code 123 just means a test failed, no need for a Just stack trace
+      # This has to be outside the (), because the () causes two stack traces
+      local JUST_IGNORE_EXIT_CODES=123
       (
         parse_testlib_args ${@+"${@}"}
         shift "${extra_args}"
@@ -39,12 +42,14 @@ function caseify()
     #   extra_args=1
     #   ;;
     test_int) # Run integration tests
+      local JUST_IGNORE_EXIT_CODES=123
       justify test --dir int ${@+"${@}"}
       extra_args=$#
       ;;
 
     test_docker) # Run tests in docker image. Useful for running in specific bash version ($1)
       local version="${1-5.0}"
+      local JUST_IGNORE_EXIT_CODES=123
       shift 1
       extra_args=1
       Just-docker-compose run "bash_test_${version}" ${@+"${@}"}
@@ -66,6 +71,7 @@ function caseify()
     test_oses) # Run test in docker image on specific os
       local VSI_COMMON_TEST_OS
       local VSI_COMMON_TEST_OS_TAG_NAME
+      local JUST_IGNORE_EXIT_CODES=123
       for VSI_COMMON_TEST_OS in ${VSI_COMMON_TEST_OSES[@]+"${VSI_COMMON_TEST_OSES[@]}"}; do
         export VSI_COMMON_TEST_OS
         # sanitize tag name
@@ -81,6 +87,7 @@ function caseify()
       extra_args=1
       ;;
     test_int_appveyor) # Run integration tests for windows appveyor
+      local JUST_IGNORE_EXIT_CODES=123
       (
         source elements.bsh
         pushd "${VSI_COMMON_DIR}/tests/int/" &> /dev/null
@@ -96,10 +103,12 @@ function caseify()
       )
       ;;
     test_recipe) # Run docker recipe tests
+      local JUST_IGNORE_EXIT_CODES=123
       TESTLIB_DISCOVERY_DIR="${VSI_COMMON_DIR}/docker/recipes/tests" vsi_test_env "${VSI_COMMON_DIR}/tests/run_tests" ${@+"${@}"}
       extra_args=$#
       ;;
     test_darling) # Run unit tests using darling
+      local JUST_IGNORE_EXIT_CODES=123
       (
         cd "${VSI_COMMON_DIR}"
         TESTLIB_PARALLEL=8 vsi_test_env darling shell ./tests/run_tests ${@+"${@}"}
@@ -131,6 +140,7 @@ function caseify()
       ;;
     test_bash) # Run command (like bash) in the contain for a specific version of bash ($1)
       local bash_version="${1}"
+      local JUST_IGNORE_EXIT_CODES=123
       extra_args=$#
       shift 1
       Just-docker-compose run "bash_test_${bash_version}" ${@+"${@}"}
@@ -156,6 +166,7 @@ function caseify()
       extra_args=$#
       ;;
     test_wine) # Run unit tests using wine
+      local JUST_IGNORE_EXIT_CODES=123
       justify run wine -c "
         cd /z/vsi
         source setup.env

--- a/Justfile
+++ b/Justfile
@@ -50,6 +50,21 @@ function caseify()
       Just-docker-compose run "bash_test_${version}" ${@+"${@}"}
       extra_args+=$#
       ;;
+
+    build_oses) # Build images for other OSes
+      local VSI_COMMON_TEST_OS
+      local VSI_COMMON_TEST_OS_TAG_NAME
+      for VSI_COMMON_TEST_OS in ${VSI_COMMON_TEST_OSES[@]+"${VSI_COMMON_TEST_OSES[@]}"}; do
+        export VSI_COMMON_TEST_OS
+        # sanitize tag name
+        VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS//:/_}
+        export VSI_COMMON_TEST_OS_TAG_NAME=${VSI_COMMON_TEST_OS_TAG_NAME//@/_}
+        Just-docker-compose build os
+      done
+      ;;
+    test_os) # Run test in docker image on specific os
+
+      ;;
     ci_load) # Load ci
       justify docker-compose_ci-load "${VSI_COMMON_DIR}/docker-compose.yml" "bash_test_${1}"
       extra_args=1

--- a/Justfile
+++ b/Justfile
@@ -37,10 +37,6 @@ function caseify()
       )
       extra_args=$#
       ;;
-    # --test) # Run only this test
-    #   export TESTLIB_RUN_SINGLE_TEST="${1}"
-    #   extra_args=1
-    #   ;;
     test_int) # Run integration tests
       local JUST_IGNORE_EXIT_CODES=123
       justify test --dir int ${@+"${@}"}

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ In order to use these directories, all you have to do is
     * Write tests for your modules using the unittest
     * Tests should be stored separately in files names "test_*.py"
 
-      ```
+      ```python
       import unittest
       class MyTestClass(unittest.TestCase):
         def test_something(self): #This function MUST start with "test_"
@@ -155,15 +155,14 @@ In order to use these directories, all you have to do is
 
 Documentation uses sphinx. To compile documentation, run
 
-```
+```bash
 just docs
 just docs view
 ```
 
 Sphinx documentation can be embedded in any source file. There must be a `#*#` comment stating the filename and any `#` comments surrounded with `#**` will be added to sphinx documentation
 
-```
-
+```bash
 # This documentation path will become:
 #   {VSI_COMMON_DIR}/docs/example/readme.auto.rst
 # Other files will refer to is the document with .auto. in the name
@@ -178,9 +177,15 @@ Sphinx documentation can be embedded in any source file. There must be a `#*#` c
 #     You can not run the script and download in one call, you must call new_just as a file, not a pipe stream. ``
 #**
 
-# These lines are not
-# No #** at the beginnig of this line
+# This line is not documentation
+# No #** at the beginning of this line
 ```
+
+#### Documentation FAQ
+
+1. Why is there an `bash:env` directive, when `envvar` already exists?
+
+    - They are both for documenting environment variables, `bash:env` should be used for locally scoped variables, that only affect that one file, while `envvar` might affect many files.
 
 ### Who do I talk to? ###
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,6 +161,8 @@ services:
       args:
         - OS=${VSI_COMMON_TEST_OS-debian:8}
     image: ${VSI_COMMON_DOCKER_REPO}:os_${VSI_COMMON_TEST_OS_TAG_NAME-debian_8}
+    volumes:
+      - <<: *vsi_common_volume
 
 volumes:
   wine_home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,13 @@ services:
       bash -c '
         cd /vsi/python
         pipenv run python3 -B -m unittest discover -s "/vsi/python/vsi/test"'
+  os:
+    build:
+      context: docker/tests/
+      dockerfile: os.Dockerfile
+      args:
+        - OS=${VSI_COMMON_TEST_OS-debian:8}
+    image: ${VSI_COMMON_DOCKER_REPO}:os_${VSI_COMMON_TEST_OS_TAG_NAME-debian_8}
 
 volumes:
   wine_home:

--- a/docker/tests/bash_test.Justfile
+++ b/docker/tests/bash_test.Justfile
@@ -36,7 +36,7 @@ function vsi_test_env()
   #   # Does not work in darling unless usleep for 1001 and larger. TOO slow
   #   # perl -e 'use Time::HiRes; print && Time::HiRes::usleep(1) while <>;'
   # else
-    env -i "${test_env[@]}" "${@}"
+    ${DRYRUN-} env -i "${test_env[@]}" "${@}"
   # fi
 }
 

--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -15,21 +15,25 @@ RUN set -euxv; \
           findutils; \
     elif command -v apt-get; then \
       apt-get update; \
-      DEBIAN_FRONTEND=noninteractive  apt-get install --no-install-recommends -y \
-              # cmp for unit tests
-              diffutils \
-              # nm for lwhich
-              binutils \
-              # column
-              bsdmainutils \
-              # xxd for unit tests
-              vim; \
+      DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+             # cmp for unit tests
+             diffutils \
+             # nm for lwhich
+             binutils \
+             # column for unit tests
+             bsdmainutils \
+             # xxd for unit tests
+             vim; \
     elif command -v zypper; then \
-      zypper -n install -y \
-                # nm for lwhich
-                binutils \
-                # xxd for unit tests
-                vim; \
+      zypper --gpg-auto-import-keys --non-interactive install -y \
+             # column for unit tests
+             util-linux \
+             # cmp for unit tests
+             diffutils \
+             # nm for lwhich
+             binutils \
+             # xxd for unit tests
+             vim; \
     elif [ -f /etc/os-release ]; then \
       source /etc/os-release; \
       if [ "${ID}" = "clear-linux-os" ]; then \

--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -2,10 +2,34 @@ ARG OS
 FROM ${OS}
 
 RUN set -euxv; \
-    if command -v yum &>/dev/null; then \
+    if command -v yum; then \
       # column for unit tests
-      yum install -y util-linux; \
-    fi; \
+      yum install -y util-linux \
+          # xxd for unit tests
+          vim \
+          # nm for lwhich
+          binutils \
+          # cmp for unit tests
+          diffutils \
+          # find and xargs for run tests/dir_tools (and maybe more?)
+          findutils; \
+    elif command -v apt-get; then \
+      apt-get update; \
+      DEBIAN_FRONTEND=noninteractive  apt-get install --no-install-recommends -y \
+              # cmp for unit tests
+              diffutils \
+              # nm for lwhich
+              binutils \
+              # column
+              bsdmainutils \
+              # xxd for unit tests
+              vim; \
+    elif command -v zypper; then \
+      zypper -n install -y \
+                # nm for lwhich
+                binutils \
+                # xxd for unit tests
+                vim; \
     elif [ -f /etc/os-release ]; then \
       source /etc/os-release; \
       if [ "${ID}" = "clear-linux-os" ]; then \
@@ -20,3 +44,10 @@ RUN set -euxv; \
     fi
 
 SHELL ["/usr/bin/env", "bash", "-euxvc"]
+
+ENV JUSTFILE=/vsi/Justfile
+
+CMD set +xv; \
+    cd /vsi; \
+    source setup.env; \
+    just test

--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -1,5 +1,10 @@
 ARG OS
+
+# FROM busybox:latest as wget
+
 FROM ${OS}
+
+# COPY --from=wget /bin/wget /musl/wget
 
 RUN set -euxv; \
     if command -v yum; then \
@@ -34,6 +39,46 @@ RUN set -euxv; \
              binutils \
              # xxd for unit tests
              vim; \
+    elif command -v apk; then \
+      apk add --no-cache \
+          bash \
+          # Better awk
+          gawk \
+          # Better sed, that supports \x00 notation
+          sed \
+          # column
+          util-linux \
+          # Better xargs command because ?
+          findutils \
+          # nm
+          binutils; \
+    elif command -v slackpkg; then \
+      slackpkg update; \
+      # Is there a "right" way to do this?
+                             # xxd for unit tests
+      yes | slackpkg install vim \
+                             # nm for lwhich
+                             binutils; \
+    elif command -v emerge; then \
+      emerge --sync; \
+      # xxd Test dependencies
+      emerge vim; \
+    elif command -v pacman; then \
+      # Test dependencies
+      pacman -S vim binutils diffutils; \
+    elif command -v busybox; then \
+      # if ! command -v wget; then \
+      #   export PATH="/musl:${PATH}"; \
+      # fi; \
+      wget -O - http://bin.entware.net/x64-k3.2/installer/generic.sh | sh; \
+      # Make it more linux like
+      ln -s /opt/bin /usr/bin; \
+      ln -s /bin/env /usr/bin/env || : ; \
+                            # Test dependencies
+      /opt/bin/opkg install bash column binutils \
+                            # just dependencies
+                            gawk sed; \
+      ln -s /opt/bin/gawk /opt/bin/awk; \
     elif [ -f /etc/os-release ]; then \
       source /etc/os-release; \
       if [ "${ID}" = "clear-linux-os" ]; then \

--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -1,0 +1,22 @@
+ARG OS
+FROM ${OS}
+
+RUN set -euxv; \
+    if command -v yum &>/dev/null; then \
+      # column for unit tests
+      yum install -y util-linux; \
+    fi; \
+    elif [ -f /etc/os-release ]; then \
+      source /etc/os-release; \
+      if [ "${ID}" = "clear-linux-os" ]; then \
+        swupd bundle-add \
+              # cmp for unit tests
+              diffutils \
+              # xxd for unit tests
+              vim \
+              # nm for lwhich
+              binutils; \
+      fi; \
+    fi
+
+SHELL ["/usr/bin/env", "bash", "-euxvc"]

--- a/docker/vsi_common/bashcov.Dockerfile
+++ b/docker/vsi_common/bashcov.Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update; \
 
 ENV JUSTFILE=/vsi/docker/vsi_common/bashcov.Justfile
 COPY --from=tini /usr/local /usr/local
-COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
-COPY --from=jq /usr/local/bin/jq /usr/local/bin/jq
-COPY --from=docker /usr/local/bin /usr/local/bin
-COPY --from=docker-compose /usr/local/bin/docker-compose /usr/local/bin/docker-compose
+COPY --from=gosu /usr/local /usr/local
+COPY --from=jq /usr/local /usr/local
+COPY --from=docker /usr/local /usr/local
+COPY --from=docker-compose /usr/local /usr/local
 COPY --from=vsi /vsi /vsi
 
 ENTRYPOINT ["/usr/local/bin/tini", "--", "/usr/bin/env", "bash", "/vsi/linux/just_entrypoint.sh"]

--- a/docker/vsi_common/docker-compose.yml
+++ b/docker/vsi_common/docker-compose.yml
@@ -58,6 +58,8 @@ services:
     image: ${MAKESELF_IMAGE-vsiri/makeself:latest}
     environment:
       <<: *plugin_environment
+      MAKESELF_NAME: just
+      MAKESELF_LABEL: just_label
     volumes:
       - type: bind
         source: ${MAKESELF_SOURCE_DIR-}

--- a/docker/vsi_common/docker-compose.yml
+++ b/docker/vsi_common/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       MAKESELF_NAME: just
       MAKESELF_LABEL: just_label
     volumes:
+      - <<: *vsi_common_volume
       - type: bind
         source: ${MAKESELF_SOURCE_DIR-}
         target: /src
@@ -68,3 +69,24 @@ services:
         source: ${MAKESELF_DIST_DIR-}
         target: /dist
     # platform: linux
+  pyinstaller:
+    build:
+      context: .
+      dockerfile: pyinstaller.Dockerfile
+    image: ${PYINSTALLER_IMAGE-vsiri/sphinxdocs:compile}
+    environment:
+      <<: *plugin_environment
+    volumes:
+      - <<: *vsi_common_volume
+      - type: bind
+        source: ${PYINSTALLER_SOURCE_DIR-}
+        target: /src
+      - type: bind
+        source: ${PYINSTALLER_DIST_DIR-}
+        target: /dist
+      - type: volume
+        source: pyinstaller-build
+        target: /build
+
+volumes:
+  pyinstaller-build:

--- a/docker/vsi_common/docker-compose.yml
+++ b/docker/vsi_common/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       DOCKER_GIDS: ${VSI_COMMON_GIDS-1000}
       DOCKER_GROUP_NAMES: ${VSI_COMMON_GROUP_NAMES-user}
       DOCKER_USERNAME: user
-      JUST_SETTINGS:
+      JUST_SETTINGS: ${VSI_COMMON_JUST_SETTINGS-}
     volumes:
       - &vsi_common_volume
         type: bind
@@ -48,3 +48,21 @@ services:
       - type: bind
         source: ${BASH_COV_SOURCE_DIR-}
         target: /src
+  makeself:
+    build:
+      context: .
+      dockerfile: makeself.Dockerfile
+      args:
+        # 2.4.3 not released yet, using a master sha
+        - MAKESELF_VERSION=${MAKESELF_VERSION-fe8e727e8955c0d10f48e318b28957fd0638464a}
+    image: ${MAKESELF_IMAGE-vsiri/makeself:latest}
+    environment:
+      <<: *plugin_environment
+    volumes:
+      - type: bind
+        source: ${MAKESELF_SOURCE_DIR-}
+        target: /src
+      - type: bind
+        source: ${MAKESELF_DIST_DIR-}
+        target: /dist
+    # platform: linux

--- a/docker/vsi_common/docker-compose.yml
+++ b/docker/vsi_common/docker-compose.yml
@@ -69,24 +69,26 @@ services:
         source: ${MAKESELF_DIST_DIR-}
         target: /dist
     # platform: linux
-  pyinstaller:
-    build:
-      context: .
-      dockerfile: pyinstaller.Dockerfile
-    image: ${PYINSTALLER_IMAGE-vsiri/pyinstaller:latest}
-    environment:
-      <<: *plugin_environment
-    volumes:
-      - <<: *vsi_common_volume
-      - type: bind
-        source: ${PYINSTALLER_SOURCE_DIR-}
-        target: /src
-      - type: bind
-        source: ${PYINSTALLER_DIST_DIR-}
-        target: /dist
-      - type: volume
-        source: pyinstaller-build
-        target: /build
-
+  # pyinstaller:
+  #   build:
+  #     context: .
+  #     dockerfile: pyinstaller.Dockerfile
+  #     args:
+  #       - PYTHON_VERSION=${PYINSTALLER_PYTHON_VERSION-3.7.7}
+  #       - PYINSTALLER_VERSION=${PYINSTALLER_VERSION-3.6}
+  #   image: ${PYINSTALLER_IMAGE-vsiri/pyinstaller:3.7.7-3.6}
+  #   environment:
+  #     <<: *plugin_environment
+  #   volumes:
+  #     - <<: *vsi_common_volume
+  #     - type: bind
+  #       source: ${PYINSTALLER_SOURCE_DIR-}
+  #       target: /src
+  #     - type: bind
+  #       source: ${PYINSTALLER_DIST_DIR-}
+  #       target: /dist
+  #     - type: volume
+  #       source: pyinstaller-build
+  #       target: /build
 volumes:
   pyinstaller-build:

--- a/docker/vsi_common/docker-compose.yml
+++ b/docker/vsi_common/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     build:
       context: .
       dockerfile: pyinstaller.Dockerfile
-    image: ${PYINSTALLER_IMAGE-vsiri/sphinxdocs:compile}
+    image: ${PYINSTALLER_IMAGE-vsiri/pyinstaller:latest}
     environment:
       <<: *plugin_environment
     volumes:

--- a/docker/vsi_common/makeself.Dockerfile
+++ b/docker/vsi_common/makeself.Dockerfile
@@ -1,0 +1,46 @@
+FROM vsiri/recipe:tini-musl as tini
+FROM vsiri/recipe:gosu as gosu
+FROM vsiri/recipe:vsi as vsi
+
+FROM alpine:3.8
+
+RUN apk add --no-cache bash tar
+
+SHELL ["/usr/bin/env", "bash", "-euxvc"]
+
+# Need newer than 2.4.2 for certain features like ARCHIVE_DIR
+ARG MAKESELF_VERSION=release-2.4.3
+
+RUN apk add --no-cache --virtual .deps wget; \
+    mkdir /makeself; \
+    cd /makeself; \
+    wget https://github.com/megastep/makeself/archive/${MAKESELF_VERSION}/makeself.tar.gz; \
+    tar xf makeself.tar.gz --strip-components=1; \
+    rm makeself.tar.gz; \
+
+    # Disable arg parsing by makeself executable, and make executable quietly extract
+    sed '1,/^while true/s|^while true|while \\${MAKESELF_PARSE-false}|; 1,/^quiet="n"/s|^quiet="n"|quiet="y"|' \
+        "/makeself/makeself-header.sh" > "/makeself/makeself-header_just.sh"; \
+
+    # Add sourcing local.env to the header, to cover corner cases like needing to to change TMPDIR
+    sed -i '2r /dev/stdin' "/makeself/makeself-header_just.sh" < \
+           <(echo 'for check_dir in "\`dirname \$0\`" "\${PWD}"; do'; \
+             echo '  if test -f "\${check_dir}/local.env"; then'; \
+             echo '    set -a'; \
+             echo '    source "\${check_dir}/local.env"'; \
+             echo '    set +a'; \
+             echo '  fi'; \
+             echo 'done'); \
+    apk del .deps
+
+ENV JUSTFILE=/vsi/docker/vsi_common/makeself.Justfile
+
+COPY --from=tini /usr/local /usr/local
+COPY --from=gosu /usr/local /usr/local
+# Allow non-privileged to run gosu (remove this to take root away from user)
+RUN chmod u+s /usr/local/bin/gosu
+COPY --from=vsi /vsi /vsi
+
+ENTRYPOINT ["/usr/local/bin/tini", "--", "/usr/bin/env", "bash", "/vsi/linux/just_entrypoint.sh"]
+
+CMD ["makeself"]

--- a/docker/vsi_common/makeself.Justfile
+++ b/docker/vsi_common/makeself.Justfile
@@ -1,0 +1,56 @@
+#!/usr/bin/env false bash
+
+source "${VSI_COMMON_DIR}/linux/command_tools.bsh"
+
+function caseify()
+{
+  local cmd="${1}"
+  shift 1
+  case "${cmd}" in
+    makeself)
+      cd /src
+      mkdir -p /src/dist
+      /makeself/makeself.sh --tar-extra "--exclude=.git --exclude=docs ../.juste_wrapper" --noprogress --nomd5 --nocrc --nox11 --keep-umask --header /makeself/makeself-header_just.sh vsi_common/ /src/dist/juste juste_label ./.juste_wrapper
+      ;;
+
+    just-project) # Make a self extracting executable for a just \
+        # project, locally. Add "--tests" flag to include VSI Common's unit tests. \
+        # Unit tests can be run via: just --wrap bash -c 'cd ${VSI_COMMON_DIR}; just test'
+      local include_unit_tests
+      parse_args extra_args --tests include_unit_tests -- ${@+"${@}"}
+      if [ "${include_unit_tests}" = "0" ]; then
+        include_unit_tests='--exclude=test-*.bsh'
+      else
+        include_unit_tests=""
+      fi
+
+      # Review: Does the transform below handle (multiple) spaces in the path correctly???
+      local vsi_common_rel="${1}"
+
+      # Start by adding just vsi_common, and transform it to have the same relative path as vsi_common_dir really has.
+      "/makeself/makeself.sh" \
+          --header "/makeself/makeself-header_just.sh" \
+          --noprogress --nomd5 --nocrc --nox11 --keep-umask \
+          --tar-extra "--show-transformed --transform s|^\./|./${vsi_common_rel}/| ${include_unit_tests} --exclude=./docs --exclude=.git --exclude=*.egg-info" \
+          "${VSI_COMMON_DIR}" /dist/just just_label "./${vsi_common_rel}/freeze/just_wrapper"
+      # You can't put quotes in tar-extra apparently, it'll screw things up.
+
+      extra_args=1
+      ;;
+    add-files) # Append files to a makeself executable
+      pushd /src &> /dev/null
+        MAKESELF_PARSE=true "/makeself/makeself.sh" \
+            --header "/makeself/makeself-header_just.sh" \
+            --noprogress --nomd5 --nocrc --nox11 --keep-umask \
+            --tar-extra "${1-}" --append \
+            . /dist/just
+
+        extra_args=$#
+      popd &> /dev/null
+      ;;
+
+    *)
+      exec "${cmd}" ${@+"${@}"}
+      ;;
+  esac
+}

--- a/docker/vsi_common/makeself.Justfile
+++ b/docker/vsi_common/makeself.Justfile
@@ -6,11 +6,23 @@ function caseify()
 {
   local cmd="${1}"
   shift 1
+
+  local vsi_common_excludes='--exclude=./docs --exclude=.git --exclude=*.egg-info'
+
   case "${cmd}" in
-    makeself)
+    juste) # Make a pure just executable, not a project executable (Not finished. .juste_wrapper needs to be merged into just_wrapper)
       cd /src
       mkdir -p /src/dist
-      /makeself/makeself.sh --tar-extra "--exclude=.git --exclude=docs ../.juste_wrapper" --noprogress --nomd5 --nocrc --nox11 --keep-umask --header /makeself/makeself-header_just.sh vsi_common/ /src/dist/juste juste_label ./.juste_wrapper
+      /makeself/makeself.sh \
+        --header /makeself/makeself-header_just.sh \
+        --noprogress --nomd5 --nocrc --nox11 --keep-umask \
+        --tar-extra "${vsi_common_excludes} ../.juste_wrapper" \
+        vsi_common/ /src/dist/juste juste_label ./.juste_wrapper
+      ;;
+
+    makeself) # Run makeself
+      /makeself/makeself.sh ${@+"${@}"}
+      extra_args=$#
       ;;
 
     just-project) # Make a self extracting executable for a just \
@@ -28,22 +40,22 @@ function caseify()
       local vsi_common_rel="${1}"
 
       # Start by adding just vsi_common, and transform it to have the same relative path as vsi_common_dir really has.
-      "/makeself/makeself.sh" \
-          --header "/makeself/makeself-header_just.sh" \
+      /makeself/makeself.sh \
+          --header /makeself/makeself-header_just.sh \
           --noprogress --nomd5 --nocrc --nox11 --keep-umask \
-          --tar-extra "--show-transformed --transform s|^\./|./${vsi_common_rel}/| ${include_unit_tests} --exclude=./docs --exclude=.git --exclude=*.egg-info" \
-          "${VSI_COMMON_DIR}" /dist/just just_label "./${vsi_common_rel}/freeze/just_wrapper"
+          --tar-extra "--show-transformed --transform s|^\./|./${vsi_common_rel}/| ${include_unit_tests} ${vsi_common_exlcudes}" \
+          "${VSI_COMMON_DIR}" "/dist/${MAKESELF_NAME-just}" "${MAKESELF_LABEL-just_label}" "./${vsi_common_rel}/freeze/just_wrapper"
       # You can't put quotes in tar-extra apparently, it'll screw things up.
 
       extra_args=1
       ;;
     add-files) # Append files to a makeself executable
       pushd /src &> /dev/null
-        MAKESELF_PARSE=true "/makeself/makeself.sh" \
-            --header "/makeself/makeself-header_just.sh" \
+        MAKESELF_PARSE=true /makeself/makeself.sh \
+            --header /makeself/makeself-header_just.sh \
             --noprogress --nomd5 --nocrc --nox11 --keep-umask \
             --tar-extra "${1-}" --append \
-            . /dist/just
+            . "/dist/${MAKESELF_NAME-just}"
 
         extra_args=$#
       popd &> /dev/null

--- a/docker/vsi_common/pyinstaller.Dockerfile
+++ b/docker/vsi_common/pyinstaller.Dockerfile
@@ -1,0 +1,37 @@
+FROM vsiri/recipe:gosu as gosu
+FROM vsiri/recipe:tini as tini
+FROM vsiri/recipe:pipenv as pipenv
+FROM vsiri/recipe:vsi as vsi
+
+FROM python:3.7.0
+
+SHELL ["/usr/bin/env", "bash", "-euxvc"]
+
+ENV WORKON_HOME=/venv \
+    PIPENV_PIPFILE=/vsi/docker/vsi_common/pyinstaller.Pipfile \
+    PIPENV_CACHE_DIR=/venv/cache \
+    PYENV_SHELL=/bin/bash \
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8 \
+    JUSTFILE=/vsi/docker/vsi_common/pyinstaller.Justfile
+
+COPY --from=pipenv /usr/local /usr/local
+RUN for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
+
+# I need these Pipfiles before the rest of VSI below. This way the cache is only
+# invalidated by the Pipfiles, not the rest of vsi_common
+ADD pyinstaller.Pipfile pyinstaller.Pipfile.lock /vsi/docker/vsi_common/
+
+RUN pipenv sync; \
+    rm -rf "${PIPENV_PIPFILE}*" /tmp/pip*
+
+COPY --from=tini /usr/local /usr/local
+COPY --from=gosu /usr/local /usr/local
+# Allow non-privileged to run gosu (remove this to take root away from user)
+RUN chmod u+s /usr/local/bin/gosu
+
+COPY --from=vsi /vsi /vsi
+
+ENTRYPOINT ["/usr/local/bin/tini", "--", "/usr/bin/env", "bash", "/vsi/linux/just_entrypoint.sh"]
+
+CMD ["pyinstaller"]

--- a/docker/vsi_common/pyinstaller.Justfile
+++ b/docker/vsi_common/pyinstaller.Justfile
@@ -1,0 +1,18 @@
+#!/usr/bin/env false bash
+
+function caseify()
+{
+  local cmd="${1}"
+  shift 1
+  case "${cmd}" in
+    pyinstaller) # Freeze a python program
+      exec pipenv run "${cmd}" ${@+"${@}"}
+      ;;
+    nopipenv) # Run command not in pipenv
+      exec ${@+"${@}"}
+      ;;
+    *) # Run command in pipenv
+      exec pipenv run "${cmd}" ${@+"${@}"}
+      ;;
+  esac
+}

--- a/docker/vsi_common/pyinstaller.Justfile
+++ b/docker/vsi_common/pyinstaller.Justfile
@@ -6,6 +6,7 @@ function caseify()
   shift 1
   case "${cmd}" in
     pyinstaller) # Freeze a python program
+      cd /src
       exec pipenv run "${cmd}" ${@+"${@}"}
       ;;
     nopipenv) # Run command not in pipenv

--- a/docker/vsi_common/pyinstaller.Justfile
+++ b/docker/vsi_common/pyinstaller.Justfile
@@ -7,13 +7,10 @@ function caseify()
   case "${cmd}" in
     pyinstaller) # Freeze a python program
       cd /src
-      exec pipenv run "${cmd}" ${@+"${@}"}
+      exec "${cmd}" --distpath /dist ${@+"${@}"}
       ;;
-    nopipenv) # Run command not in pipenv
-      exec ${@+"${@}"}
-      ;;
-    *) # Run command in pipenv
-      exec pipenv run "${cmd}" ${@+"${@}"}
+    *) # Run command
+      exec "${cmd}" ${@+"${@}"}
       ;;
   esac
 }

--- a/docker/vsi_common/pyinstaller.Pipfile
+++ b/docker/vsi_common/pyinstaller.Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pyinstaller = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.7"

--- a/docker/vsi_common/pyinstaller.Pipfile.lock
+++ b/docker/vsi_common/pyinstaller.Pipfile.lock
@@ -1,0 +1,35 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "81a9ba32036dba6695f7951a4ed05cb5480d349083df41082ce2cd964f9f6bff"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "altgraph": {
+            "hashes": [
+                "sha256:1f05a47122542f97028caf78775a095fbe6a2699b5089de8477eb583167d69aa",
+                "sha256:c623e5f3408ca61d4016f23a681b9adb100802ca3e3da5e718915a9e4052cebe"
+            ],
+            "version": "==0.17"
+        },
+        "pyinstaller": {
+            "hashes": [
+                "sha256:3730fa80d088f8bb7084d32480eb87cbb4ddb64123363763cf8f2a1378c1c4b7"
+            ],
+            "index": "pypi",
+            "version": "==3.6"
+        }
+    },
+    "develop": {}
+}

--- a/docker/vsi_common/sphinx.Dockerfile
+++ b/docker/vsi_common/sphinx.Dockerfile
@@ -28,7 +28,7 @@ RUN pipenv sync; \
     rm -rf "${PIPENV_PIPFILE}*" /tmp/pip*
 
 COPY --from=tini /usr/local /usr/local
-COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
+COPY --from=gosu /usr/local /usr/local
 # Allow non-privileged to run gosu (remove this to take root away from user)
 RUN chmod u+s /usr/local/bin/gosu
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 #
 import os
 import sys
+sys.path.insert(0, os.path.abspath('/src/linux'))
 sys.path.insert(0, os.path.abspath('/src/python'))
 
 # -- Project information -----------------------------------------------------
@@ -109,6 +110,7 @@ autodoc_mock_imports = [
     "boxm2_scene_adaptor",
     "vpgl_adaptor_boxm2_batch",
     "yaml",
+    "prompt_toolkit"
 ]
 
 nitpick_ignore = [

--- a/docs/linux/index.rst
+++ b/docs/linux/index.rst
@@ -9,3 +9,4 @@ Linux Utilities
    :glob:
 
    *.auto
+   python_scripts/modules

--- a/docs/linux/python_scripts/modules.rst
+++ b/docs/linux/python_scripts/modules.rst
@@ -1,0 +1,10 @@
+Pyhton Scripts
+==============
+
+.. toctree::
+   :maxdepth: 4
+
+   ci_load
+   debug_readline
+   load_nvidia_uvm
+   new_notebook

--- a/linux/Just_wrap
+++ b/linux/Just_wrap
@@ -58,6 +58,7 @@
 #**
 
 source "$(dirname "${BASH_SOURCE[0]}")/just"
+source "$(dirname "${BASH_SOURCE[0]}")/string_tools.bsh"
 
 #    Make sure set -eu doesn't fail      if Just_wrap is wrapped and not being sourced
 if ( ( [ ${#BASH_SOURCE[@]} -gt 1 ] && [ "${BASH_SOURCE[1]}" == "${0}" ] ) || \
@@ -90,13 +91,13 @@ if ( ( [ ${#BASH_SOURCE[@]} -gt 1 ] && [ "${BASH_SOURCE[1]}" == "${0}" ] ) || \
     source "$(dirname "${BASH_SOURCE[0]}")/set_flags.bsh"
     # Source this script and the env file with it.
     unset_flag u # In case $1 is unset
-    rc_file_line="source '${0//\'/\'\"\'\"\'}' '${1//\'/\'\"\'\"\'}'"
+    rc_file_line="source $(quote_escape "${0}") $(quote_escape "${1}")"
     reset_flag u
   else
     # The wrapped script does not need to have the environment file passed back
     # to it, ${0} will point to that script, which will still have the
     # environment argument in it
-    rc_file_line="source '${0//\'/\'\"\'\"\'}'"
+    rc_file_line="source $(quote_escape "${0}")"
   fi
 
   # Make using interactive more tolerable for a normal user

--- a/linux/bash_utils.bsh
+++ b/linux/bash_utils.bsh
@@ -1,0 +1,71 @@
+#!/usr/bin/env false bash
+
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return 0
+fi
+
+#*# linux/bash_utils.bsh
+
+#**
+# .. default-domain:: bash
+#
+# ==========
+# Bash Utils
+# ==========
+#
+# .. file:: bash_utils.bsh
+#
+# A few utilities to help scripts in bash.
+#**
+
+#**
+# .. function:: print_bash_stack
+#
+# Prints the current call stack
+#
+# :Arguments: * ``$1`` - Number of stack levels to skip (not including :func:`print_bash_stack` itself. It will automatically add one to this number for itself). You typically set this to ``1`` in a function that gets called to print the stack. Default: ``0``
+#             * [``$2``] - Optional function to customize the printing of the stack. Variables you can expect to be set are (actual) ``stack_depth``, ``stack_depth_pad``, ``BASH_LINENO``, ``lineno_pad``, ``FUNCNAME``, ``funcname_pad``, and ``BASH_SOURCE``
+#**
+function print_bash_stack()
+{
+  if [ -f /.dockerenv ]; then
+    source "${VSI_COMMON_DIR}/linux/colors.bsh"
+    echo "Call stack ${YELLOW-}(in docker container)${NC-}" >&2
+    echo '--------------------------------' >&2
+  elif [ -d /.singularity.d ]; then
+    source "${VSI_COMMON_DIR}/linux/colors.bsh"
+    echo "Call stack ${YELLOW-}(in singularity container)${NC-}" >&2
+    echo '-------------------------------------' >&2
+  elif [ "${container-}" = "podman" ]; then
+    source "${VSI_COMMON_DIR}/linux/colors.bsh"
+    echo "Call stack ${YELLOW-}(in podman container)${NC-}" >&2
+    echo '--------------------------------' >&2
+  else
+    echo 'Call stack' >&2
+    echo '----------' >&2
+  fi
+  local -i i=0
+  local -i stack_depth_pad="$(awk '{print int(log($1)/log(10)+1e-10)+1}' <<< "${#BASH_SOURCE[@]}")"
+  local -i lineno_pad=0
+  local -i funcname_pad=0
+  for (( i=1+${1-0}; i<${#BASH_SOURCE[@]}; ++i)); do
+    if [ "${lineno_pad}" -lt "${#BASH_LINENO[i-1]}" ]; then
+      lineno_pad="${#BASH_LINENO[i-1]}"
+    fi
+    if [ "${funcname_pad}" -lt "${#FUNCNAME[i]}" ]; then
+      funcname_pad="${#FUNCNAME[i]}"
+    fi
+  done
+
+  if [ -n "${2+set}" ]; then
+    local stack_depth
+    for (( stack_depth=1+${1-0}; stack_depth<${#BASH_SOURCE[@]}; ++stack_depth)); do
+      "${2}"
+    done
+  else
+    funcname_pad+=3
+    for (( i=1+${1-0}; i<${#BASH_SOURCE[@]}; ++i)); do
+      printf "%${stack_depth_pad}s. %-${funcname_pad}s:%-${lineno_pad}s %s\n" "$((i-${1-0}))" "${FUNCNAME[i]:+${FUNCNAME[i]}()}" "${BASH_LINENO[i-1]}" "${BASH_SOURCE[i]}" >&2
+    done
+  fi
+}

--- a/linux/bin_utils.bsh
+++ b/linux/bin_utils.bsh
@@ -183,7 +183,8 @@ function lwhich()
   # musl doesn't have ld.so.conf, or cache, or ldconfig -p, so do it manually. The only way this
   # test could have a false positive is in a container situation where ldconfig cache hasn't been
   # built, in which case ldconfig -p would fail anyways.
-  if [ -e /etc/ld.so.cache ]; then
+  # The grep check will work on OSes like Clear Linux that are... special
+  if [ -e /etc/ld.so.cache ] || grep -q '/etc/ld\.so\.conf' `command -v ldconfig`; then
     # This only complicated the wildcard idea, and I don't CARE about this case
     for match in $(${LDCONFIG-ldconfig} -p | grep ${case_insensitive} -E $'^\t'"$1" | awk '{print $(NF)}'); do
       if isxbit ${bits} "${match}" && ! isin "$(basename "$match")" ${filenames+"${filenames[@]}"}; then

--- a/linux/bin_utils.bsh
+++ b/linux/bin_utils.bsh
@@ -185,7 +185,7 @@ function lwhich()
   # test could have a false positive is in a container situation where ldconfig cache hasn't been
   # built, in which case ldconfig -p would fail anyways.
   # The grep check will work on OSes like Clear Linux that are... special
-  if [ -e /etc/ld.so.cache ] || grep -q '/etc/ld\.so\.conf' `command -v ldconfig`; then
+  if [ -e /etc/ld.so.cache ] || grep -q '/etc/ld\.so\.conf' "$(command -v ldconfig)"; then
     # This only complicated the wildcard idea, and I don't CARE about this case
     for match in $(${LDCONFIG-ldconfig} -p | grep ${case_insensitive} -E $'^\t'"$1" | awk '{print $(NF)}'); do
       if isxbit ${bits} "${match}" && ! isin "$(basename "$match")" ${filenames+"${filenames[@]}"}; then

--- a/linux/bin_utils.bsh
+++ b/linux/bin_utils.bsh
@@ -43,7 +43,7 @@ source "${VSI_COMMON_DIR}/linux/compat.bsh"
 #
 # Prints out the number of bits (typically 32 or 64) in a file
 #
-# .. note:
+# .. note::
 #
 #    On macOS, it is common to have both 32 and 64 printed out. I.e. ``32 64``
 #**

--- a/linux/bin_utils.bsh
+++ b/linux/bin_utils.bsh
@@ -21,6 +21,7 @@ if [ -z ${VSI_COMMON_DIR+set} ]; then
 fi
 source "${VSI_COMMON_DIR}/linux/set_flags.bsh"
 source "${VSI_COMMON_DIR}/linux/isin"
+source "${VSI_COMMON_DIR}/linux/compat.bsh"
 
 #**
 # :Functions: - object_bits - Print out the number of bits in an object file (requires nm)
@@ -80,7 +81,7 @@ elif [ "${OS-}" = "Windows_NT" ]; then
 else
   function object_bits()
   {
-    nm -D "${1}" | sed -En '/^[0-9A-Fa-f]{8,}/ {p; q}' | awk '{print length($1)*4}'
+    nm -D "${1}" | sed -${sed_flag_rE}n '/^[0-9A-Fa-f]{8,}/ {p; q}' | awk '{print length($1)*4}'
   }
 fi
 

--- a/linux/check_shell
+++ b/linux/check_shell
@@ -48,7 +48,7 @@ if [ -d /proc ]; then
 
 elif command -v ps &> /dev/null; then
   ppid="$(ps -p $$ -o ppid=)"
-  parent_name="$(ps -p "${ppid}" -0 comm=)"
+  parent_name="$(ps -p "${ppid}" -o comm=)"
 else
   # Can't determine parent shell, so assume everything is ok
   exit 0

--- a/linux/check_shell
+++ b/linux/check_shell
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+#*# linux/check_shell
+
+#**
+# ===========
+# Check Shell
+# ===========
+#
+# .. default-domain:: bash
+#
+# .. file:: colors.bsh
+#
+# Script to inspect the shell you are running, to make sure you are running the expected shell. Commonly used in script you source
+#
+# :Arguments: ``$1...`` - Valid names of shells
+# :Return Value: * ``0`` - Check passed
+#                * ``1`` - Check failed
+# :Uses: * ``/proc`` or ``ps``. ``ps`` must support the ``-p`` and ``-o`` flags.
+#
+# .. rubric:: Example
+#
+# .. code-block:: bash
+#
+#    check_shell bash
+#    check_shell zsh bash
+#    check_shell csh fish
+#
+#**
+
+set -eu
+
+# Prefer /proc, it's more standard than ps's support for -p and -o
+if [ -d /proc ]; then
+  proc_data="$(</proc/$$/stat)"
+
+  pattern='\) [^ ]* ([0-9]+) '
+  [[ ${proc_data} =~ ${pattern} ]]
+  ppid="${BASH_REMATCH[1]}"
+
+  # This could result in "-bash" on WSL 1... I don't know why, how, nor where else that would likely happen. csh often appears as "-sh".
+  # IFS= read -r -d '' parent_name < "/proc/${ppid}/cmdline"
+
+  # This method consistently gives the expected result
+  pattern='\((.*)\)'
+  [[ ${proc_data} =~ ${pattern} ]]
+  parent_name="${BASH_REMATCH[1]}"
+
+elif command -v ps &> /dev/null; then
+  ppid="$(ps -p $$ -o ppid=)"
+  parent_name="$(ps -p "${ppid}" -0 comm=)"
+else
+  # Can't determine parent shell, so assume everything is ok
+  exit 0
+fi
+
+shell_ok=0
+IFS=',' shells="${*}"
+while (( $# )); do
+  # Check "shellname" and "/dir/shellname", both common, based on how you start the shell
+  if [ "${parent_name}" = "$1" ] || [[  ${parent_name} = */$1 ]]; then
+    shell_ok=1
+    break
+  fi
+  shift 1
+done
+
+if [ "${shell_ok}" = "0" ]; then
+  echo "Your shell was detected to be ${parent_name}, not ${shells}. You must be running ${shells} to source ${shells} scripts" >&2
+  exit 1
+fi
+
+exit 0

--- a/linux/command_tools.bsh
+++ b/linux/command_tools.bsh
@@ -240,7 +240,7 @@ function _compose_arguments()
 #      dynamic_set_a "${JUST_PROJECT_PREFIX}_SINGULAR_COMPOSE_FILES" "${compose_files[@]}"
 #    fi
 #
-# .. note:
+# .. note::
 #
 #    Variables are always overwritten, even if not used. A ``0`` for options without arguments, and an empty string for options that take arguments indicates the option was never used. However, arrays are always appended to.
 #

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -6,6 +6,14 @@ fi
 
 function load_vsi_compat()
 {
+  if [ -z "${VSI_SED_COMPAT-}" ]; then
+    local VSI_SED_COMPAT
+    if [[ $(sed --version) = GNU* ]]; then
+      VSI_SED_COMPAT=gnu
+    else
+      VSI_SED_COMPAT=bsd
+    fi
+  fi
   # Needed for CentOS 6 running sed 4.1.5
   if [ "${VSI_SED_COMPAT-}" = "gnu" ]; then
     sed_flag_rE='r'

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -20,6 +20,13 @@ function load_vsi_compat()
   else
     sed_flag_rE='E'
   fi
+
+  # Handle macos BSD version
+  if [[ ${OSTYPE-} = darwin* ]]; then
+    sed_flag_i="i ''"
+  else
+    sed_flag_i='i'
+  fi
 }
 
 # The purpose of this file is to set all these flag. Make it a function to help

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -8,7 +8,9 @@ function load_vsi_compat()
 {
   if [ -z "${VSI_SED_COMPAT-}" ]; then
     local VSI_SED_COMPAT
-    if [[ $(sed --version) = GNU* ]]; then
+    if [[ ${OSTYPE-} = darwin* ]]; then
+      VSI_SED_COMPAT=bsd
+    elif [[ $(sed --version) = GNU* ]]; then
       VSI_SED_COMPAT=gnu
     else
       VSI_SED_COMPAT=bsd

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -6,6 +6,10 @@ fi
 
 function load_vsi_compat()
 {
+  #######
+  # Sed #
+  #######
+
   if [ -z "${VSI_SED_COMPAT-}" ]; then
     local VSI_SED_COMPAT
     if [[ ${OSTYPE-} = darwin* ]]; then
@@ -28,6 +32,26 @@ function load_vsi_compat()
     sed_flag_i="i ''"
   else
     sed_flag_i='i'
+  fi
+
+  ########
+  # Bash #
+  ########
+
+  #**
+  # The following variables will help cope with the difference in bash versions, as seamlessly as possible.
+  #
+  # .. variable: bash_declare_array_quote
+  #
+  # In bash version 4.3 and older, ``declare -p`` of an array adds an extra ``'`` around the array. This variable stores the state of that variable
+  #
+  # :Value: * ``(null)`` - Bash 4.4 or newer
+  #         * ``'`` - Bash 4.3 or older
+  #**
+  if [ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -gt "43" ]; then
+    bash_declare_array_quote=""
+  else
+    bash_declare_array_quote="'"
   fi
 }
 

--- a/linux/container_functions.bsh
+++ b/linux/container_functions.bsh
@@ -70,3 +70,30 @@ function container_environment_override()
     fi
   done
 }
+
+#**
+# .. function:: translate_path
+#
+# Translates a path from one filesystem to another, useful for going from host to a container.
+#
+# :Arguments: * ``$1`` - Original path
+#             * ``$2, [$4, $6, ...]`` - Host paths
+#             * ``$3, [$5, $7, ...]`` - Container paths
+# :Output: **stdout** - The translated path. If none of the path pairs translated the path, the original path returned
+#**
+function translate_path()
+{
+  local __translate_paths_original_path="${1}"
+  local __translate_paths_relative_path
+  shift 1
+
+  while [ $# -gt 1 ]; do
+    __translate_paths_relative_path="$(relative_path "${__translate_paths_original_path}" "${1}")"
+    if [ "${__translate_paths_relative_path:0:3}" != "../" ]; then
+      echo "${2}/${__translate_paths_relative_path}"
+      return
+    fi
+    shift 2
+  done
+  echo "${__translate_paths_original_path}"
+}

--- a/linux/container_functions.bsh
+++ b/linux/container_functions.bsh
@@ -36,6 +36,10 @@ fi
 #**
 function container_environment_override()
 {
+  local var
+  local indirect
+  local indirect2
+
   if [ "${OS-}" = "Windows_NT" ]; then
     "${1}" JUST_HOST_WINDOWS 1
   fi
@@ -50,8 +54,11 @@ function container_environment_override()
         if [ "${JUST_DISABLE_ENVIRONMENT_SWAP-}" == "1" ]; then
           "${1}" ${indirect} "${!indirect}"
         else
-          # Set ENV_VAR_HOST to ${ENV_VAR} in the container
-          "${1}" ${indirect}_HOST "${!indirect}"
+          indirect2="${indirect}_HOST"
+          if [ -z "${!indirect2+set}" ]; then
+            # Set ENV_VAR_HOST to ${ENV_VAR} in the container
+            "${1}" ${indirect}_HOST "${!indirect}"
+          fi
         fi
       fi
       if [ "${JUST_DISABLE_ENVIRONMENT_SWAP-}" == "1" ]; then

--- a/linux/container_functions.bsh
+++ b/linux/container_functions.bsh
@@ -20,7 +20,7 @@ fi
 # .. function:: container_environment_override
 #
 # :Arguments: * ``${1}`` - The name of a function that takes two arguments, variable name and variable value, and writes to the corresponding configuration file.
-# :Arguments: * ``JUST_PROJECT_PREFIX`` - The Just project prefix value
+#             * ``JUST_PROJECT_PREFIX`` - The Just project prefix value
 #             * ``JUST_DISABLE_ENVIRONMENT_SWAP`` - Transparently swap environment variables as they are added to the docker environment
 #             * ``EXPORT_DOCKER`` - Also exports the ``${1}_.*_DOCKER`` version of the variable when using the transparent environment variable swap feature (the swap effectively becomes a copy).
 #

--- a/linux/debug_readline.py
+++ b/linux/debug_readline.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+'''
+Script that uses IPython's prompt_toolkit to read in a line of input and echo
+it out on stdout
+
+Used by pbdb as an more advanced version of readline.
+'''
+
 import sys
 from os import environ as env
 import os
@@ -9,98 +16,103 @@ from pygments.styles import get_style_by_name
 import prompt_toolkit
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
-if prompt_toolkit.__version__[0:2] != "1.":
-  from prompt_toolkit import PromptSession
-  from prompt_toolkit.lexers import PygmentsLexer
-  from prompt_toolkit.styles.pygments import style_from_pygments_cls
-  from prompt_toolkit.key_binding import KeyBindings
+
+def main():
+  if prompt_toolkit.__version__[0:2] != "1.":
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.lexers import PygmentsLexer
+    from prompt_toolkit.styles.pygments import style_from_pygments_cls
+    from prompt_toolkit.key_binding import KeyBindings
 
 
-  def key_bindings():
-    key_binding = KeyBindings()
-    key_binding.add('enter')(return_handler)
-    key_binding.add('tab')(tab_handler)
-    return key_binding
+    def key_bindings():
+      key_binding = KeyBindings()
+      key_binding.add('enter')(return_handler)
+      key_binding.add('tab')(tab_handler)
+      return key_binding
 
-  def return_handler(event):
-    buffer = event.current_buffer
-    # document = buffer.document
-    if buffer.text.endswith("\\"):
-      buffer.text=buffer.text[:-1]+'\n'
-    else:
-      buffer.validate_and_handle()
+    def return_handler(event):
+      buffer = event.current_buffer
+      # document = buffer.document
+      if buffer.text.endswith("\\"):
+        buffer.text=buffer.text[:-1]+'\n'
+      else:
+        buffer.validate_and_handle()
 
-  def tab_handler(event):
-    buffer = event.current_buffer
-    document = buffer.document
-    if buffer.auto_suggest:
-      suggestion = buffer.auto_suggest.get_suggestion(buffer, document)
-      if suggestion.text:
-        buffer.text+=suggestion.text
-        buffer.cursor_position+=len(suggestion.text)
+    def tab_handler(event):
+      buffer = event.current_buffer
+      document = buffer.document
+      if buffer.auto_suggest:
+        suggestion = buffer.auto_suggest.get_suggestion(buffer, document)
+        if suggestion.text:
+          buffer.text+=suggestion.text
+          buffer.cursor_position+=len(suggestion.text)
 
-  def prompt_continuation(width, line_number, is_soft_wrap):
-    return ' '*(width-2) + "… "
+    def prompt_continuation(width, line_number, is_soft_wrap):
+      return ' '*(width-2) + "… "
 
 
-  style = style_from_pygments_cls(get_style_by_name(env.get(
-      '_debug_read_color_scheme', 'vim')))
-  session = PromptSession(message=env.get('_debug_prompt', '$ '),
-                          lexer=PygmentsLexer(BashLexer),
-                          style=style,
-                          key_bindings=key_bindings(),
-                          history=FileHistory(env.get('JUST_DEBUG_HISTORY',
-                              os.path.expanduser('~/.debug_bash_history'))+'3'),
-                          enable_history_search=True,
-                          multiline=True,
-                          auto_suggest=AutoSuggestFromHistory(),
-                          prompt_continuation=prompt_continuation)
+    style = style_from_pygments_cls(get_style_by_name(env.get(
+        '_debug_read_color_scheme', 'vim')))
+    session = PromptSession(message=env.get('_debug_prompt', '$ '),
+                            lexer=PygmentsLexer(BashLexer),
+                            style=style,
+                            key_bindings=key_bindings(),
+                            history=FileHistory(env.get('JUST_DEBUG_HISTORY',
+                                os.path.expanduser('~/.debug_bash_history'))+'3'),
+                            enable_history_search=True,
+                            multiline=True,
+                            auto_suggest=AutoSuggestFromHistory(),
+                            prompt_continuation=prompt_continuation)
 
-  try:
-    text = session.prompt()
-    sys.stderr.write(text)
-  except KeyboardInterrupt:
-    pass
-else:
-  # from __future__ import unicode_literals
-  from prompt_toolkit import prompt
-  from prompt_toolkit.styles import style_from_pygments
-  from prompt_toolkit.layout.lexers import PygmentsLexer
-  from prompt_toolkit.key_binding.manager import KeyBindingManager
-  from prompt_toolkit.keys import Keys
+    try:
+      text = session.prompt()
+      sys.stderr.write(text)
+    except KeyboardInterrupt:
+      pass
+  else:
+    # from __future__ import unicode_literals
+    from prompt_toolkit import prompt
+    from prompt_toolkit.styles import style_from_pygments
+    from prompt_toolkit.layout.lexers import PygmentsLexer
+    from prompt_toolkit.key_binding.manager import KeyBindingManager
+    from prompt_toolkit.keys import Keys
 
-  manager = KeyBindingManager.for_prompt()
+    manager = KeyBindingManager.for_prompt()
 
-  @manager.registry.add_binding(Keys.Enter)
-  def return_handler(event):
-    buffer = event.current_buffer
-    if buffer.text.endswith("\\"):
-      buffer.text=buffer.text[:-1]+'\n'
-    else:
-      buffer.accept_action.validate_and_handle(event.cli, buffer)
+    @manager.registry.add_binding(Keys.Enter)
+    def return_handler(event):
+      buffer = event.current_buffer
+      if buffer.text.endswith("\\"):
+        buffer.text=buffer.text[:-1]+'\n'
+      else:
+        buffer.accept_action.validate_and_handle(event.cli, buffer)
 
-  @manager.registry.add_binding(Keys.Tab)
-  def tab_handler(event):
-    buffer = event.current_buffer
-    document = buffer.document
-    if buffer.auto_suggest:
-      suggestion = buffer.auto_suggest.get_suggestion(event.cli, buffer, document)
-      if suggestion.text:
-        buffer.text+=suggestion.text
-        buffer.cursor_position+=len(suggestion.text)
+    @manager.registry.add_binding(Keys.Tab)
+    def tab_handler(event):
+      buffer = event.current_buffer
+      document = buffer.document
+      if buffer.auto_suggest:
+        suggestion = buffer.auto_suggest.get_suggestion(event.cli, buffer, document)
+        if suggestion.text:
+          buffer.text+=suggestion.text
+          buffer.cursor_position+=len(suggestion.text)
 
-  style = style_from_pygments(get_style_by_name(env.get(
-      '_debug_read_color_scheme', 'vim')))
+    style = style_from_pygments(get_style_by_name(env.get(
+        '_debug_read_color_scheme', 'vim')))
 
-  try:
-    text = prompt(env.get('_debug_prompt', '$ '),
-                  lexer=PygmentsLexer(BashLexer),
-                  style=style,
-                  key_bindings_registry=manager.registry,
-                  history=FileHistory(env.get('JUST_DEBUG_HISTORY',
-                              os.path.expanduser('~/.debug_bash_history'))+'3'),
-                  multiline=True,
-                  auto_suggest=AutoSuggestFromHistory())
-    sys.stderr.write(text)
-  except KeyboardInterrupt:
-    pass
+    try:
+      text = prompt(env.get('_debug_prompt', '$ '),
+                    lexer=PygmentsLexer(BashLexer),
+                    style=style,
+                    key_bindings_registry=manager.registry,
+                    history=FileHistory(env.get('JUST_DEBUG_HISTORY',
+                                os.path.expanduser('~/.debug_bash_history'))+'3'),
+                    multiline=True,
+                    auto_suggest=AutoSuggestFromHistory())
+      sys.stderr.write(text)
+    except KeyboardInterrupt:
+      pass
+
+if __name__ == '__main__':
+  main()

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -137,7 +137,7 @@ _make_temp_path_cleanup()
   local temp_path
   for temp_path in ${_VSI_TEMP_PATHS+"${_VSI_TEMP_PATHS[@]}"}; do
     if [ -d "${temp_path}" ]; then
-      if [[ ${OSTYPE-} = darwin* ]]; then
+      if [[ ${OSTYPE-} = darwin* ]] || ! command -v find &> /dev/null; then
         # :nocov_mac:
         rm -rf "${temp_path}"
         # :nocov_mac:

--- a/linux/docker_compose_override
+++ b/linux/docker_compose_override
@@ -185,6 +185,7 @@ function generate_docker_compose_override()
   local just_docker_entrypoint_links
   local just_docker_entrypoint_internal_volumes
   local just_docker_entrypoint_internal_ro_volumes
+  local all_dynamic_internal_volumes=()
 
   # indirect fun
   local volumes_name
@@ -309,6 +310,7 @@ function generate_docker_compose_override()
         else
           just_docker_entrypoint_internal_volumes+=("${volume_docker}")
         fi
+        all_dynamic_internal_volumes+=("${volume_host}")
       else # Else the volume is a path, get the real path
         volume_host="$(real_path "${volume_host}")"
       fi
@@ -351,7 +353,7 @@ function generate_docker_compose_override()
     # Remove duplicates (https://unix.stackexchange.com/q/159695) because
     # docker-compose doesn't like them
     IFS=$'\n'
-    over_volumes=($(awk '!count[$0]++' <<< ${over_volumes+"${over_volumes[*]}"}))
+    over_volumes=($(awk '!count[$0]++' <<< ${over_volumes[@]+"${over_volumes[*]}"}))
     if [ "${over_volumes+set}" == "set" ]; then
       echo "    volumes:"
       echo ${over_volumes+"${over_volumes[*]}"}
@@ -377,6 +379,23 @@ function generate_docker_compose_override()
 
     container_environment_override _env_echo
   done
+
+  ###################
+  # volumes section #
+  ###################
+  IFS=$'\n'
+  # Make unique list
+  all_dynamic_internal_volumes=($(awk '!count[$0]++' <<< ${all_dynamic_internal_volumes[@]+"${all_dynamic_internal_volumes[*]}"}))
+  IFS="${OLD_IFS}"
+
+  # A space is needed for older bashes (an extra null "" works only in newer bashes)
+  if [ " ${all_dynamic_internal_volumes[@]+set}" = " set" ]; then
+    # Declare newly added volumes
+    echo "volumes:"
+    for volume in "${all_dynamic_internal_volumes[@]}"; do
+      echo "  ${volume}:"
+    done
+  fi
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then

--- a/linux/docker_functions.bsh
+++ b/linux/docker_functions.bsh
@@ -844,60 +844,54 @@ function docker-compose-list-internal-volumes()
 function docker-compose-volumes()
 {
   local volume_line
-  local flag
   DOCKER_VOLUME_SOURCES=()
   DOCKER_VOLUME_TARGETS=()
   DOCKER_VOLUME_FLAGS=()
   DOCKER_VOLUME_FORMATS=()
+  local -i count=0
+
   for volume_line in ${DOCKER_VOLUME_LINES+"${DOCKER_VOLUME_LINES[@]}"}; do
+    # Capital means new volume
     if [[ ${volume_line:0:1} = [SL] ]]; then
-      # If the flag hasn't been added, then add it. This only won't happen on
-      # the first loop through
-      if [ "${#DOCKER_VOLUME_FLAGS[@]}" -lt "${#DOCKER_VOLUME_TARGETS[@]}" ]; then
-        DOCKER_VOLUME_FLAGS+=("${flag}")
-      fi
-      # Clear the flag because it's a new volume (S/L)
-      flag=
+      count+=1
+      # Extend each array, to guarantee there are no holes and they are the
+      # same length. Makes more robust and the code simpler
+      DOCKER_VOLUME_SOURCES[count]=""
+      DOCKER_VOLUME_TARGETS[count]=""
+      DOCKER_VOLUME_FORMATS[count]=""
+      DOCKER_VOLUME_FLAGS[count]=""
     fi
 
     if [ "${volume_line:0:1}" = "S" ]; then # Short format
       volume_line="${volume_line:1}"
       if [[ $volume_line =~ ${DOCKER_VOLUME_PATTERN} ]]; then
-        DOCKER_VOLUME_SOURCES+=("${BASH_REMATCH[1]}")
-        DOCKER_VOLUME_TARGETS+=("${BASH_REMATCH[3]}")
-        DOCKER_VOLUME_FORMATS+=("short")
-        flag=("${BASH_REMATCH[5]}")
+        DOCKER_VOLUME_SOURCES[count]="${BASH_REMATCH[1]}"
+        DOCKER_VOLUME_TARGETS[count]="${BASH_REMATCH[3]}"
+        DOCKER_VOLUME_FORMATS[count]="short"
+        DOCKER_VOLUME_FLAGS[count]="${BASH_REMATCH[5]}"
       else
         echo "Invalid short form volume string: ${volume_line}" >&2
         return 1
       fi
     elif [[ ${volume_line:0:1} = [Ll] ]]; then
       if [ ${volume_line:0:1} = L ]; then
-        DOCKER_VOLUME_FORMATS+=("long")
+        DOCKER_VOLUME_FORMATS[count]="long"
       fi
+      # Remove the L/l, so the rest is simpler to parse
       volume_line="${volume_line:1}"
       if [[ ${volume_line} = source:* ]]; then
-        DOCKER_VOLUME_SOURCES+=("${volume_line#source: *}")
+        DOCKER_VOLUME_SOURCES[count]="${volume_line#source: *}"
       elif [[ ${volume_line} = target:* ]]; then
-        DOCKER_VOLUME_TARGETS+=("${volume_line#target: *}")
-      elif [[ ${volume_line} = type:* ]]; then
-        if [ "${volume_line}" = "type: tmpfs" ]; then
-          DOCKER_VOLUME_SOURCES+=("")
-        fi
-      else
-        if [ "${flag}" = "" ]; then
-          flag="${volume_line}"
+        DOCKER_VOLUME_TARGETS[count]="${volume_line#target: *}"
+      elif [[ ${volume_line} != type:* ]]; then
+        if [ "${DOCKER_VOLUME_FLAGS[count]}" = "" ]; then
+          DOCKER_VOLUME_FLAGS[count]="${volume_line}"
         else
-          flag+=$'\n'"${volume_line}"
+          DOCKER_VOLUME_FLAGS[count]+=$'\n'"${volume_line}"
         fi
       fi
     fi
   done
-
-  # Do the same logic again for the last pass-through
-  if [ "${#DOCKER_VOLUME_FLAGS[@]}" -lt "${#DOCKER_VOLUME_TARGETS[@]}" ]; then
-    DOCKER_VOLUME_FLAGS+=("${flag}")
-  fi
 }
 
 #**

--- a/linux/docker_functions.bsh
+++ b/linux/docker_functions.bsh
@@ -906,8 +906,8 @@ function docker-compose-volumes()
 # :Arguments: ``$1``.. - Arguments to be sent to docker-compose command
 # :Parameters: [``JUST_DOCKER_COMPOSE_DIR``] - By default, the docker-compose files will initially be searched for in the ``JUSTFILE`` directory, and then up the parent dirs until / is hit. However, if you wish to the disable this behavior and start searching for a docker-compose file from the current directory where "just" is called, then set this var to an empty string. You can also set to a specific directory to start searching from within that directory.
 # :Output: * ``docker_compose_args`` - Arguments to docker-compose, before the docker-compose command (run, up, down, etc...)
-#          * ``docker_compose_arguments`` - Docker compose command specified
-#          * ``docker_compose_arguments_args`` - Arguments for the specified command
+#          * ``docker_compose_command`` - Docker compose command specified
+#          * ``docker_compose_command_args`` - Arguments for the specified command
 #          * ``docker_compose_files`` - Array of docker compose files that are used
 #          * ``docker_compose_project_name`` - Docker compose project name
 #
@@ -923,8 +923,8 @@ function docker-compose-volumes()
 #
 # .. code-block:: bash
 #
-#   docker-compose "${docker_compose_args[@]}" "${docker_compose_arguments}" \
-#                  "${docker_compose_arguments_args[@]}"
+#   docker-compose "${docker_compose_args[@]}" "${docker_compose_command}" \
+#                  "${docker_compose_command_args[@]}"
 #
 # .. rubric:: Example
 #
@@ -959,8 +959,8 @@ function parse-docker-compose()
   docker_compose_files=()
   docker_compose_args=()
   docker_compose_project_name=
-  docker_compose_arguments=
-  docker_compose_arguments_args=()
+  docker_compose_command=
+  docker_compose_command_args=()
 
   while (( $# )); do
     case "$1" in
@@ -1018,9 +1018,9 @@ function parse-docker-compose()
         ;;
       # Anything else must be a docker compose command
       *)
-        docker_compose_arguments="$1"
+        docker_compose_command="$1"
         shift 1
-        docker_compose_arguments_args=(${@+"${@}"})
+        docker_compose_command_args=(${@+"${@}"})
         break
         ;;
     esac
@@ -1133,8 +1133,8 @@ function compose_path_separator()
 function Docker-compose()
 {
   local docker_compose_args
-  local docker_compose_arguments
-  local docker_compose_arguments_args
+  local docker_compose_command
+  local docker_compose_command_args
   local docker_compose_files
   local docker_compose_project_name
 
@@ -1149,21 +1149,21 @@ function _Docker-compose()
   local cmd=(${DRYRUN} ${DOCKER_COMPOSE})
   local extra_args_var
 
-  if [ "${docker_compose_arguments}" = "run" ] && [ "${DOCKER_COMPOSE_AUTOREMOVE-1}" == "1" ]; then
+  if [ "${docker_compose_command}" = "run" ] && [ "${DOCKER_COMPOSE_AUTOREMOVE-1}" == "1" ]; then
     docker_compose_extra_command_args+=(--rm)
   fi
 
   # Indirect: add DOCKER_COMPOSE_EXTRA_{COMMAND}_ARGS
-  extra_args_var=$(tr '[a-z]' '[A-Z]' <<< "${docker_compose_arguments}")
+  extra_args_var=$(tr '[a-z]' '[A-Z]' <<< "${docker_compose_command}")
   extra_args_var="DOCKER_COMPOSE_EXTRA_${extra_args_var}_ARGS[@]"
   docker_compose_extra_command_args+=(${!extra_args_var+"${!extra_args_var}"})
 
   "${cmd[@]}" \
       ${docker_compose_args+"${docker_compose_args[@]}"} \
       ${DOCKER_COMPOSE_EXTRA_ARGS+"${DOCKER_COMPOSE_EXTRA_ARGS[@]}"} \
-      ${docker_compose_arguments} \
+      ${docker_compose_command} \
       ${docker_compose_extra_command_args+"${docker_compose_extra_command_args[@]}"} \
-      ${docker_compose_arguments_args+"${docker_compose_arguments_args[@]}"}
+      ${docker_compose_command_args+"${docker_compose_command_args[@]}"}
   return $?
 }
 
@@ -1298,8 +1298,8 @@ function Just-docker-compose()
   fi
 
   local docker_compose_args
-  local docker_compose_arguments
-  local docker_compose_arguments_args
+  local docker_compose_command
+  local docker_compose_command_args
   local docker_compose_files
   local DOCKER_COMPOSE_FILES
   local docker_compose_project_name

--- a/linux/docker_functions.bsh
+++ b/linux/docker_functions.bsh
@@ -435,21 +435,22 @@ function docker_sanitize_volume()
 function parse-docker()
 {
   docker_args=()
+  docker_command=
   docker_command_args=()
 
   while (( $# )); do
     case "$1" in
+      -H|-l|\
+      --config|--context|--host|--log-level|--tlscacert|--tlscert|--tlskey)
+        docker_args+=("$1" "$2")
+        shift 2
+        ;;
       -H*|-l*|\
-      --config=*|--host=*|--log-level=*|--tlscacert=*|--tlscert=*|--tlskey=*|\
+      --config=*|--context=*|--host=*|--log-level=*|--tlscacert=*|--tlscert=*|--tlskey=*|\
       -D|-v|\
       --debug|--tls|--version|--tlsverify)
         docker_args+=("$1")
         shift 1
-        ;;
-      -H|-l|\
-      --config|--host|--log-level|--tlscacert|--tlscert|--tlskey)
-        docker_args+=("$1" "$2")
-        shift 2
         ;;
       # Anything else must be a docker compose command.
       *)

--- a/linux/docker_functions.bsh
+++ b/linux/docker_functions.bsh
@@ -958,10 +958,12 @@ function parse-docker-compose()
   docker_compose_files=()
   docker_compose_args=()
   docker_compose_project_name=
+  docker_compose_arguments=
+  docker_compose_arguments_args=()
 
   while (( $# )); do
     case "$1" in
-      -f|-p|-H)
+      -f|-p|-H|-c)
         docker_compose_args+=("$1" "$2")
         case "$1" in
           -f)
@@ -973,7 +975,7 @@ function parse-docker-compose()
         esac
         shift 2
         ;;
-      -f*|-p*|-H*)
+      -f*|-p*|-H*|-c*)
         docker_compose_args+=("$1")
         case "$1" in
           -f*)
@@ -985,9 +987,10 @@ function parse-docker-compose()
         esac
         shift 1
         ;;
-      --file=*|--project-name=*|--host=*|\
-      --tlscacert=*|--tlscert=*|--tlskey=*|--project-directory=*|\
-      --no-ansi|-v|--verbose|--tls|--skip-hostname-check|--tlsverify)
+      --file=*|--project-name=*|--host=*|--context=*|--log-level=*|\
+      --tlscacert=*|--tlscert=*|--tlskey=*|--project-directory=*|--env-file=*|\
+      --no-ansi|-v|--verbose|--tls|--skip-hostname-check|--tlsverify|\
+      --compatibility)
         docker_compose_args+=("$1")
         case "$1" in
           --file=*)
@@ -999,8 +1002,8 @@ function parse-docker-compose()
         esac
         shift 1
         ;;
-      --file|--project-name|--host|\
-      --tlscacert|--tlscert|--tlskey|--project-directory)
+      --file|--project-name|--host|--context|--log-level|\
+      --tlscacert|--tlscert|--tlskey|--project-directory|--env-file)
         docker_compose_args+=("$1" "$2")
         case "$1" in
           --file)

--- a/linux/just
+++ b/linux/just
@@ -220,7 +220,7 @@ function print_error()
     echo '----------' >&2
   fi
   local -i i=0
-  while line=("$(caller $i)"); do
+  while line="$(caller $i)"; do
     stack+="$(sed $'s| |\t|2' <<< "${line}")"$'\n'
     ((++i))
   done

--- a/linux/just
+++ b/linux/just
@@ -177,10 +177,6 @@ fi
 function print_error()
 {
   local rv=$? # This must be the first line
-  local stack=''
-  local line
-  # Stop any errors in here from throwing more errors (infinite loop), otherwise
-  # "while line=("$(caller $i)"); do" would have inherited the trap, and retrapped
 
   #**
   # ..envvar:: JUST_IGNORE_EXIT_CODES
@@ -211,51 +207,7 @@ function print_error()
 
   set +E
   echo >&2
-  if [ -f /.dockerenv ]; then
-    source "${VSI_COMMON_DIR}/linux/colors.bsh"
-    echo "Call stack ${YELLOW-}(in docker container)${NC-}" >&2
-    echo '--------------------------------' >&2
-  elif [ -d /.singularity.d ]; then
-    source "${VSI_COMMON_DIR}/linux/colors.bsh"
-    echo "Call stack ${YELLOW-}(in singularity container)${NC-}" >&2
-    echo '-------------------------------------' >&2
-  elif [ "${container-}" = "podman" ]; then
-    source "${VSI_COMMON_DIR}/linux/colors.bsh"
-    echo "Call stack ${YELLOW-}(in podman container)${NC-}" >&2
-    echo '--------------------------------' >&2
-  else
-    echo 'Call stack' >&2
-    echo '----------' >&2
-  fi
-  local -i i=0
-  local -i count_pad="$(awk '{print int(log($1)/log(10)+1e-10)+1}' <<< "${#BASH_SOURCE[@]}")"
-  local -i lineno_pad=0
-  local -i funcname_pad=0
-  for (( i=1; i<${#BASH_SOURCE[@]}; ++i)); do
-    if [ "${lineno_pad}" -lt "${#BASH_LINENO[i-1]}" ]; then
-      lineno_pad="${#BASH_LINENO[i-1]}"
-    fi
-    if [ "${funcname_pad}" -lt "${#FUNCNAME[i]}" ]; then
-      funcname_pad="${#FUNCNAME[i]}"
-    fi
-  done
-  funcname_pad+=3
-
-  for (( i=1; i<${#BASH_SOURCE[@]}; ++i)); do
-    printf "%${count_pad}s. %-${funcname_pad}s:%-${lineno_pad}s %s\n" "${i}" "${FUNCNAME[i]:+${FUNCNAME[i]}()}" "${BASH_LINENO[i-1]}" "${BASH_SOURCE[i]}" >&2
-  done
-
-  # Review: Is caller sometimes better than BASH_SOURCE[i]/BASH_LINENO[i-1]/FUNCNAME[i]?
-  # i=0
-  # while line="$(caller $i)"; do
-  #   stack+="$(sed $'s| |\t|g' <<< "${line}")"$'\n'
-  #   ((++i))
-  # done
-  # if command -v column &> /dev/null; then
-  #   column -c1 -s $'\t' -t >&2 <<< "${stack}"
-  # else
-  #   echo "${stack}" >&2
-  # fi
+  print_bash_stack 1
   echo >&2
   echo "$1: line $2: Returned $rv" >&2
 }
@@ -277,6 +229,7 @@ source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
 # Activate source_once
 source "${VSI_COMMON_DIR}/linux/source_once.bsh"
 source "${VSI_COMMON_DIR}/linux/just_functions.bsh"
+source "${VSI_COMMON_DIR}/linux/bash_utils.bsh"
 
 setup_tty ${@+"${@}"}
 
@@ -315,10 +268,17 @@ if [ "${JUSTFILE:0:1}" = "." ]; then
   JUSTFILE="$(real_path "${JUSTFILE}")"
 fi
 
+# Covers certain corner cases, like Just_wrap
+unset JUST_SETTINGS
+
 if ! _just_load_justfile "${JUSTFILE}"; then
   JUST_FILE_NOT_FOUND=1
 fi
 
+# Move this check here, so that if there are multiple JUST_SETTINGS, or other
+# advanced setups, that what ever is set when it is all done being loaded is
+# what really counts.
+check_just_version
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   justify ${@+"${@}"}

--- a/linux/just
+++ b/linux/just
@@ -176,7 +176,7 @@ fi
 
 function print_error()
 {
-  local rv=$?
+  local rv=$? # This must be the first line
   local stack=''
   local line
   # Stop any errors in here from throwing more errors (infinite loop), otherwise
@@ -211,33 +211,53 @@ function print_error()
 
   set +E
   echo >&2
-  if [ -e /.dockerenv ]; then
+  if [ -f /.dockerenv ]; then
     source "${VSI_COMMON_DIR}/linux/colors.bsh"
     echo "Call stack ${YELLOW-}(in docker container)${NC-}" >&2
+    echo '--------------------------------' >&2
+  elif [ -d /.singularity.d ]; then
+    source "${VSI_COMMON_DIR}/linux/colors.bsh"
+    echo "Call stack ${YELLOW-}(in singularity container)${NC-}" >&2
+    echo '-------------------------------------' >&2
+  elif [ "${container-}" = "podman" ]; then
+    source "${VSI_COMMON_DIR}/linux/colors.bsh"
+    echo "Call stack ${YELLOW-}(in podman container)${NC-}" >&2
     echo '--------------------------------' >&2
   else
     echo 'Call stack' >&2
     echo '----------' >&2
   fi
   local -i i=0
-  while line="$(caller $i)"; do
-    stack+="$(sed $'s| |\t|2' <<< "${line}")"$'\n'
-    ((++i))
+  local -i count_pad="$(awk '{print int(log($1)/log(10)+1e-10)+1}' <<< "${#BASH_SOURCE[@]}")"
+  local -i lineno_pad=0
+  local -i funcname_pad=0
+  for (( i=1; i<${#BASH_SOURCE[@]}; ++i)); do
+    if [ "${lineno_pad}" -lt "${#BASH_LINENO[i-1]}" ]; then
+      lineno_pad="${#BASH_LINENO[i-1]}"
+    fi
+    if [ "${funcname_pad}" -lt "${#FUNCNAME[i]}" ]; then
+      funcname_pad="${#FUNCNAME[i]}"
+    fi
   done
-  if command -v column &> /dev/null; then
-    column -c1 -s $'\t' -t >&2 <<< "${stack}"
-  else
-    echo "${stack}" >&2
-  fi
-  echo >&2
-  echo "$1: line $2: Returned $rv" >&2
-  # echo
-  # echo "External call stack"
+  funcname_pad+=3
+
+  for (( i=1; i<${#BASH_SOURCE[@]}; ++i)); do
+    printf "%${count_pad}s. %-${funcname_pad}s:%-${lineno_pad}s %s\n" "${i}" "${FUNCNAME[i]:+${FUNCNAME[i]}()}" "${BASH_LINENO[i-1]}" "${BASH_SOURCE[i]}" >&2
+  done
+
+  # Review: Is caller sometimes better than BASH_SOURCE[i]/BASH_LINENO[i-1]/FUNCNAME[i]?
   # i=0
-  # while (( i < ${#BASH_SOURCE[@]} )); do
-  #   echo "${BASH_LINENO[$i]} ${FUNCNAME[$i]} ${BASH_SOURCE[$i]}"
+  # while line="$(caller $i)"; do
+  #   stack+="$(sed $'s| |\t|g' <<< "${line}")"$'\n'
   #   ((++i))
   # done
+  # if command -v column &> /dev/null; then
+  #   column -c1 -s $'\t' -t >&2 <<< "${stack}"
+  # else
+  #   echo "${stack}" >&2
+  # fi
+  echo >&2
+  echo "$1: line $2: Returned $rv" >&2
 }
 trap 'print_error "${BASH_SOURCE[0]}" "${LINENO}"' ERR
 

--- a/linux/just_bashcov_functions.bsh
+++ b/linux/just_bashcov_functions.bsh
@@ -9,6 +9,7 @@ JUST_DEFAULTIFY_FUNCTIONS+=(bashcov_defaultify)
 JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 
 source "${VSI_COMMON_DIR}/linux/colors.bsh"
+source "${VSI_COMMON_DIR}/linux/elements.bsh"
 source "${VSI_COMMON_DIR}/linux/command_tools.bsh"
 
 #*# just/plugins/just_bashcov_functions
@@ -64,6 +65,25 @@ source "${VSI_COMMON_DIR}/linux/command_tools.bsh"
 #    end
 #**
 
+function _bashcov_docker_compose()
+{
+  local VSI_COMMON_UID="${JUST_PROJECT_PREFIX}_UID"
+  export VSI_COMMON_UID="${!VSI_COMMON_UID-1000}"
+  local VSI_COMMON_GIDS="${JUST_PROJECT_PREFIX}_GID"
+  export VSI_COMMON_GIDS="${!VSI_COMMON_GIDS-1000}"
+
+  local JUST_SETTINGSS
+  translate_just_settings "${BASH_COV_SOURCE}" /src
+  local JUST_SETTINGS
+  MIFS=/// join_a VSI_COMMON_JUST_SETTINGS ${JUST_SETTINGSS[@]+"${JUST_SETTINGSS[@]}"}
+  export VSI_COMMON_JUST_SETTINGS
+
+  local COMPOSE_FILE="${VSI_COMMON_DIR}/docker/vsi_common/docker-compose.yml"
+  export COMPOSE_FILE
+
+  Just-docker-compose ${@+"${@}"}
+}
+
 function bashcov_defaultify()
 {
   local id_project_cwd="${JUST_PROJECT_PREFIX}_CWD"
@@ -71,19 +91,6 @@ function bashcov_defaultify()
   # Export variables for docker-compose file
   local BASH_COV_SOURCE_DIR="${JUST_PROJECT_PREFIX}_BASHCOV_SOURCE_DIR"
   export BASH_COV_SOURCE_DIR="${!BASH_COV_SOURCE_DIR:-${!id_project_cwd}}"
-
-  local tmp="${JUST_PROJECT_PREFIX}_UID"
-  local VSI_COMMON_UID="${!tmp-1000}"
-  export VSI_COMMON_UID
-  tmp="${JUST_PROJECT_PREFIX}_GIDS"
-  local VSI_COMMON_GIDS="${!tmp-1000}"
-  export VSI_COMMON_GIDS
-
-  local JUST_SETTINGS="${JUST_PATH_ESC}/src/$(basename "${JUST_SETTINGS}")"
-  export JUST_SETTINGS
-
-  local COMPOSE_FILE="${VSI_COMMON_DIR}/docker/vsi_common/docker-compose.yml"
-  export COMPOSE_FILE
 
   arg=$1
   shift 1
@@ -101,7 +108,7 @@ function bashcov_defaultify()
         echo "${YELLOW}WARNING:${NC} ${BOLD}${BASH_COV_SOURCE_DIR}/coverage${NC} already exists" >&2
       fi
 
-      Just-docker-compose run bashcov bashcov ${@+"${@}"}
+      _bashcov_docker_compose run bashcov bashcov ${@+"${@}"}
       extra_args=$#
       ;;
     #**
@@ -114,7 +121,7 @@ function bashcov_defaultify()
     bashcov_multiple) # Run bashcov over multiple commands, each argument is executed \
                       # separately. There is no way to pass an argument to any of the \
                       # commands; use "just bashcov" for that.
-      Just-docker-compose run bashcov multiple ${@+"${@}"}
+      _bashcov_docker_compose run bashcov multiple ${@+"${@}"}
       extra_args=$#
       ;;
     #**
@@ -125,7 +132,7 @@ function bashcov_defaultify()
     # :Arguments: ``$1``... - Arguments passed to bashcov, one argument per call.
     #**
     bashcov_resume) # Resume running bashcov multiple
-      Just-docker-compose run bashcov resume ${@+"${@}"}
+      _bashcov_docker_compose run bashcov resume ${@+"${@}"}
       extra_args=$#
       ;;
     #**
@@ -134,7 +141,7 @@ function bashcov_defaultify()
     # Enter the bashcov container; for debugging
     #**
     bashcov_shell) # Enter the bashcov container
-      Just-docker-compose run bashcov bash
+      _bashcov_docker_compose run bashcov bash
       ;;
     #**
     # .. command:: bashcov_build
@@ -143,7 +150,7 @@ function bashcov_defaultify()
     #**
     bashcov_build) # Build bashcov docker image
       justify build recipes-auto "${VSI_COMMON_DIR}/docker/vsi_common/bashcov.Dockerfile"
-      Docker-compose build bashcov
+      _bashcov_docker_compose build bashcov
       ;;
     #**
     # .. command:: bashcov_open

--- a/linux/just_docker_functions.bsh
+++ b/linux/just_docker_functions.bsh
@@ -272,7 +272,7 @@ function get_docker_recipes()
   # / and . are the only valid character in an image name that needs regex escaping
   JUST_RECIPE_REPO="${JUST_RECIPE_REPO//./\\.}"
   # Need to escpae / for the first search
-  JUST_RECIPE_REPO="${JUST_RECIPE_REPO//"/"/\\/}"
+  JUST_RECIPE_REPO="${JUST_RECIPE_REPO////\\/}"
   sed -n${sed_flag_rE} \
           '/^ *[fF][rR][oO][mM] *'"${JUST_RECIPE_REPO}"':/{
             s/^ *[fF][rR][oO][mM]  *'"${JUST_RECIPE_REPO}"':([^ ]+).*/\1/

--- a/linux/just_docker_functions.bsh
+++ b/linux/just_docker_functions.bsh
@@ -272,7 +272,7 @@ function get_docker_recipes()
   # / and . are the only valid character in an image name that needs regex escaping
   JUST_RECIPE_REPO="${JUST_RECIPE_REPO//./\\.}"
   # Need to escpae / for the first search
-  JUST_RECIPE_REPO="${JUST_RECIPE_REPO////\\/}"
+  JUST_RECIPE_REPO="${JUST_RECIPE_REPO//"/"/\\/}"
   sed -n${sed_flag_rE} \
           '/^ *[fF][rR][oO][mM] *'"${JUST_RECIPE_REPO}"':/{
             s/^ *[fF][rR][oO][mM]  *'"${JUST_RECIPE_REPO}"':([^ ]+).*/\1/

--- a/linux/just_entrypoint.sh
+++ b/linux/just_entrypoint.sh
@@ -102,7 +102,6 @@ function load_just_settings()
 
   MIFS="${JUST_SETTINGS_SEPARATOR-///}" split_s JUST_SETTINGSS ${JUST_SETTINGS+"${JUST_SETTINGS}"}
   for just_settings in ${JUST_SETTINGSS[@]+"${JUST_SETTINGSS[@]}"}; do
-    echo "loading ${just_settings} ..." >&2
     source "${VSI_COMMON_DIR}/linux/just_env" "${just_settings}"
   done
 }

--- a/linux/just_entrypoint.sh
+++ b/linux/just_entrypoint.sh
@@ -88,8 +88,9 @@ set -eu
 : ${VSI_COMMON_DIR=/vsi}
 : ${DOCKER_USERNAME=user}
 
-if [ -d "/.singularity.d" ]; then
-  # Disable the special docker magic in singularity
+# Disable the special docker magic except in docker, no need in singularity
+# TODO: what does podman need?
+if [ ! -f "/.dockerenv" ]; then
   export ALREADY_RUN_ONCE=1
 fi
 

--- a/linux/just_entrypoint.sh
+++ b/linux/just_entrypoint.sh
@@ -94,6 +94,19 @@ if [ ! -f "/.dockerenv" ]; then
   export ALREADY_RUN_ONCE=1
 fi
 
+function load_just_settings()
+{
+  source "${VSI_COMMON_DIR}/linux/elements.bsh"
+  local JUST_SETTINGSS
+  local just_settings
+
+  MIFS="${JUST_SETTINGS_SEPARATOR-///}" split_s JUST_SETTINGSS ${JUST_SETTINGS+"${JUST_SETTINGS}"}
+  for just_settings in ${JUST_SETTINGSS[@]+"${JUST_SETTINGSS[@]}"}; do
+    echo "loading ${just_settings} ..." >&2
+    source "${VSI_COMMON_DIR}/linux/just_env" "${just_settings}"
+  done
+}
+
 if [ "${ALREADY_RUN_ONCE+set}" != "set" ]; then
 
   if [ -n "${BASH_SOURCE+set}" ]; then
@@ -105,7 +118,7 @@ if [ "${ALREADY_RUN_ONCE+set}" != "set" ]; then
   (
     # TODO: This will not source local.env if the src directory were on an nfs
     # Not sure ADDing the local files in the Dockerfile is the "right" solution
-    source "${VSI_COMMON_DIR}/linux/just_env" "${JUST_SETTINGS-/dev/null}"
+    load_just_settings
 
     # Sorted: https://serverfault.com/a/122743/321910
     for patch in "${JUST_ROOT_PATCH_DIR-/usr/local/share/just/root_run_patch}"/*; do
@@ -141,7 +154,7 @@ else
   run_just=0
 fi
 
-source "${VSI_COMMON_DIR}/linux/just_env" "${JUST_SETTINGS-/dev/null}"
+load_just_settings
 
 # Remove _DOCKER variables and undo // expansion
 source "${VSI_COMMON_DIR}/linux/just_entrypoint_user_functions.bsh"

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -274,7 +274,10 @@ function source_environment_files()
   local JUST_LOCAL_SETTINGS="${JUST_LOCAL_SETTINGS:-${project_dir}/local.env}"
   local JUST_LOCAL_SETTINGS_POST="${JUST_LOCAL_SETTINGS_POST:-${project_dir}/local_post.env}"
 
-  export JUST_SETTINGS="$(cd "${project_dir}"; pwd)/${1##*/}"
+  # In case there are multiple calls to source_environment files, the first one
+  # should be considered the JUST_SETTINGS.
+  : ${JUST_SETTINGS="$(cd "${project_dir}"; pwd)/${1##*/}"}
+  export JUST_SETTINGS
 
   if [ ! -e "${JUST_LOCAL_SETTINGS}" ]; then
     local perm

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -812,7 +812,9 @@ function defaultify()
   shift 1
   case "${arg}" in
     --dryrun|-n) # Dryrun flag. Used to echo instead of run commands
-      export DRYRUN="print_command just --wrap"
+      source "${VSI_COMMON_DIR}/linux/print_command"
+      export DRYRUN="print_command_env just --wrap"
+      print_command_save_env
       ;;
     --separator) # Commands that can take an undefined number of additional \
                  # arguments use the -- separator to start and end the extra \

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -48,6 +48,9 @@ function check_just_version()
     echo "since it was last updated (${last_just_version})" >&2
     # echo "You may want to source ${JUST_SETUP_SCRIPT-your setup script} again" >&2
     echo "You may want to run 'just_diff -- --' and see what's changed in just." >&2
+    if [ -z "${JUST_SETTINGS+set}" ]; then
+      local JUST_SETTINGS=/dev/null
+    fi
     echo "When you are done, update 'JUST_VERSION=${JUST_VERSION}' in '${JUST_SETTINGS//${JUST_SETTINGS_SEPARATOR}/"' or '"}'" >&2
     echo >&2
   fi

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -9,6 +9,8 @@ if [ -z ${VSI_COMMON_DIR+set} ]; then
   VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 fi
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
+source "${VSI_COMMON_DIR}/linux/elements.bsh"
+source "${VSI_COMMON_DIR}/linux/container_functions.bsh"
 
 #*# just/just_functions
 
@@ -45,9 +47,7 @@ function check_just_version()
     echo "since it was last updated (${last_just_version})" >&2
     # echo "You may want to source ${JUST_SETUP_SCRIPT-your setup script} again" >&2
     echo "You may want to run 'just_diff -- --' and see what's changed in just." >&2
-    if [ -n "${JUST_VERSION+set}" ]; then
-      echo "When you are done, update 'JUST_VERSION=${JUST_VERSION}' in '$(basename ${JUST_SETTINGS})'" >&2
-    fi
+    echo "When you are done, update 'JUST_VERSION=${JUST_VERSION}' in '${JUST_SETTINGS//${JUST_SETTINGS_SEPARATOR}/"' or '"}'" >&2
     echo >&2
   fi
 }
@@ -233,6 +233,15 @@ fi
 #
 #   source "${VSI_COMMON_DIR}/linux/just_env" "$(dirname "${BASH_SOURCE[0]}")"/'my_project.env'
 #
+# .. note::
+#   :envvar:`JUST_SETTINGS` supports multiple files using the :envvar:`JUST_SETTINGS_SEPARATOR` (default: ``///``). The user and developer should not need to come up with this themselves, as it is automatically generated, unless they are manually overriding it.
+#
+# .. envvar:: JUST_SETTINGS_SEPARATOR
+#
+# Separator used between filenames of :envvar:`JUST_SETTINGS`
+#**
+: ${JUST_SETTINGS_SEPARATOR=///}
+#**
 # .. function:: source_environment_files
 #
 # Convenience function for sourcing environments
@@ -274,9 +283,18 @@ function source_environment_files()
   local JUST_LOCAL_SETTINGS="${JUST_LOCAL_SETTINGS:-${project_dir}/local.env}"
   local JUST_LOCAL_SETTINGS_POST="${JUST_LOCAL_SETTINGS_POST:-${project_dir}/local_post.env}"
 
-  # In case there are multiple calls to source_environment files, the first one
-  # should be considered the JUST_SETTINGS.
-  : ${JUST_SETTINGS="$(cd "${project_dir}"; pwd)/${1##*/}"}
+  # In case there are multiple calls to source_environment files, create an
+  # exportable list of all the file names. Since arrays can't be exported
+  x="$(cd "${project_dir}"; pwd)/${1##*/}"
+
+  if [ -z "${JUST_SETTINGS+set}" ]; then
+    # First settings env file
+    JUST_SETTINGS="${x}"
+  else
+    # Additional settings env file
+    JUST_SETTINGS="${JUST_SETTINGS}${JUST_SETTINGS_SEPARATOR}${x}"
+  fi
+
   export JUST_SETTINGS
 
   if [ ! -e "${JUST_LOCAL_SETTINGS}" ]; then
@@ -347,8 +365,30 @@ function source_environment_files()
       export -fn $x
     fi
   done < <(declare -Fx)
+}
 
-  check_just_version
+#**
+# .. function:: translate_just_settings
+#
+# Convert :envvar:`JUST_SETTINGS` to an array: ``JUST_SETTINGSS``, translating the paths to another filesystem
+#
+# :Arguments: - ``$1`` - Directory name to be translated from
+#             - ``$2`` - Directory name to translate to
+# :Output: ``JUST_SETTINGSS`` - Array of the translated paths
+#
+# Useful for translating :envvar:`JUST_SETTINGS` from host to a container.
+#
+# .. seealso:
+#   :func:`container_functions.bsh-translate_paths`
+#**
+function translate_just_settings()
+{
+  JUST_SETTINGSS=()
+  MIFS="${JUST_SETTINGS_SEPARATOR}" split_s JUST_SETTINGSS ${JUST_SETTINGS+"${JUST_SETTINGS}"}
+  local i
+  for i in ${JUST_SETTINGSS[@]+"${!JUST_SETTINGSS[@]}"}; do
+    JUST_SETTINGSS[i]="$(translate_path "${JUST_SETTINGSS[i]}" ${@+"${@}"})"
+  done
 }
 
 #**

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -382,8 +382,8 @@ function source_environment_files()
 #
 # Useful for translating :envvar:`JUST_SETTINGS` from host to a container.
 #
-# .. seealso:
-#   :func:`container_functions.bsh-translate_paths`
+# .. seealso::
+#   :func:`container_functions.bsh translate_path`
 #**
 function translate_just_settings()
 {

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -833,7 +833,7 @@ function defaultify()
         current_version=$(juste --version | awk '{print $NF}')
         if command -v curl &> /dev/null; then
             url="$(curl -sL https://api.github.com/repos/visionsystemsinc/just/releases | \
-                  sed -En '/"browser_download_url": ".*juste"/{
+                  sed -${sed_flag_rE}n '/"browser_download_url": ".*juste"/{
                             s/ *"browser_download_url": "(.*juste)"/\1/;
                             p;
                             q;}')"
@@ -847,7 +847,7 @@ function defaultify()
             fi
         elif command -v wget &> /dev/null; then
             url="$(wget -qO- https://api.github.com/repos/visionsystemsinc/just/releases | \
-                  sed -En '/"browser_download_url": ".*juste"/{
+                  sed -${sed_flag_rE}n '/"browser_download_url": ".*juste"/{
                             s/ *"browser_download_url": "(.*juste)"/\1/;
                             p;
                             q;}')"

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -391,9 +391,8 @@ function auto_path_escape()
 #**
 # .. function:: set_temp_array
 #
-# :Arguments: ``$1`` - Name of array to check if it is already set
-#
-#             ``$2...`` - Default values of the array
+# :Arguments: - ``$1`` - Name of array to check if it is already set
+#             - ``$2...`` - Default values of the array
 #
 # :Output: ``JUST_TEMP_ARRAY`` - Destination for all the values set
 #

--- a/linux/just_functions.bsh
+++ b/linux/just_functions.bsh
@@ -36,6 +36,7 @@ source "${VSI_COMMON_DIR}/linux/findin"
 
 function check_just_version()
 {
+  # 0.2.0 is when JUST_VERSION was added to new_just as an env variable.
   local last_just_version=${JUST_VERSION-pre0.2.0}
   source "${VSI_COMMON_DIR}/linux/just_version.bsh"
   export JUST_VERSION

--- a/linux/just_git_functions.bsh
+++ b/linux/just_git_functions.bsh
@@ -309,7 +309,7 @@ git_reattach_heads()
   ${GIT} submodule foreach --recursive '
   if [ "$('${GIT}' rev-parse --abbrev-ref --symbolic-full-name HEAD)" = "HEAD" ]; then
     current_sha="$('${GIT}' rev-parse HEAD)"
-    branch_name="$('${GIT}' show-ref --heads | sed -En "/^${current_sha} .*/{ s|.*/(.*)|\1|; p; q}")"
+    branch_name="$('${GIT}' show-ref --heads | sed -${sed_flag_rE}n "/^${current_sha} .*/{ s|.*/(.*)|\1|; p; q}")"
     if [ "${branch_name}" != "" ]; then
       '${GIT}' checkout "${branch_name}"
     fi

--- a/linux/just_makeself_functions.bsh
+++ b/linux/just_makeself_functions.bsh
@@ -41,8 +41,6 @@ source "${VSI_COMMON_DIR}/linux/elements.bsh"
 
 function _makeself_docker_compose()
 {
-  local id_project_cwd="${JUST_PROJECT_PREFIX}_CWD"
-
   #**
   # Most environment variables try to auto determine reasonable defaults, but they can always be overridden and customized.
   #
@@ -109,6 +107,7 @@ function makeself_defaultify()
   local PROJECT_CWD="${JUST_PROJECT_PREFIX}_CWD"
   PROJECT_CWD="${!PROJECT_CWD}"
 
+  local id_project_cwd="${JUST_PROJECT_PREFIX}_CWD"
   local MAKESELF_SOURCE_DIR="${JUST_PROJECT_PREFIX}_MAKESELF_SRC_DIR"
   export MAKESELF_SOURCE_DIR="${!MAKESELF_SOURCE_DIR:-${!id_project_cwd}}"
 
@@ -131,7 +130,7 @@ function makeself_defaultify()
         source "${VSI_COMMON_DIR}/linux/colors.bsh"
         echo "${RED}ERROR${NC}: You should use your own Justfile to build \"${MAKESELF_IMAGE}\"" >&2
         local JUST_IGNORE_EXIT_CODES=1
-        false
+        return 1
       fi
       justify build recipes-auto "${VSI_COMMON_DIR}/docker/vsi_common/makeself.Dockerfile"
       _makeself_docker_compose build makeself

--- a/linux/just_makeself_functions.bsh
+++ b/linux/just_makeself_functions.bsh
@@ -82,7 +82,10 @@ function _makeself_docker_compose()
   #
   # Set values should start with ``${JUST_PATH_ESC}/`` and must be in the container's file system, not hosts. That means it depends on how :env:`MAKESELF_SOURCE_DIR` is mounted.
   #**
-  local VSI_COMMON_JUST_SETTINGS="${VSI_COMMON_JUST_SETTINGS-"${JUST_PATH_ESC}/src/$(basename "${JUST_SETTINGS}")"}"
+  local JUST_SETTINGSS
+  translate_just_settings "${PYINSTALLER_SOURCE_DIR}" /src
+  local VSI_COMMON_JUST_SETTINGS
+  MIFS=/// join_a VSI_COMMON_JUST_SETTINGS ${JUST_SETTINGSS[@]+"${JUST_SETTINGSS[@]}"}
   export VSI_COMMON_JUST_SETTINGS
 
   Just-docker-compose \

--- a/linux/just_makeself_functions.bsh
+++ b/linux/just_makeself_functions.bsh
@@ -23,6 +23,25 @@ source "${VSI_COMMON_DIR}/linux/compat.bsh"
 # .. file:: just_makeself_functions.bsh
 #**
 
+function _makeself_docker_compose()
+{
+  local id_project_cwd="${JUST_PROJECT_PREFIX}_CWD"
+
+  local MAKESELF_DIST_DIR="${JUST_PROJECT_PREFIX}_MAKESELF_DIST_DIR"
+  export MAKESELF_DIST_DIR="${!MAKESELF_DIST_DIR:-${MAKESELF_SOURCE_DIR}/dist}"
+
+  local VSI_COMMON_UID="${JUST_PROJECT_PREFIX}_UID"
+  export VSI_COMMON_UID="${!VSI_COMMON_UID-1000}"
+  local VSI_COMMON_GIDS="${JUST_PROJECT_PREFIX}_GID"
+  export VSI_COMMON_GIDS="${!VSI_COMMON_GIDS-1000}"
+
+  local VSI_COMMON_JUST_SETTINGS="${VSI_COMMON_JUST_SETTINGS-"${JUST_PATH_ESC}/src/$(basename "${JUST_SETTINGS}")"}"
+  export VSI_COMMON_JUST_SETTINGS
+
+  Just-docker-compose \
+    -f "${VSI_COMMON_DIR}/docker/vsi_common/docker-compose.yml" ${@+"${@}"}
+}
+
 #**
 # .. function:: makeself_defaultify
 #**
@@ -38,35 +57,20 @@ function makeself_defaultify()
   local PROJECT_CWD="${JUST_PROJECT_PREFIX}_CWD"
   PROJECT_CWD="${!PROJECT_CWD}"
 
+  local MAKESELF_SOURCE_DIR="${JUST_PROJECT_PREFIX}_MAKESELF_SRC_DIR"
+  export MAKESELF_SOURCE_DIR="${!MAKESELF_SOURCE_DIR:-${!id_project_cwd}}"
+
   case $arg in
-    #**
-    # .. command:: makeself_setup-local
-    #
-    # Download and install makeself locally in Project's CWD/build/makeself
-    #**
-    makeself_setup-local) # Setup makeself locally
-      mkdir -p "${PROJECT_CWD}/build/makeself"
-      pushd "${PROJECT_CWD}/build/makeself"
-        curl -LO "https://github.com/megastep/makeself/archive/${JUST_MAKESELF_VERSION}/makeself.tar.gz"
-        tar xf makeself.tar.gz --strip-components=1
-        rm makeself.tar.gz
+    makeself_build) # Build the makeself docker images
+      if [ "${MAKESELF_IMAGE-vsiri/makeself:latest}" != "vsiri/makeself:latest" ]; then
+        source "${VSI_COMMON_DIR}/linux/colors.bsh"
+        echo "${RED}ERROR${NC}: You should use your own Justfile to build \"${MAKESELF_IMAGE}\"" >&2
+        false
+      fi
+      justify build recipes-auto "${VSI_COMMON_DIR}/docker/vsi_common/makeself.Dockerfile"
+      _makeself_docker_compose build makeself
+      ;;
 
-        # Disable makeself's argument parser (so all arguments go to just by
-        # default) and make quiet the default
-        sed '1,/^while true/s|^while true|while \\${MAKESELF_PARSE-false}|; 1,/^quiet="n"/s|^quiet="n"|quiet="y"|' \
-            "${PROJECT_CWD}/build/makeself/makeself-header.sh" > "${PROJECT_CWD}/build/makeself/makeself-header_just.sh"
-
-        # Add sourcing local.env to the header, to cover corner cases like needing to to change TMPDIR
-        sed -${sed_flag_i} '2r /dev/stdin' "${PROJECT_CWD}/build/makeself/makeself-header_just.sh" < \
-          <(echo 'for check_dir in "\`dirname \$0\`" "\${PWD}"; do'
-            echo '  if test -f "\${check_dir}/local.env"; then'
-            echo '    set -a'
-            echo '    source "\${check_dir}/local.env"'
-            echo '    set +a'
-            echo '  fi'
-            echo 'done')
-      popd &> /dev/null
-    ;;
     #**
     # .. command:: makeself_just-project-locally
     #
@@ -86,65 +90,118 @@ function makeself_defaultify()
     #
     # All calls are made from the root repo directory (``.``), and the output will be in ``./dist``
     #**
-    makeself_just-project-locally) # Make a self extracting executable for a just \
-        # project, locally. Add "--tests" flag to include VSI Common's unit tests. \
-        # Unit tests can be run via: just --wrap bash -c 'cd ${VSI_COMMON_DIR}; just test'
-      local include_unit_tests
-      parse_args extra_args --tests include_unit_tests -- ${@+"${@}"}
-      if [ "${include_unit_tests}" = "0" ]; then
-        include_unit_tests='--exclude=test-*.bsh'
-      else
-        include_unit_tests=""
-      fi
-
-      if [ ! -f "${PROJECT_CWD}/build/makeself/makeself.sh" ]; then
-        justify makeself setup-local
-      fi
-
-      # Ideally, this should be the App's CWD, since just projects cd into their
-      # Project CWD. We want the dist dir relative to what ever dir we are in now.
-      mkdir -p "./dist"
-
-      # Review: Does the transform below handle (multiple) spaces in the path correctly???
+    makeself_just-project) # Makeself
       local vsi_common_rel="$(relative_path "${VSI_COMMON_DIR}" .)" # Does not start with ./
 
-      # Start by adding just vsi_common, and transform it to have the same relative path as vsi_common_dir really has.
-      # NOTE: This will only work on gnu-tar
-      "${PROJECT_CWD}/build/makeself/makeself.sh" \
-          --header "${PROJECT_CWD}/build/makeself/makeself-header_just.sh" \
-          --noprogress --nomd5 --nocrc --nox11 --keep-umask \
-          --tar-extra "--show-transformed --transform s|^\./|./${vsi_common_rel}/| ${include_unit_tests} --exclude=./docs --exclude=.git --exclude=*.egg-info" \
-          "${VSI_COMMON_DIR}" ./dist/just just_label "./${vsi_common_rel}/freeze/just_wrapper"
-      # You can't put quotes in tar-extra apparently, it'll screw things up.
+      _makeself_docker_compose run makeself just-project "${vsi_common_rel}"
       ;;
     #**
-    # .. command:: makeself_add-files-locally
+    # .. command:: makeself_add-files
     #
     # :Arguments: * ``$1`` - Directory to add
     #             * ``[$2]`` - Extra tar flags to be passed to makeself/tar
     #
-    # After the initial just executable is created by calling :command:`makeself_just-project-locally`, project directories are called using :command:`makeself_add-files-locally`
+    # After the initial just executable is created by calling :command:`makeself_just-project`, project directories are added using :command:`makeself_add-files`
     #
-    # The second argument should be used to exclude files, and in complicated situations, set up path transforms.
-    # * Simple: ``${project_dir}/external/vsi_common``
-    # * Complicated: ``${project_dir}/external/${other_project}/external/vsi_common``
+    # The second argument can be used to exclude files, and in complicated situations, set up path transforms.
+    # * Simple case: ``${project_dir}/external/vsi_common``
+    # * Complicated case: ``${project_dir}/external/${other_project}/external/vsi_common``
+    #
+    # .. rubric:: Example
+    #
+    # .. code-block:: bash
+    #
+    #   makeself) # Simple case
+    #     justify makeself just-project external/vsi_common
+    #     justify makeself add-files "${MY_PROJECT_CWD}"
     #
     # .. seealso::
-    #   :command:`makeself_just-project-locally`
+    #   :command:`makeself_just-project`
     #**
-    makeself_add-files-locally) # Append files to a makeself executable
-      MAKESELF_PARSE=true "${PROJECT_CWD}/build/makeself/makeself.sh" \
-          --header "${PROJECT_CWD}/build/makeself/makeself-header_just.sh" \
-          --noprogress --nomd5 --nocrc --nox11 --keep-umask \
-          --tar-extra "${2-}" --append \
-          "${1}" ./dist/just
-
+    makeself_add-files) # Append files to a makeself executable
+      export MAKESELF_SOURCE_DIR="${1}"
       if [ "${2+set}" ]; then
         extra_args=2
       else
         extra_args=1
       fi
+      shift 1
+
+      _makeself_docker_compose run makeself add-files ${@+"${@}"}
       ;;
+
+    ##**
+    ## .. command:: makeself_setup-local
+    ##
+    ## Download and install makeself locally in Project's CWD/build/makeself
+    ##**
+    ## makeself_setup-local) # Setup makeself locally
+    #   mkdir -p "${PROJECT_CWD}/build/makeself"
+    #   pushd "${PROJECT_CWD}/build/makeself"
+    #     curl -LO "https://github.com/megastep/makeself/archive/${JUST_MAKESELF_VERSION}/makeself.tar.gz"
+    #     tar xf makeself.tar.gz --strip-components=1
+    #     rm makeself.tar.gz
+
+    #     # Disable makeself's argument parser (so all arguments go to just by
+    #     # default) and make quiet the default
+    #     sed '1,/^while true/s|^while true|while \\${MAKESELF_PARSE-false}|; 1,/^quiet="n"/s|^quiet="n"|quiet="y"|' \
+    #         "${PROJECT_CWD}/build/makeself/makeself-header.sh" > "${PROJECT_CWD}/build/makeself/makeself-header_just.sh"
+
+    #     # Add sourcing local.env to the header, to cover corner cases like needing to to change TMPDIR
+    #     sed -${sed_flag_i} '2r /dev/stdin' "${PROJECT_CWD}/build/makeself/makeself-header_just.sh" < \
+    #       <(echo 'for check_dir in "\`dirname \$0\`" "\${PWD}"; do'
+    #         echo '  if test -f "\${check_dir}/local.env"; then'
+    #         echo '    set -a'
+    #         echo '    source "\${check_dir}/local.env"'
+    #         echo '    set +a'
+    #         echo '  fi'
+    #         echo 'done')
+    #   popd &> /dev/null
+    # ;;
+    ## makeself_just-project-locally) # Make a self extracting executable for a just \
+    #     # project, locally. Add "--tests" flag to include VSI Common's unit tests. \
+    #     # Unit tests can be run via: just --wrap bash -c 'cd ${VSI_COMMON_DIR}; just test'
+    #   local include_unit_tests
+    #   parse_args extra_args --tests include_unit_tests -- ${@+"${@}"}
+    #   if [ "${include_unit_tests}" = "0" ]; then
+    #     include_unit_tests='--exclude=test-*.bsh'
+    #   else
+    #     include_unit_tests=""
+    #   fi
+
+    #   if [ ! -f "${PROJECT_CWD}/build/makeself/makeself.sh" ]; then
+    #     justify makeself setup-local
+    #   fi
+
+    #   # Ideally, this should be the App's CWD, since just projects cd into their
+    #   # Project CWD. We want the dist dir relative to what ever dir we are in now.
+    #   mkdir -p "./dist"
+
+    #   # Review: Does the transform below handle (multiple) spaces in the path correctly???
+    #   local vsi_common_rel="$(relative_path "${VSI_COMMON_DIR}" .)" # Does not start with ./
+
+    #   # Start by adding just vsi_common, and transform it to have the same relative path as vsi_common_dir really has.
+    #   # NOTE: This will only work on gnu-tar
+    #   "${PROJECT_CWD}/build/makeself/makeself.sh" \
+    #       --header "${PROJECT_CWD}/build/makeself/makeself-header_just.sh" \
+    #       --noprogress --nomd5 --nocrc --nox11 --keep-umask \
+    #       --tar-extra "--show-transformed --transform s|^\./|./${vsi_common_rel}/| ${include_unit_tests} --exclude=./docs --exclude=.git --exclude=*.egg-info" \
+    #       "${VSI_COMMON_DIR}" ./dist/just just_label "./${vsi_common_rel}/freeze/just_wrapper"
+    #   # You can't put quotes in tar-extra apparently, it'll screw things up.
+    #   ;;
+    ## makeself_add-files-locally) # Append files to a makeself executable
+    #   MAKESELF_PARSE=true "${PROJECT_CWD}/build/makeself/makeself.sh" \
+    #       --header "${PROJECT_CWD}/build/makeself/makeself-header_just.sh" \
+    #       --noprogress --nomd5 --nocrc --nox11 --keep-umask \
+    #       --tar-extra "${2-}" --append \
+    #       "${1}" ./dist/just
+
+    #   if [ "${2+set}" ]; then
+    #     extra_args=2
+    #   else
+    #     extra_args=1
+    #   fi
+    #   ;;
     *)
       plugin_not_found=1
       ;;

--- a/linux/just_makeself_functions.bsh
+++ b/linux/just_makeself_functions.bsh
@@ -10,6 +10,7 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/command_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
+source "${VSI_COMMON_DIR}/linux/elements.bsh"
 
 #*# just/plugins/just_makeself_functions
 

--- a/linux/just_makeself_functions.bsh
+++ b/linux/just_makeself_functions.bsh
@@ -20,6 +20,21 @@ source "${VSI_COMMON_DIR}/linux/compat.bsh"
 #
 # .. default-domain:: bash
 #
+# A plugin for creating a `makeself executable <https://makeself.io/>`_, using a docker container.
+#
+# The features of this plugin are focused on putting :file:`just` in a self sufficient executable, for deployment of just and just projects.
+#
+# - A just deploying, referred to as ``juste`` (``just`` Executable) allows just to be run without the vsi_common submodule in a project. However, it does require you have ``juste`` installed/available on every machine you need it on. No other dependencies are needed, other than ``bash`` and common linux core tools like ``tar``, ``awk`` and ``sed``.
+# - A "just project executable" is similar to ``juste``, but with one significant difference. It includes all the files of a project with it. This means that the repository for a project is no longer needed to run the project. This makes for a very easy to run deployment strategy. Again, the only dependencies are ``bash``, ``tar``, ``awk``, ``sed``, etc...
+#
+# .. note::
+#
+#   Large files should not includes in just project executables. Makeself (quietly) extract the entire contents of the project every time it is run. While this works with in reason, once you start including MBs of files, this time will eventually become noticeable.
+#
+# The executables made by this plugin put the makeself executables in ``quiet`` modes, and the normal argument parsing of makeself is also disabled. This creates a smoother experience for the end user.
+#
+# Makeself argument parsing can be enabled by exporting ``MAKESELF_PARSE=true``. This can be useful if you ever want to permanently extract the executable, and use the expanded version.
+#
 # .. file:: just_makeself_functions.bsh
 #**
 
@@ -27,14 +42,46 @@ function _makeself_docker_compose()
 {
   local id_project_cwd="${JUST_PROJECT_PREFIX}_CWD"
 
+  #**
+  # Most environment variables try to auto determine reasonable defaults, but they can always be overridden and customized.
+  #
+  # .. env:: MAKESELF_NAME
+  #
+  # The name of the makeself executable written to :env:`MAKESELF_DIST_DIR`. Default: ``just``
+  #
+  # .. env:: MAKESELF_LABEL
+  #
+  # The makeself internal "label". Not really relevant, as quiet mode is enforced. Default: just_label.
+  #
+  # .. env:: MAKESELF_SOURCE_DIR
+  #
+  # The input directory of the files used to add files to the makeself executable. Default: ``${JUST_PROJECT_PREFIX}_MAKESELF_SRC_DIR`` or else ``${JUST_PROJECT_PREFIX}_CWD``.
+  #
+  # .. env:: MAKESELF_DIST_DIR
+  #
+  # The output directory for the makeself distribution. Default: ``${MAKESELF_SOURCE_DIR}/dist``
+  #**
   local MAKESELF_DIST_DIR="${JUST_PROJECT_PREFIX}_MAKESELF_DIST_DIR"
   export MAKESELF_DIST_DIR="${!MAKESELF_DIST_DIR:-${MAKESELF_SOURCE_DIR}/dist}"
 
+  #**
+  # .. env:: VSI_COMMON_UID
+  # .. env:: VSI_COMMON_GIDS
+  #
+  # Used to determine user id in container. Should be automatically set by Project's ``${JUST_PROJECT_PREFIX}_UID`` and ``${JUST_PROJECT_PREFIX}_GID``, or else uses ``1000``.
+  #**
   local VSI_COMMON_UID="${JUST_PROJECT_PREFIX}_UID"
   export VSI_COMMON_UID="${!VSI_COMMON_UID-1000}"
-  local VSI_COMMON_GIDS="${JUST_PROJECT_PREFIX}_GID"
+  local VSI_COMMON_GIDS="${JUST_PROJECT_PREFIX}_GID" # The GIDS vs GID is not a typo
   export VSI_COMMON_GIDS="${!VSI_COMMON_GIDS-1000}"
 
+  #**
+  # .. env:: VSI_COMMON_JUST_SETTINGS
+  #
+  # In more complicated projects, the :envvar:`JUST_SETTINGS` variable cannot be auto determined, and must be set via :env:`VSI_COMMON_JUST_SETTINGS`.
+  #
+  # Set values should start with ``${JUST_PATH_ESC}/`` and must be in the container's file system, not hosts. That means it depends on how :env:`MAKESELF_SOURCE_DIR` is mounted.
+  #**
   local VSI_COMMON_JUST_SETTINGS="${VSI_COMMON_JUST_SETTINGS-"${JUST_PATH_ESC}/src/$(basename "${JUST_SETTINGS}")"}"
   export VSI_COMMON_JUST_SETTINGS
 
@@ -53,6 +100,7 @@ function makeself_defaultify()
   # Must be version after 2.4.2, I need a working ARCHIVE_DIR and append.
   # https://github.com/megastep/makeself/issues/213
   # https://github.com/megastep/makeself/issues/216
+  # https://github.com/megastep/makeself/issues/219
   local JUST_MAKESELF_VERSION=${JUST_MAKESELF_VERSION:-d9a61e67803f95c4d91050932347811a00aa38e9}
   local PROJECT_CWD="${JUST_PROJECT_PREFIX}_CWD"
   PROJECT_CWD="${!PROJECT_CWD}"
@@ -61,6 +109,11 @@ function makeself_defaultify()
   export MAKESELF_SOURCE_DIR="${!MAKESELF_SOURCE_DIR:-${!id_project_cwd}}"
 
   case $arg in
+    #**
+    # .. command:: makeself_build
+    #
+    # Build the makeself docker images.
+    #**
     makeself_build) # Build the makeself docker images
       if [ "${MAKESELF_IMAGE-vsiri/makeself:latest}" != "vsiri/makeself:latest" ]; then
         source "${VSI_COMMON_DIR}/linux/colors.bsh"
@@ -72,12 +125,12 @@ function makeself_defaultify()
       ;;
 
     #**
-    # .. command:: makeself_just-project-locally
+    # .. command:: makeself_just-project
     #
     # :Arguments: * ``[--tests]`` - Include unit tests. Calling this from another project is tricky though. For example, ``./just --wrap bash -c 'JUSTFILE="${VSI_COMMON_DIR}/Justfile" just test'``
-    # :Uses: - ``tar`` - Only works with GNU Tar on the path.
+    # :Uses: - ``tar`` - Only works using GNU Tar.
     #
-    # Creates a just project executable using makeself. Should be called from the main project's just project, otherwise directory paths will not line up. After the initial executable is added, called to :command:`makeself_add-files-locally` should be made to add project files. For example:
+    # Creates a just project executable using makeself. Should be called from the main project's just project, otherwise directory paths will be auto determined correctly. After the initial executable is added, called to :command:`makeself_add-files` should be made to add project files. For example:
     #
     # * Project: ``foo`` in ``.``
     # * Submodule: ``bar`` in ``./external/bar``
@@ -88,9 +141,12 @@ function makeself_defaultify()
     # #. Call: ``makeself_add-files-locally ./external/bar '"--show-transformed --transform s|^\./|./${bar_rel}/| --exclude=.git --exclude=./docs --exclude=./external --exclude=./tests"'`` in ``.``
     # #. Call: ``makeself_add-files-locally ./ '"--exclude=.git --exclude=./docs --exclude=./external/bar --exclude=./tests"'`` in ``.``
     #
-    # All calls are made from the root repo directory (``.``), and the output will be in ``./dist``
+    # All calls are made from the root repo directory (``.``)
+    #
+    # .. seealso::
+    #   :cmd:`makeself_add-files`
     #**
-    makeself_just-project) # Makeself
+    makeself_just-project) # Run makeself to create a just project executable
       local vsi_common_rel="$(relative_path "${VSI_COMMON_DIR}" .)" # Does not start with ./
 
       _makeself_docker_compose run makeself just-project "${vsi_common_rel}"
@@ -107,16 +163,46 @@ function makeself_defaultify()
     # * Simple case: ``${project_dir}/external/vsi_common``
     # * Complicated case: ``${project_dir}/external/${other_project}/external/vsi_common``
     #
-    # .. rubric:: Example
+    # .. rubric:: Example just targets
     #
     # .. code-block:: bash
     #
     #   makeself) # Simple case
-    #     justify makeself just-project external/vsi_common
-    #     justify makeself add-files "${MY_PROJECT_CWD}"
+    #     justify makeself just-project
+    #     justify makeself add-files "${MY_PROJECT_CWD}" "--exclude .git --exclude ./external/vsi_common"
+    #     ;;
+    #
+    #   makeself_complicated) # Complicated case
+    #     # First step is the same, it uses your PWD do determing the "main dir",
+    #     # so it can determine the relative path of VSI_COMMON_DIR
+    #     justify makeself just-project
+    #
+    #     # The "other project" has a different default settings file.
+    #     # Tell the makeself plugin what it is
+    #     local VSI_COMMON_JUST_SETTINGS=/src/other_project.env
+    #     # Now determine the other project relative path (again, to pwd aka ".")
+    #     # This is too variable to be automated
+    #     local other_project_rel="$(relative_path "${OTHER_PROJECT_CWD}" .)"
+    #     # Add the other project files
+    #     justify makeself add-files "${OTHER_PROJECT_CWD}" \
+    #       "--show-transformed --transform s|^\./|./${other_project_rel}/| --exclude=.git --exclude=./external/vsi_common"
+    #       # The above transform, makes the files in /src/ appear to be in the
+    #       # "relative" path, determined above
+    #
+    #     # Finally add the "main" project files.
+    #     justify makeself add-files "${MY_PROJECT_CWD}" "--exclude .git --exclude ./external/other_project"
+    #
+    #     # A neat trick to "exclude all subdirectories except those you want to include"
+    #     # justify makeself add-files "${MY_PROJECT_CWD}" \
+    #     #   "$(find . -mindepth 1 -maxdepth 1 -type d -not -name keep_dir_1 \
+    #     #                                             -not -name keep_dir_2 \
+    #     #                                             -not -name keep_dir_3 -printf ' --exclude %p')"
+    #     # Note: This also includes all the files in the root dir too. This can
+    #     # be customized you your heart's content.
+    #     ;;
     #
     # .. seealso::
-    #   :command:`makeself_just-project`
+    #   :cmd:`makeself_just-project`
     #**
     makeself_add-files) # Append files to a makeself executable
       export MAKESELF_SOURCE_DIR="${1}"

--- a/linux/just_makeself_functions.bsh
+++ b/linux/just_makeself_functions.bsh
@@ -113,11 +113,20 @@ function makeself_defaultify()
     # .. command:: makeself_build
     #
     # Build the makeself docker images.
+    #
+    # .. env:: MAKESELF_IMAGE
+    #
+    # The name of the makeself docker image. Default: vsiri/makeself:latest
+    #
+    # .. env:: MAKESELF_VERSION
+    #
+    # The branch/tag name or SHA of makeself used. Requires version 2.4.3 or newer.
     #**
     makeself_build) # Build the makeself docker images
       if [ "${MAKESELF_IMAGE-vsiri/makeself:latest}" != "vsiri/makeself:latest" ]; then
         source "${VSI_COMMON_DIR}/linux/colors.bsh"
         echo "${RED}ERROR${NC}: You should use your own Justfile to build \"${MAKESELF_IMAGE}\"" >&2
+        local JUST_IGNORE_EXIT_CODES=1
         false
       fi
       justify build recipes-auto "${VSI_COMMON_DIR}/docker/vsi_common/makeself.Dockerfile"

--- a/linux/just_makeself_functions.bsh
+++ b/linux/just_makeself_functions.bsh
@@ -9,6 +9,7 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 
 source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/command_tools.bsh"
+source "${VSI_COMMON_DIR}/linux/compat.bsh"
 
 #*# just/plugins/just_makeself_functions
 
@@ -54,6 +55,16 @@ function makeself_defaultify()
         # default) and make quiet the default
         sed '1,/^while true/s|^while true|while \\${MAKESELF_PARSE-false}|; 1,/^quiet="n"/s|^quiet="n"|quiet="y"|' \
             "${PROJECT_CWD}/build/makeself/makeself-header.sh" > "${PROJECT_CWD}/build/makeself/makeself-header_just.sh"
+
+        # Add sourcing local.env to the header, to cover corner cases like needing to to change TMPDIR
+        sed -${sed_flag_i} '2r /dev/stdin' "${PROJECT_CWD}/build/makeself/makeself-header_just.sh" < \
+          <(echo 'for check_dir in "\`dirname \$0\`" "\${PWD}"; do'
+            echo '  if test -f "\${check_dir}/local.env"; then'
+            echo '    set -a'
+            echo '    source "\${check_dir}/local.env"'
+            echo '    set +a'
+            echo '  fi'
+            echo 'done')
       popd &> /dev/null
     ;;
     #**

--- a/linux/just_pyinstaller_functions.bsh
+++ b/linux/just_pyinstaller_functions.bsh
@@ -1,0 +1,137 @@
+#!/usr/bin/env false bash
+
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return 0
+fi
+
+JUST_DEFAULTIFY_FUNCTIONS+=(pyinstaller_defaultify)
+JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
+
+source "${VSI_COMMON_DIR}/linux/command_tools.bsh"
+source "${VSI_COMMON_DIR}/linux/elements.bsh"
+source "${VSI_COMMON_DIR}/linux/set_flags.bsh"
+source "${VSI_COMMON_DIR}/linux/ask_question"
+source "${VSI_COMMON_DIR}/linux/just_docker_functions.bsh"
+
+#*# just/plugins/just_pyinstaller_functions
+
+#**
+# .. default-domain:: bash
+#
+#
+#====================================
+# J.U.S.T. PyInstaller Docs Functions
+# ===================================
+#
+# .. file:: just_pyinstaller_functions.bsh
+#
+# Plugin for building PyInstaller executables for a python project
+#**
+
+
+
+function _pyinstaller_docker_compose()
+{
+  local id_project_cwd="${JUST_PROJECT_PREFIX}_CWD"
+
+  local PYINSTALLER_SOURCE_DIR="${JUST_PROJECT_PREFIX}_PYINSTALLER_SRC_DIR"
+  export PYINSTALLER_SOURCE_DIR="${!PYINSTALLER_SOURCE_DIR:-${!id_project_cwd}}"
+  local PYINSTALLER_DIST_DIR="${JUST_PROJECT_PREFIX}_PYINSTALLER_DIST_DIR"
+  export PYINSTALLER_DIST_DIR="${!PYINSTALLER_DIST_DIR:-${!id_project_cwd}}"
+
+  local VSI_COMMON_UID="${JUST_PROJECT_PREFIX}_UID"
+  export VSI_COMMON_UID="${!VSI_COMMON_UID-1000}"
+  local VSI_COMMON_GIDS="${JUST_PROJECT_PREFIX}_GID"
+  export VSI_COMMON_GIDS="${!VSI_COMMON_GIDS-1000}"
+
+  # local VSI_COMMON_JUST_SETTINGS="${VSI_COMMON_JUST_SETTINGS-"${JUST_PATH_ESC}/src/$(basename "${JUST_SETTINGS}")"}"
+  local JUST_SETTINGSS
+  translate_just_settings "${PYINSTALLER_SOURCE_DIR}" /src
+  local VSI_COMMON_JUST_SETTINGS
+  MIFS=/// join_a VSI_COMMON_JUST_SETTINGS ${JUST_SETTINGSS[@]+"${JUST_SETTINGSS[@]}"}
+  export VSI_COMMON_JUST_SETTINGS
+
+  Just-docker-compose \
+      -f "${VSI_COMMON_DIR}/docker/vsi_common/docker-compose.yml" ${@+"${@}"}
+}
+
+#**
+# -----------------------------
+# J.U.S.T. python freeze plugin
+# -----------------------------
+#
+#**
+function pyinstaller_defaultify()
+{
+  arg=$1
+  shift 1
+  case $arg in
+    # sphinx) # Guided "just" make sphinx documents happen (build => setup => compile)
+    #   justify sphinx build
+    #   if [ ! -d "${docs_dir}" ]; then
+    #     justify sphinx setup
+    #   fi
+    #   justify sphinx compile
+    #   ;;
+   pyinstaller_build) # Build the pyinstaller docker images
+      if [ "${PYINSTALLER_IMAGE-vsiri/pyinstaller:latest}" != "vsiri/pyinstaller:latest" ]; then
+        source "${VSI_COMMON_DIR}/linux/colors.bsh"
+        echo "${RED}ERROR${NC}: You should use your own Justfile to build \"${PYINSTALLER_IMAGE}\"" >&2
+        local JUST_IGNORE_EXIT_CODES=1
+        false
+      fi
+      justify build recipes-auto "${VSI_COMMON_DIR}/docker/vsi_common/pyinstaller.Dockerfile"
+      _pyinstaller_docker_compose build pyinstaller
+      ;;
+
+    pyinstaller_pipenv-update) # Update PyInstaller Pipenv file
+      # Create a new volume
+      local volume="$(docker volume create)"
+      local rv=0
+      # Shadow /venv so it copies it. This makes chowning thousands of times faster... or something like that.
+      # extra_pyinstaller_arguments=(-v "${volume}:/venv")
+      # justify sphinx compile nopipenv bash -c "
+      _pyinstaller_docker_compose run -v "${volume}:/venv" pyinstaller nopipenv bash -c "
+          echo 'Owning virtual env'
+          sudo chown -R user: /venv
+          pipenv lock" || rv=$?
+      docker volume rm "${volume}"
+      if [ "${rv}" != 0 ]; then return "${rv}"; fi
+      justify pyinstaller build
+      ;;
+
+    # sphinx_setup) # Setup a new sphinx project
+    #   mkdir -p "${docs_dir}"
+    #   _sphinx_docker_compose run --rm \
+    #       sphinx bash -c "cd /docs; sphinx-quickstart"
+    #   ;;
+    pyinstaller_shell) # Enter the pyinstaller container
+      echo "Run 'just pyinstaller ...' to run pyinstaller"
+      _pyinstaller_docker_compose run pyinstaller bash
+      ;;
+    pyinstaller_run) # Compile sphinx documents
+      _pyinstaller_docker_compose run \
+          ${extra_sphinx_arguments[@]+"${extra_sphinx_arguments[@]}"} \
+          pyinstaller ${@+"${@}"}
+      extra_args+=$#
+      ;;
+    pyinstaller_clean) # Cleans doc directory
+      justify docker-compose clean pyinstaller-build
+      ;;
+    *)
+      plugin_not_found=1
+      ;;
+  esac
+  return 0
+}
+
+#**
+# Advanced Debugging
+# ------------------
+#
+# To run any custom command (like ``bash``), in the docs docker environment, additional arguments can be given to the :cmd:`sphinx_compile` command, and that will be run instead of the docs script. For example:
+#
+# .. code-block:: bash
+#
+#   just docs compile bash``
+#**

--- a/linux/just_pyinstaller_functions.bsh
+++ b/linux/just_pyinstaller_functions.bsh
@@ -1,137 +1,137 @@
 #!/usr/bin/env false bash
 
-if [[ $- != *i* ]]; then
-  source_once &> /dev/null && return 0
-fi
+# I couldn't get this right
+# TODO: Finish this
 
-JUST_DEFAULTIFY_FUNCTIONS+=(pyinstaller_defaultify)
-JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
+# if [[ $- != *i* ]]; then
+#   source_once &> /dev/null && return 0
+# fi
 
-source "${VSI_COMMON_DIR}/linux/command_tools.bsh"
-source "${VSI_COMMON_DIR}/linux/elements.bsh"
-source "${VSI_COMMON_DIR}/linux/set_flags.bsh"
-source "${VSI_COMMON_DIR}/linux/ask_question"
-source "${VSI_COMMON_DIR}/linux/just_docker_functions.bsh"
+# JUST_DEFAULTIFY_FUNCTIONS+=(pyinstaller_defaultify)
+# JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 
-#*# just/plugins/just_pyinstaller_functions
+# source "${VSI_COMMON_DIR}/linux/command_tools.bsh"
+# source "${VSI_COMMON_DIR}/linux/elements.bsh"
+# source "${VSI_COMMON_DIR}/linux/set_flags.bsh"
+# source "${VSI_COMMON_DIR}/linux/ask_question"
+# source "${VSI_COMMON_DIR}/linux/just_docker_functions.bsh"
 
-#**
-# .. default-domain:: bash
-#
-#
-#====================================
-# J.U.S.T. PyInstaller Docs Functions
-# ===================================
-#
-# .. file:: just_pyinstaller_functions.bsh
-#
-# Plugin for building PyInstaller executables for a python project
-#**
+# #*# just/plugins/just_pyinstaller_functions
+
+# #**
+# # .. default-domain:: bash
+# #
+# #
+# #====================================
+# # J.U.S.T. PyInstaller Docs Functions
+# # ===================================
+# #
+# # .. file:: just_pyinstaller_functions.bsh
+# #
+# # Plugin for building PyInstaller executables for a python project
+# #**
 
 
 
-function _pyinstaller_docker_compose()
-{
-  local id_project_cwd="${JUST_PROJECT_PREFIX}_CWD"
+# function _pyinstaller_docker_compose()
+# {
+#   local id_project_cwd="${JUST_PROJECT_PREFIX}_CWD"
 
-  local PYINSTALLER_SOURCE_DIR="${JUST_PROJECT_PREFIX}_PYINSTALLER_SRC_DIR"
-  export PYINSTALLER_SOURCE_DIR="${!PYINSTALLER_SOURCE_DIR:-${!id_project_cwd}}"
-  local PYINSTALLER_DIST_DIR="${JUST_PROJECT_PREFIX}_PYINSTALLER_DIST_DIR"
-  export PYINSTALLER_DIST_DIR="${!PYINSTALLER_DIST_DIR:-${!id_project_cwd}}"
+#   local PYINSTALLER_SOURCE_DIR="${JUST_PROJECT_PREFIX}_PYINSTALLER_SRC_DIR"
+#   export PYINSTALLER_SOURCE_DIR="${!PYINSTALLER_SOURCE_DIR:-${!id_project_cwd}}"
+#   local PYINSTALLER_DIST_DIR="${JUST_PROJECT_PREFIX}_PYINSTALLER_DIST_DIR"
+#   export PYINSTALLER_DIST_DIR="${!PYINSTALLER_DIST_DIR:-${!id_project_cwd}}"
+#   # local PYINSTALLER_VENV_DIR="${JUST_PROJECT_PREFIX}_PYINSTALLER_VENV_DIR"
+#   # export PYINSTALLER_VENV_DIR="${!PYINSTALLER_VENV_DIR:-}"
+#   # local PYINSTALLER_VENV_TYPE="${JUST_PROJECT_PREFIX}_PYINSTALLER_VENV_TYPE"
+#   # export PYINSTALLER_VENV_TYPE="${!PYINSTALLER_VENV_TYPE:-volume}"
 
-  local VSI_COMMON_UID="${JUST_PROJECT_PREFIX}_UID"
-  export VSI_COMMON_UID="${!VSI_COMMON_UID-1000}"
-  local VSI_COMMON_GIDS="${JUST_PROJECT_PREFIX}_GID"
-  export VSI_COMMON_GIDS="${!VSI_COMMON_GIDS-1000}"
+#   local VSI_COMMON_UID="${JUST_PROJECT_PREFIX}_UID"
+#   export VSI_COMMON_UID="${!VSI_COMMON_UID-1000}"
+#   local VSI_COMMON_GIDS="${JUST_PROJECT_PREFIX}_GID"
+#   export VSI_COMMON_GIDS="${!VSI_COMMON_GIDS-1000}"
 
-  # local VSI_COMMON_JUST_SETTINGS="${VSI_COMMON_JUST_SETTINGS-"${JUST_PATH_ESC}/src/$(basename "${JUST_SETTINGS}")"}"
-  local JUST_SETTINGSS
-  translate_just_settings "${PYINSTALLER_SOURCE_DIR}" /src
-  local VSI_COMMON_JUST_SETTINGS
-  MIFS=/// join_a VSI_COMMON_JUST_SETTINGS ${JUST_SETTINGSS[@]+"${JUST_SETTINGSS[@]}"}
-  export VSI_COMMON_JUST_SETTINGS
+#   # local VSI_COMMON_JUST_SETTINGS="${VSI_COMMON_JUST_SETTINGS-"${JUST_PATH_ESC}/src/$(basename "${JUST_SETTINGS}")"}"
+#   local JUST_SETTINGSS
+#   translate_just_settings "${PYINSTALLER_SOURCE_DIR}" /src
+#   local VSI_COMMON_JUST_SETTINGS
+#   MIFS=/// join_a VSI_COMMON_JUST_SETTINGS ${JUST_SETTINGSS[@]+"${JUST_SETTINGSS[@]}"}
+#   export VSI_COMMON_JUST_SETTINGS
 
-  Just-docker-compose \
-      -f "${VSI_COMMON_DIR}/docker/vsi_common/docker-compose.yml" ${@+"${@}"}
-}
+#   Just-docker-compose \
+#       -f "${VSI_COMMON_DIR}/docker/vsi_common/docker-compose.yml" ${@+"${@}"}
+# }
 
-#**
-# -----------------------------
-# J.U.S.T. python freeze plugin
-# -----------------------------
-#
-#**
-function pyinstaller_defaultify()
-{
-  arg=$1
-  shift 1
-  case $arg in
-    # sphinx) # Guided "just" make sphinx documents happen (build => setup => compile)
-    #   justify sphinx build
-    #   if [ ! -d "${docs_dir}" ]; then
-    #     justify sphinx setup
-    #   fi
-    #   justify sphinx compile
-    #   ;;
-   pyinstaller_build) # Build the pyinstaller docker images
-      if [ "${PYINSTALLER_IMAGE-vsiri/pyinstaller:latest}" != "vsiri/pyinstaller:latest" ]; then
-        source "${VSI_COMMON_DIR}/linux/colors.bsh"
-        echo "${RED}ERROR${NC}: You should use your own Justfile to build \"${PYINSTALLER_IMAGE}\"" >&2
-        local JUST_IGNORE_EXIT_CODES=1
-        false
-      fi
-      justify build recipes-auto "${VSI_COMMON_DIR}/docker/vsi_common/pyinstaller.Dockerfile"
-      _pyinstaller_docker_compose build pyinstaller
-      ;;
+# #**
+# # -----------------------------
+# # J.U.S.T. python freeze plugin
+# # -----------------------------
+# #
+# #**
+# function pyinstaller_defaultify()
+# {
+#   arg=$1
+#   shift 1
+#   case $arg in
+#    pyinstaller_build) # Build the pyinstaller docker images
+#       if [ "${PYINSTALLER_IMAGE-vsiri/pyinstaller:latest}" != "vsiri/pyinstaller:latest" ]; then
+#         source "${VSI_COMMON_DIR}/linux/colors.bsh"
+#         echo "${RED}ERROR${NC}: You should use your own Justfile to build \"${PYINSTALLER_IMAGE}\"" >&2
+#         local JUST_IGNORE_EXIT_CODES=1
+#         return 1
+#       fi
+#       justify build recipes-auto "${VSI_COMMON_DIR}/docker/vsi_common/pyinstaller.Dockerfile"
+#       _pyinstaller_docker_compose build pyinstaller
+#       ;;
 
-    pyinstaller_pipenv-update) # Update PyInstaller Pipenv file
-      # Create a new volume
-      local volume="$(docker volume create)"
-      local rv=0
-      # Shadow /venv so it copies it. This makes chowning thousands of times faster... or something like that.
-      # extra_pyinstaller_arguments=(-v "${volume}:/venv")
-      # justify sphinx compile nopipenv bash -c "
-      _pyinstaller_docker_compose run -v "${volume}:/venv" pyinstaller nopipenv bash -c "
-          echo 'Owning virtual env'
-          sudo chown -R user: /venv
-          pipenv lock" || rv=$?
-      docker volume rm "${volume}"
-      if [ "${rv}" != 0 ]; then return "${rv}"; fi
-      justify pyinstaller build
-      ;;
+#     pyinstaller_pipenv-update) # Update PyInstaller Pipenv file
+#       # Create a new volume
+#       local volume="$(docker volume create)"
+#       local rv=0
+#       # Shadow /venv so it copies it. This makes chowning thousands of times faster... or something like that.
+#       # extra_pyinstaller_arguments=(-v "${volume}:/venv")
+#       # justify sphinx compile nopipenv bash -c "
+#       _pyinstaller_docker_compose run -v "${volume}:/venv" pyinstaller nopipenv bash -c "
+#           echo 'Owning virtual env'
+#           sudo chown -R user: /venv
+#           pipenv lock" || rv=$?
+#       docker volume rm "${volume}"
+#       if [ "${rv}" != 0 ]; then return "${rv}"; fi
+#       justify pyinstaller build
+#       ;;
 
-    # sphinx_setup) # Setup a new sphinx project
-    #   mkdir -p "${docs_dir}"
-    #   _sphinx_docker_compose run --rm \
-    #       sphinx bash -c "cd /docs; sphinx-quickstart"
-    #   ;;
-    pyinstaller_shell) # Enter the pyinstaller container
-      echo "Run 'just pyinstaller ...' to run pyinstaller"
-      _pyinstaller_docker_compose run pyinstaller bash
-      ;;
-    pyinstaller_run) # Compile sphinx documents
-      _pyinstaller_docker_compose run \
-          ${extra_sphinx_arguments[@]+"${extra_sphinx_arguments[@]}"} \
-          pyinstaller ${@+"${@}"}
-      extra_args+=$#
-      ;;
-    pyinstaller_clean) # Cleans doc directory
-      justify docker-compose clean pyinstaller-build
-      ;;
-    *)
-      plugin_not_found=1
-      ;;
-  esac
-  return 0
-}
+#     # sphinx_setup) # Setup a new sphinx project
+#     #   mkdir -p "${docs_dir}"
+#     #   _sphinx_docker_compose run --rm \
+#     #       sphinx bash -c "cd /docs; sphinx-quickstart"
+#     #   ;;
+#     pyinstaller_shell) # Enter the pyinstaller container
+#       echo "Run 'just pyinstaller ...' to run pyinstaller"
+#       _pyinstaller_docker_compose run pyinstaller bash
+#       ;;
+#     pyinstaller_run) # Compile sphinx documents
+#       _pyinstaller_docker_compose run \
+#           ${extra_sphinx_arguments[@]+"${extra_sphinx_arguments[@]}"} \
+#           pyinstaller ${@+"${@}"}
+#       extra_args+=$#
+#       ;;
+#     pyinstaller_clean) # Cleans doc directory
+#       justify docker-compose clean pyinstaller-build
+#       ;;
+#     *)
+#       plugin_not_found=1
+#       ;;
+#   esac
+#   return 0
+# }
 
-#**
-# Advanced Debugging
-# ------------------
-#
-# To run any custom command (like ``bash``), in the docs docker environment, additional arguments can be given to the :cmd:`sphinx_compile` command, and that will be run instead of the docs script. For example:
-#
-# .. code-block:: bash
-#
-#   just docs compile bash``
-#**
+# #**
+# # Advanced Debugging
+# # ------------------
+# #
+# # To run any custom command (like ``bash``), in the docs docker environment, additional arguments can be given to the :cmd:`sphinx_compile` command, and that will be run instead of the docs script. For example:
+# #
+# # .. code-block:: bash
+# #
+# #   just docs compile bash``
+# #**

--- a/linux/just_sphinx_functions.bsh
+++ b/linux/just_sphinx_functions.bsh
@@ -120,7 +120,10 @@ function _sphinx_docker_compose()
   local VSI_COMMON_GIDS="${JUST_PROJECT_PREFIX}_GID"
   export VSI_COMMON_GIDS="${!VSI_COMMON_GIDS-1000}"
 
-  local VSI_COMMON_JUST_SETTINGS="${VSI_COMMON_JUST_SETTINGS-"${JUST_PATH_ESC}/src/$(basename "${JUST_SETTINGS}")"}"
+  local JUST_SETTINGSS
+  translate_just_settings "${DOCS_SOURCE_DIR}" /src
+  local JUST_SETTINGS
+  MIFS=/// join_a VSI_COMMON_JUST_SETTINGS ${JUST_SETTINGSS[@]+"${JUST_SETTINGSS[@]}"}
   export VSI_COMMON_JUST_SETTINGS
 
   Docker-compose \

--- a/linux/just_sphinx_functions.bsh
+++ b/linux/just_sphinx_functions.bsh
@@ -256,7 +256,7 @@ function docs_defaultify()
         source "${VSI_COMMON_DIR}/linux/colors.bsh"
         echo "${RED}ERROR${NC}: You should use your own Justfile to build \"${SPHINX_COMPILE_IMAGE}\"" >&2
         local JUST_IGNORE_EXIT_CODES=1
-        false
+        return 1
       fi
       justify build recipes-auto "${VSI_COMMON_DIR}/docker/vsi_common/sphinx.Dockerfile"
       _sphinx_docker_compose build sphinx

--- a/linux/just_sphinx_functions.bsh
+++ b/linux/just_sphinx_functions.bsh
@@ -267,8 +267,8 @@ function docs_defaultify()
       local volume="$(docker volume create)"
       local rv=0
       # Shadow /venv so it copies it. This makes chowning thousands of times faster... or something like that.
-      extra_sphinx_arguments=(-v "${volume}:/venv")
-      justify sphinx compile nopipenv bash -c "
+      # extra_sphinx_arguments=(-v "${volume}:/venv")
+      _sphinx_docker_compose run -v "${volume}:/venv" sphinx nopipenv bash -c "
           echo 'Owning virtual env'
           sudo chown -R user: /venv/*
           pipenv lock" || rv=$?
@@ -282,11 +282,11 @@ function docs_defaultify()
       _sphinx_docker_compose run --rm \
           sphinx bash -c "cd /docs; sphinx-quickstart"
       ;;
-    sphinx_shell) # Enter the spinx container
+    sphinx_shell) # Enter the sphinx container
       echo "Run 'just docs' to build to docs"
       justify sphinx compile bash
       ;;
-    sphinx_compile) # Compile spinx documents
+    sphinx_compile) # Compile sphinx documents
       local nit_pick
       local rebuild_all
       parse_args extra_args -n nit_pick --nit nit_pick -E rebuild_all --all rebuild_all -- ${@+"${@}"}

--- a/linux/just_sphinx_functions.bsh
+++ b/linux/just_sphinx_functions.bsh
@@ -111,19 +111,18 @@ function _docs_serialize_dirs()
 
 function _sphinx_docker_compose()
 {
-  local src_dir="${JUST_PROJECT_PREFIX}_SPHINX_SRC_DIR"
-  src_dir="${!src_dir:-${!id_project_cwd}}"
+  local DOCS_SOURCE_DIR="${JUST_PROJECT_PREFIX}_SPHINX_SRC_DIR"
+  export DOCS_SOURCE_DIR="${!DOCS_SOURCE_DIR:-${!id_project_cwd}}"
+  export DOCS_DIR="${docs_dir}"
 
-  local uid="${JUST_PROJECT_PREFIX}_UID"
-  uid="${!uid-1000}"
-  local gid="${JUST_PROJECT_PREFIX}_GID"
-  gid="${!gid-1000}"
+  local VSI_COMMON_UID="${JUST_PROJECT_PREFIX}_UID"
+  export VSI_COMMON_UID="${!VSI_COMMON_UID-1000}"
+  local VSI_COMMON_GIDS="${JUST_PROJECT_PREFIX}_GID"
+  export VSI_COMMON_GIDS="${!VSI_COMMON_GIDS-1000}"
 
-  DOCS_SOURCE_DIR="${src_dir}" \
-  DOCS_DIR="${docs_dir}" \
-  VSI_COMMON_UID="${uid}" \
-  VSI_COMMON_GIDS="${gid}" \
-  JUST_SETTINGS="${JUST_PATH_ESC}/src/$(basename "${JUST_SETTINGS}")" \
+  local VSI_COMMON_JUST_SETTINGS="${VSI_COMMON_JUST_SETTINGS-"${JUST_PATH_ESC}/src/$(basename "${JUST_SETTINGS}")"}"
+  export VSI_COMMON_JUST_SETTINGS
+
   Docker-compose \
       -f "${VSI_COMMON_DIR}/docker/vsi_common/docker-compose.yml" ${@+"${@}"}
 }
@@ -255,7 +254,7 @@ function docs_defaultify()
         echo "${RED}ERROR${NC}: You should use your own Justfile to build \"${SPHINX_COMPILE_IMAGE}\"" >&2
         false
       fi
-      justify build recipes gosu tini pipenv vsi
+      justify build recipes-auto "${VSI_COMMON_DIR}/docker/vsi_common/sphinx.Dockerfile"
       _sphinx_docker_compose build sphinx
       ;;
 

--- a/linux/just_sphinx_functions.bsh
+++ b/linux/just_sphinx_functions.bsh
@@ -111,13 +111,21 @@ function _docs_serialize_dirs()
 
 function _sphinx_docker_compose()
 {
-  ${DRYRUN} ${DRYRUN+env} DOCS_SOURCE_DIR="${src_dir}" \
-      DOCS_DIR="${docs_dir}" \
-      VSI_COMMON_UID="${uid}" \
-      VSI_COMMON_GIDS="${gid}" \
-      JUST_SETTINGS="${JUST_PATH_ESC}/src/$(basename "${JUST_SETTINGS}")" \
-      ${DOCKER_COMPOSE} \
-         -f "${VSI_COMMON_DIR}/docker/vsi_common/docker-compose.yml" ${@+"${@}"}
+  local src_dir="${JUST_PROJECT_PREFIX}_SPHINX_SRC_DIR"
+  src_dir="${!src_dir:-${!id_project_cwd}}"
+
+  local uid="${JUST_PROJECT_PREFIX}_UID"
+  uid="${!uid-1000}"
+  local gid="${JUST_PROJECT_PREFIX}_GID"
+  gid="${!gid-1000}"
+
+  DOCS_SOURCE_DIR="${src_dir}" \
+  DOCS_DIR="${docs_dir}" \
+  VSI_COMMON_UID="${uid}" \
+  VSI_COMMON_GIDS="${gid}" \
+  JUST_SETTINGS="${JUST_PATH_ESC}/src/$(basename "${JUST_SETTINGS}")" \
+  Docker-compose \
+      -f "${VSI_COMMON_DIR}/docker/vsi_common/docker-compose.yml" ${@+"${@}"}
 }
 
 #**
@@ -231,14 +239,6 @@ function docs_defaultify()
   local docs_dir="${JUST_PROJECT_PREFIX}_SPHINX_DIR"
   docs_dir="${!docs_dir:-${!id_project_cwd}/docs}"
 
-  local src_dir="${JUST_PROJECT_PREFIX}_SPHINX_SRC_DIR"
-  src_dir="${!src_dir:-${!id_project_cwd}}"
-
-  local uid="${JUST_PROJECT_PREFIX}_UID"
-  uid="${!uid-1000}"
-  local gid="${JUST_PROJECT_PREFIX}_GID"
-  gid="${!gid-1000}"
-
   arg=$1
   shift 1
   case $arg in
@@ -317,7 +317,7 @@ function docs_defaultify()
         precompile_script="${!JUST_TEMP_ARRAY}"
       fi
 
-      _sphinx_docker_compose run --rm \
+      _sphinx_docker_compose run \
           -e SPHINXOPTS \
           -e DOCS_EXCLUDE_DIRS="$(_docs_serialize_dirs "${exclude_dirs[@]}")" \
           -e DOCS_AUTODOC_EXCLUDE_DIRS="$(_docs_serialize_dirs "${autodoc_exclude_dirs[@]}")" \

--- a/linux/just_sphinx_functions.bsh
+++ b/linux/just_sphinx_functions.bsh
@@ -252,6 +252,7 @@ function docs_defaultify()
       if [ "${SPHINX_COMPILE_IMAGE-vsiri/sphinxdocs:compile}" != "vsiri/sphinxdocs:compile" ]; then
         source "${VSI_COMMON_DIR}/linux/colors.bsh"
         echo "${RED}ERROR${NC}: You should use your own Justfile to build \"${SPHINX_COMPILE_IMAGE}\"" >&2
+        local JUST_IGNORE_EXIT_CODES=1
         false
       fi
       justify build recipes-auto "${VSI_COMMON_DIR}/docker/vsi_common/sphinx.Dockerfile"

--- a/linux/load_nvidia_uvm.py
+++ b/linux/load_nvidia_uvm.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+'''
+A script to load the nvidia uvm device
+
+Some (older) Linux Operating systems do not load ``/dev/nvidia-uvm`` on boot to
+runlevel 3 (headless). This results in the ``nvidia-uvm`` module not being
+loaded.
+
+Unfortunately, a simple modprobe does not fix the issue, but a CUDA call on the
+host (not in a container) will.
+
+This scripts attempts to locate a ``libcudart.so`` library and calls the
+``cudaGetDeviceCount`` function, which loads the ``/dev/nvidia-uvm`` driver. If
+it cannot locate the cuda runtime, you can give it the location as an argument.
+
+The CUDA Runtime is required on the host.
+'''
+
+import ctypes as c
+import os
+from glob import glob
+import sys
+
+def main(args=[]):
+  cuda_runtimes=[]
+
+  if args:
+    cuda_runtimes=args
+  else:
+    # Attempt to discover cuda runtime
+    common_dirs = glob('/usr/local/cuda*') + glob('/usr/cuda*') + ['/usr'] \
+                  + [os.path.dirname(__file__)]
+
+    for common_dir in common_dirs:
+      for root, dirs, files in os.walk(common_dir, followlinks=False):
+        cuda_runtimes.extend([os.path.join(root, rt) \
+                            for rt in files \
+                            if rt.startswith('libcudart.so')])
+        if cuda_runtimes:
+          break
+      if cuda_runtimes:
+        break
+
+  if not cuda_runtimes:
+    print("Could not find cuda runtime. "
+          "Please pass the full path of a cuda runtime as an argument")
+    exit(1)
+
+  cudart = c.cdll.LoadLibrary(cuda_runtimes[0])
+  cudart.cudaGetDeviceCount.argtypes = (c.POINTER(c.c_int),)
+
+  gpu_count = c.c_int(-1)
+  result = cudart.cudaGetDeviceCount(c.pointer(gpu_count))
+
+  print("result", result)
+  print("gpu_count", gpu_count.value)
+
+if __name__ == '__main__':
+  main(sys.argv[1:])

--- a/linux/mount_tools.bsh
+++ b/linux/mount_tools.bsh
@@ -4,6 +4,11 @@ if [[ $- != *i* ]]; then
   source_once &> /dev/null && return 0
 fi
 
+if [ -z ${VSI_COMMON_DIR+set} ]; then
+  VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+fi
+source "${VSI_COMMON_DIR}/linux/compat.bsh"
+
 #*# linux/mount_tools
 
 #**
@@ -88,7 +93,7 @@ function mount_point()
 #**
 function mount_type()
 {
-  mount | sed -En 's:^.* on '"$1"' (type |\()([^, ]*).*:\2:p'
+  mount | sed -${sed_flag_rE}n 's:^.* on '"$1"' (type |\()([^, ]*).*:\2:p'
 }
 
 #**

--- a/linux/new_just
+++ b/linux/new_just
@@ -193,7 +193,8 @@ function write_setup_env()
 {
   exists "${1}" && return 0
 
-  uwecho 'export JUST_SETUP_SCRIPT="$(basename "${BASH_SOURCE[0]}")"
+  uwecho "test -f $(quote_escape "${RELATIVE_PATH}/linux/check_shell") && $(quote_escape "${RELATIVE_PATH}/linux/check_shell") bash zsh"'
+          export JUST_SETUP_SCRIPT="$(basename "${BASH_SOURCE[0]}")"
           source "$(dirname "${BASH_SOURCE[0]}")/"'"$(quote_escape "${RELATIVE_PATH}/env.bsh")" >> "${1}"
   if [ "${JUSTFILE}" != "Justfile" ]; then
     echo "export JUSTFILE=$(quote_escape "${JUSTFILE}")" >> "${1}"

--- a/linux/print_command
+++ b/linux/print_command
@@ -113,7 +113,7 @@ function print_command_save_env()
 #
 # .. rubric:: Example
 #
-# .. code:: bash
+# .. code-block:: bash
 #
 #   export A=1
 #   export B=2

--- a/linux/print_command
+++ b/linux/print_command
@@ -5,6 +5,7 @@ if [[ $- != *i* ]]; then
 fi
 
 source "${VSI_COMMON_DIR}/linux/findin"
+source "${VSI_COMMON_DIR}/linux/string_tools.bsh"
 
 #*# linux/print_command
 
@@ -28,6 +29,7 @@ source "${VSI_COMMON_DIR}/linux/findin"
 #
 # :Arguments: ``$1``... - List of command + arguments to be echoed
 # :Output: *stdout* - A quote escaped version of the command + arguments, ready for ``eval``
+# :Uses: :func:`string-tools.bsh-quote_escape`
 #
 # Accurately echoes out a properly escaped single string representation of a command + arguments.
 #
@@ -58,6 +60,8 @@ function print_command()
 
 function _print_command()
 {
+  # Bash < 4.2 https://unix.stackexchange.com/a/411047/123413
+
   while [ "$#" -gt 0 ]; do
     # https://unix.stackexchange.com/a/357932/123413
     if [[ ${1} =~ ^[a-zA-Z0-9_.:/=@%^,+-]+$ ]]; then
@@ -69,7 +73,7 @@ function _print_command()
         echo -n "${1}"
       fi
     else
-      echo -n "'${1//\'/\'\"\'\"\'}'"
+      echo -n "$(quote_escape "${1}")"
     fi
     shift 1
     if [ "$#" -gt 0 ]; then
@@ -106,6 +110,8 @@ function print_command_save_env()
 #
 # :Arguments: ``$1``... - List of command + arguments to be echoed
 # :Output: *stdout* - A quote escaped version of the command + arguments, ready for ``eval``
+# :Uses: * :func:`string-tools.bsh-quote_escape`
+#        * :func:`print_command`
 #
 # Accurately echoes out a properly escaped single string representation of a command + arguments, including any "optional variable assignments" and exported environment variables.
 #
@@ -149,6 +155,7 @@ function print_command_env()
   local __print_command_new_name
   local __print_command_name
   local __print_command_parentheses=0
+  local __print_command_new_value
 
   # Path should always beee set...
   if [ -z "${__print_command_copy_PATH+set}" ]; then
@@ -160,7 +167,7 @@ function print_command_env()
     if [[ ${PWD} =~ ^[a-zA-Z0-9_.:/=@%^,+-]+$ ]]; then
       echo -n "(cd ${PWD}; "
     else
-      echo -n "(cd '${PWD//\'/\'\"\'\"\'}'; "
+      echo -n "(cd $(quote_escape "${PWD}"); "
     fi
     __print_command_parentheses=1
   fi
@@ -169,6 +176,13 @@ function print_command_env()
   for __print_command_name in $(compgen -A export __print_command_copy_); do
     # If it is no longer an exported variable
     __print_command_name="${__print_command_name#__print_command_copy_}"
+
+    # Skip PWD and _, it's a special case
+    if [ "${__print_command_name}" = "_" -o "${__print_command_name}" = "PWD" -o \
+         "${__print_command_name}" = "SHLVL" -o "${__print_command_name}" = "OLDPWD" ]; then
+      continue
+    fi
+
     if ! compgen -A export -X "!${__print_command_name}" &> /dev/null; then
       if [ "${__print_command_parentheses}" = "0" ]; then
         echo -n "("
@@ -178,6 +192,31 @@ function print_command_env()
     fi
   done
 
+  local __print_command_version_check=0
+  # 0 = bash 4.3 or newer
+  # 1 = bash 4.2 or older
+
+  # Cover local shadow corner case in older bashes
+  # https://paper.dropbox.com/doc/BASH-Corner-cases--A3zpNV61~3VRjP3ptdi2HCzcAQ-qAg7oQqDdxIJzhHKzmVEh
+  if [ "${BASH_VERSINFO[0]}" = "4" -a "${BASH_VERSINFO[1]}" -lt "3" ] || [ "${BASH_VERSINFO[0]}" -lt "4" ]; then
+    __print_command_version_check=1
+    for __print_command_new_name in ${__print_command_new_export_names[@]+"${__print_command_new_export_names[@]}"}; do
+      # Skip PWD and _, it's a special case
+      if [ "${__print_command_new_name}" = "_" -o "${__print_command_new_name}" = "PWD" -o \
+           "${__print_command_new_name}" = "SHLVL" -o "${__print_command_new_name}" = "OLDPWD" ]; then
+        continue
+      fi
+
+      if [ -z "${!__print_command_new_name+set}" ]; then
+        if [ "${__print_command_parentheses}" = "0" ]; then
+          echo -n "("
+          __print_command_parentheses=1
+        fi
+        echo -n "unset ${__print_command_name}; "
+      fi
+    done
+  fi
+
   for __print_command_new_name in ${__print_command_new_export_names[@]+"${__print_command_new_export_names[@]}"}; do
     # Skip PWD and _, it's a special case
     if [ "${__print_command_new_name}" = "_" -o "${__print_command_new_name}" = "PWD" -o \
@@ -185,12 +224,32 @@ function print_command_env()
       continue
     fi
     __print_command_name="__print_command_copy_${__print_command_new_name}"
+
+
+    if [ -z "${!__print_command_new_name+set}" ]; then
+      # Older bash handled above
+      if [ "${__print_command_version_check}" = "1" ]; then
+        continue
+      fi
+
+      # Cover local shadow corner case in bash 4.3 or newer
+      # https://paper.dropbox.com/doc/BASH-Corner-cases--A3zpNV61~3VRjP3ptdi2HCzcAQ-qAg7oQqDdxIJzhHKzmVEh
+      # It is possible for compgen to find a variable that appears to be unset.
+      # In this case, the global, not locally unset variable, is exported and used
+
+      # This is the only way I know to access a locally shadowed exported variable
+      __print_command_new_value="$(bash -c "echo \"\${${__print_command_new_name}}\"")"
+    else
+      # Normal case
+      __print_command_new_value="${!__print_command_new_name}"
+    fi
+
     # If it was unset or set to a new value
-    if [ -z "${!__print_command_name+set}" ] || [ "${!__print_command_name}" != "${!__print_command_new_name}" ]; then
-      if [[ ${!__print_command_new_name} =~ ^[a-zA-Z0-9_.:/=@%^,+-]+$ ]]; then
-        echo -n "${__print_command_new_name}=${!__print_command_new_name} "
+    if [ -z "${!__print_command_name+set}" ] || [ "${!__print_command_name}" != "${__print_command_new_value}" ]; then
+      if [[ ${__print_command_new_value} =~ ^[a-zA-Z0-9_.:/=@%^,+-]+$ ]]; then
+        echo -n "${__print_command_new_name}=${__print_command_new_value} "
       else
-        echo -n "${__print_command_new_name}='${!__print_command_new_name//\'/\'\"\'\"\'}' "
+        echo -n "${__print_command_new_name}=$(quote_escape "${__print_command_new_value}") "
       fi
     fi
   done

--- a/linux/print_command
+++ b/linux/print_command
@@ -29,7 +29,7 @@ source "${VSI_COMMON_DIR}/linux/string_tools.bsh"
 #
 # :Arguments: ``$1``... - List of command + arguments to be echoed
 # :Output: *stdout* - A quote escaped version of the command + arguments, ready for ``eval``
-# :Uses: :func:`string-tools.bsh-quote_escape`
+# :Uses: :func:`string_tools.bsh quote_escape`
 #
 # Accurately echoes out a properly escaped single string representation of a command + arguments.
 #
@@ -73,7 +73,7 @@ function _print_command()
         echo -n "${1}"
       fi
     else
-      echo -n "$(quote_escape "${1}")"
+      echo -n "$ quote_escape "${1}")"
     fi
     shift 1
     if [ "$#" -gt 0 ]; then
@@ -110,7 +110,7 @@ function print_command_save_env()
 #
 # :Arguments: ``$1``... - List of command + arguments to be echoed
 # :Output: *stdout* - A quote escaped version of the command + arguments, ready for ``eval``
-# :Uses: * :func:`string-tools.bsh-quote_escape`
+# :Uses: * :func:`string_tools.bsh quote_escape`
 #        * :func:`print_command`
 #
 # Accurately echoes out a properly escaped single string representation of a command + arguments, including any "optional variable assignments" and exported environment variables.

--- a/linux/print_command
+++ b/linux/print_command
@@ -73,7 +73,7 @@ function _print_command()
         echo -n "${1}"
       fi
     else
-      echo -n "$ quote_escape "${1}")"
+      echo -n "$(quote_escape "${1}")"
     fi
     shift 1
     if [ "$#" -gt 0 ]; then

--- a/linux/print_command
+++ b/linux/print_command
@@ -88,15 +88,17 @@ function _print_command()
 function print_command_save_env()
 {
   # Create a copy of the original env
-  __print_command_export_names=($(compgen -A export))
-  __print_command_export_values=()
+  local __print_command_export_names=($(compgen -A export -X __print_command_copy_*))
+  local __name
+
   for __name in ${__print_command_export_names[@]+"${__print_command_export_names[@]}"}; do
-    __print_command_export_values+=("${!__name}")
+    export __print_command_copy_${__name}="${!__name}"
   done
 
   # Now that print_command_env is setup, export print_command_env so it is
   # available in children
   export -f print_command_env
+  export -f _print_command
 }
 
 #**
@@ -139,23 +141,35 @@ function print_command_save_env()
 #   foo c
 #   # C=4 some command c
 #**
+
+# Add special case for PWD
 function print_command_env()
 {
-  local __print_command_new_export_names=($(compgen -A export))
+  local __print_command_new_export_names=($(compgen -A export -X __print_command_copy_*))
+  local __print_command_new_name
   local __print_command_name
-  local __print_command_index
   local __print_command_parentheses=0
 
-  if [ -z "${__print_command_export_names+set}" ]; then
+  # Path should always beee set...
+  if [ -z "${__print_command_copy_PATH+set}" ]; then
     echo "Warning: print_command_env called without print_command_save_env being called first" >&2
-    print_command ${@+"${@}"}
-    return
+  fi
+
+  # Handle PWD, because I can
+  if [ "${PWD}" != "${__print_command_copy_PWD}" ]; then
+    if [[ ${PWD} =~ ^[a-zA-Z0-9_.:/=@%^,+-]+$ ]]; then
+      echo -n "(cd ${PWD}; "
+    else
+      echo -n "(cd '${PWD//\'/\'\"\'\"\'}'; "
+    fi
+    __print_command_parentheses=1
   fi
 
   # Look for unset variables
-  for __print_command_name in ${__print_command_export_names[@]+"${__print_command_export_names[@]}"}; do
-    __print_command_index="$(findin "${__print_command_name}" ${__print_command_new_export_names[@]+"${__print_command_new_export_names[@]}"})"
-    if [ "${__print_command_index}" = "-1" ]; then
+  for __print_command_name in $(compgen -A export __print_command_copy_); do
+    # If it is no longer an exported variable
+    __print_command_name="${__print_command_name#__print_command_copy_}"
+    if ! compgen -A export -X "!${__print_command_name}" &> /dev/null; then
       if [ "${__print_command_parentheses}" = "0" ]; then
         echo -n "("
         __print_command_parentheses=1
@@ -164,13 +178,19 @@ function print_command_env()
     fi
   done
 
-  for __print_command_name in ${__print_command_new_export_names[@]+"${__print_command_new_export_names[@]}"}; do
-    __print_command_index="$(findin "${__print_command_name}" ${__print_command_export_names[@]+"${__print_command_export_names[@]}"})"
-    if [ "${__print_command_index}" = "-1" ] || [ "${!__print_command_name}" != "${__print_command_export_values[__print_command_index]}" ]; then
-      if [[ ${!__print_command_name} =~ ^[a-zA-Z0-9_.:/=@%^,+-]+$ ]]; then
-        echo -n "${__print_command_name}=${!__print_command_name} "
+  for __print_command_new_name in ${__print_command_new_export_names[@]+"${__print_command_new_export_names[@]}"}; do
+    # Skip PWD and _, it's a special case
+    if [ "${__print_command_new_name}" = "_" -o "${__print_command_new_name}" = "PWD" -o \
+         "${__print_command_new_name}" = "SHLVL" -o "${__print_command_new_name}" = "OLDPWD" ]; then
+      continue
+    fi
+    __print_command_name="__print_command_copy_${__print_command_new_name}"
+    # If it was unset or set to a new value
+    if [ -z "${!__print_command_name+set}" ] || [ "${!__print_command_name}" != "${!__print_command_new_name}" ]; then
+      if [[ ${!__print_command_new_name} =~ ^[a-zA-Z0-9_.:/=@%^,+-]+$ ]]; then
+        echo -n "${__print_command_new_name}=${!__print_command_new_name} "
       else
-        echo -n "${__print_command_name}='${!__print_command_name//\'/\'\"\'\"\'}' "
+        echo -n "${__print_command_new_name}='${!__print_command_new_name//\'/\'\"\'\"\'}' "
       fi
     fi
   done

--- a/linux/print_command
+++ b/linux/print_command
@@ -4,6 +4,8 @@ if [[ $- != *i* ]]; then
   source_once &> /dev/null && return 0
 fi
 
+source "${VSI_COMMON_DIR}/linux/findin"
+
 #*# linux/print_command
 
 #**
@@ -42,33 +44,144 @@ fi
 #   eval "$(print_command "${stuff[@]}")"
 #   or
 #   bash -c "$(print_command "${stuff[@]}")"
+#
+# .. seealso::
+#   :func:`print_command_env`
+#     Version that captures changes in the environment
 #**
 function print_command()
 {
+  _print_command ${@+"${@}"}
+  # Add a newline to the end
+  echo ""
+}
+
+function _print_command()
+{
   while [ "$#" -gt 0 ]; do
-    # if [[ ${1} =~ ^[a-zA-Z0-9_.:/=-]*$ ]]; then
     # https://unix.stackexchange.com/a/357932/123413
-    if [[ ${1} =~ ^[a-zA-Z0-9_.:/=@%^,+-]*$ ]]; then
-      printf '%s' "${1}"
+    if [[ ${1} =~ ^[a-zA-Z0-9_.:/=@%^,+-]+$ ]]; then
+      if [ "${1::1}" = "-" ]; then
+        # Printf is 1000 times slower in windows (fork cost), so only use it if
+        # you have to. The only time this is an issue, if if you use -e -E -n
+        printf '%s' "${1}"
+      else
+        echo -n "${1}"
+      fi
     else
-      printf "'${1//\'/\'\"\'\"\'}'"
+      echo -n "'${1//\'/\'\"\'\"\'}'"
     fi
     shift 1
-    [ "$#" -gt 0 ] && printf " "
+    if [ "$#" -gt 0 ]; then
+      echo -n " "
+    fi
   done
-  printf "\n"
+}
 
-  # if command -v python &> /dev/null; then
-  #   python -c "import pipes as p; import sys as s; print(' '.join([p.quote(x) for x in s.argv[1:]]))" "${@}"
-  # else
-  #   # FAR from perfect... Need to escape " and not always print ''
-  #   while [ "$#" -gt 0 ]; do
-  #     printf \'"$1"\'
-  #     shift 1
-  #     [ "$#" -gt 0 ] && printf " "
-  #   done
-  #   printf "\n"
-  # fi
+#**
+# .. function:: print_command_save_env
+#
+# Sets the saved version of the environment, to compare with when calling :func:`print_command_env`
+#
+# :func:`print_command_env` needs a before version of the environment, to compare with so it will know which environment variables changes. The only "optional variable assignments" or exported variables that will not be captures, are ones set the same value they already have.
+#**
+function print_command_save_env()
+{
+  # Create a copy of the original env
+  __print_command_export_names=($(compgen -A export))
+  __print_command_export_values=()
+  for __name in ${__print_command_export_names[@]+"${__print_command_export_names[@]}"}; do
+    __print_command_export_values+=("${!__name}")
+  done
+
+  # Now that print_command_env is setup, export print_command_env so it is
+  # available in children
+  export -f print_command_env
+}
+
+#**
+# .. function:: print_command_env
+#
+# :Arguments: ``$1``... - List of command + arguments to be echoed
+# :Output: *stdout* - A quote escaped version of the command + arguments, ready for ``eval``
+#
+# Accurately echoes out a properly escaped single string representation of a command + arguments, including any "optional variable assignments" and exported environment variables.
+#
+# When :func:`print_command_save_env` is called, the environment is saved and any changes made to the environment from then on, are captures in a call to :func:`print_command_env`
+#
+# .. rubric:: Example
+#
+# .. code:: bash
+#
+#   export A=1
+#   export B=2
+#
+#   function foo()
+#   {
+#     ${DRYRUN} some command ${@+"${@}"}
+#   }
+#
+#   print_command_save_env
+#   export DRYRUN=print_command
+#
+#   # ...
+#
+#   foo -e q=5
+#   # some command -e q=5
+#   A=2 foo -t
+#   # A=2 some command -t
+#   B=2 foo -f
+#   # some command -f
+#   unset A; foo -y
+#   # (unset A; some command -y)
+#   export A=1
+#   export C=4
+#   foo c
+#   # C=4 some command c
+#**
+function print_command_env()
+{
+  local __print_command_new_export_names=($(compgen -A export))
+  local __print_command_name
+  local __print_command_index
+  local __print_command_parentheses=0
+
+  if [ -z "${__print_command_export_names+set}" ]; then
+    echo "Warning: print_command_env called without print_command_save_env being called first" >&2
+    print_command ${@+"${@}"}
+    return
+  fi
+
+  # Look for unset variables
+  for __print_command_name in ${__print_command_export_names[@]+"${__print_command_export_names[@]}"}; do
+    __print_command_index="$(findin "${__print_command_name}" ${__print_command_new_export_names[@]+"${__print_command_new_export_names[@]}"})"
+    if [ "${__print_command_index}" = "-1" ]; then
+      if [ "${__print_command_parentheses}" = "0" ]; then
+        echo -n "("
+        __print_command_parentheses=1
+      fi
+      echo -n "unset ${__print_command_name}; "
+    fi
+  done
+
+  for __print_command_name in ${__print_command_new_export_names[@]+"${__print_command_new_export_names[@]}"}; do
+    __print_command_index="$(findin "${__print_command_name}" ${__print_command_export_names[@]+"${__print_command_export_names[@]}"})"
+    if [ "${__print_command_index}" = "-1" ] || [ "${!__print_command_name}" != "${__print_command_export_values[__print_command_index]}" ]; then
+      if [[ ${!__print_command_name} =~ ^[a-zA-Z0-9_.:/=@%^,+-]+$ ]]; then
+        echo -n "${__print_command_name}=${!__print_command_name} "
+      else
+        echo -n "${__print_command_name}='${!__print_command_name//\'/\'\"\'\"\'}' "
+      fi
+    fi
+  done
+
+  _print_command ${@+"${@}"}
+
+  if [ "${__print_command_parentheses}" = "1" ]; then
+    echo ")"
+  else
+    echo ""
+  fi
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then

--- a/linux/requirements.bsh
+++ b/linux/requirements.bsh
@@ -41,7 +41,7 @@ source "${VSI_COMMON_DIR}/linux/compat.bsh"
 #
 # .. rubric:: Example
 #
-# .. code:: bash
+# .. code-block:: bash
 #
 #    meet_requirements 1.0.0 <2.0.0 >0.5.0
 #    meet_requirements 1.0.0 =1
@@ -290,7 +290,7 @@ function version_gt()
 #
 # .. rubric:: Example:
 #
-# .. code:: bash
+# .. code-block:: bash
 #
 #    $ split_version_string x "$(bash_version)"
 #    $ declare -p x

--- a/linux/time_tools.bsh
+++ b/linux/time_tools.bsh
@@ -29,9 +29,12 @@ fi
 get_time_seconds()
 {
   # If this date doesn't support nanoseconds
-  if [ "$(date +%N)" == "N" ]; then
+  if [[ ! $(date +%N) =~ ^[0-9]+$ ]]; then
+    local python_cmd="import time; print('%0.9f' % time.time())"
     if command -v python &> /dev/null; then
-      python -c "import time; print('%0.9f' % time.time())"
+      python -c "${python_cmd}"
+    elif command -v python3 &> /dev/null; then
+      python3 -c "${python_cmd}"
     elif command -v ruby &> /dev/null; then
       ruby -e "print Time.now.to_f"
     # Add other elif commands here for other common languages. Perl needs a
@@ -113,8 +116,7 @@ fi
 #**
 
 
-# TODO: variable indirection to form a "scope" like behavior. On bash 4 use aarray, on bash 3.2 use old style variables
-if [ "$(date +%N)" == "N" ]; then
+if [[ ! $(date +%N) =~ ^[0-9]+$ ]]; then
   _tictoc_cmd="date +%s000000000"
 else
   _tictoc_cmd="date +%s%N"

--- a/linux/yarp
+++ b/linux/yarp
@@ -36,7 +36,7 @@ fi
 # * And nested combinations of the above.
 # * A form of multiline values where the lines end in ``\``
 #
-# .. note:
+# .. note::
 #
 #   Limited support of comments. Entire commented lines are removed from the output, but lines ending with a comment will not have the comments removed from the final output. This should have minimal side effects when grepping.
 #

--- a/linux/yarp.awk
+++ b/linux/yarp.awk
@@ -15,7 +15,7 @@ function get_path()
 {
   result=""
   sep="" # Make it so the first key doesn't have a period before it
-  for (join_i = 0; join_i < length(indents); ++join_i)
+  for (join_i = 0; join_i < length_sequences; ++join_i)
   {
     if (sequences[join_i] != -1)
     {
@@ -36,18 +36,19 @@ function process_sequence(sequence, key, indents, paths, sequences)
 {
   if ( sequence )
   {
-    sequences[length(sequences)-1]++
+    sequences[length_sequences-1]++
 
     if ( key != "\"\"" )
     {
       indent += 2
-      indents[length(indents)] = indent
-      paths[length(paths)] = key
-      sequences[length(sequences)] = -1
+      indents[length_sequences] = indent
+      paths[length_sequences] = key
+      sequences[length_sequences] = -1
+      ++length_sequences
     }
   }
   else
-    sequences[length(sequences)-1] = -1
+    sequences[length_sequences-1] = -1
 }
 
 function get_indent(str)
@@ -81,11 +82,12 @@ function process_line(str)
   if ( indent < last_indent )
   {
     # Add sequence, because in the sequence case, it's > not >=
-    while ( length(indents) && indents[length(indents)-1] > indent) # + sequence )
+    while ( length_sequences && indents[length_sequences-1] > indent) # + sequence )
     {
-      delete indents[length(indents)-1]
-      delete paths[length(paths)-1]
-      delete sequences[length(sequences)-1]
+      delete indents[length_sequences-1]
+      delete paths[length_sequences-1]
+      delete sequences[length_sequences-1]
+      --length_sequences
     }
     last_indent = indent
   }
@@ -93,23 +95,25 @@ function process_line(str)
   # Indenting
   if ( indent > last_indent )
   {
-    indents[length(indents)] = indent
-    paths[length(paths)] = key
-    sequences[length(sequences)] = -1
+    indents[length_sequences] = indent
+    paths[length_sequences] = key
+    sequences[length_sequences] = -1
+    ++length_sequences
 
     process_sequence(sequence, key, indents, paths, sequences)
   } # Same indent
   else if (indent == last_indent )
   {
     # Corner case
-    if ( length(paths) == 0)
+    if ( length_sequences == 0)
     {
-      paths[0]=""
-      sequences[0]=-1
-      indents[0]=0
+      paths[0] = ""
+      sequences[0] = -1
+      indents[0] = 0
+      length_sequences = 1
     }
 
-    paths[length(paths)-1] = key
+    paths[length_sequences-1] = key
 
     process_sequence(sequence, key, indents, paths, sequences)
   }
@@ -186,6 +190,8 @@ BEGIN {
   delete paths[0]
   delete indents[0]
   delete sequences[0]
+
+  length_sequences = 0
 
   last_indent = 0
 }

--- a/setup.env
+++ b/setup.env
@@ -1,3 +1,4 @@
+test -f ./linux/check_shell && ./linux/check_shell bash zsh
 export JUST_SETUP_SCRIPT="$(basename "${BASH_SOURCE[0]}")"
 source "$(dirname "${BASH_SOURCE[0]}")/env.bsh"
 unset JUSTFILE

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -222,5 +222,6 @@ function run_all_tests()
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   run_all_tests ${@+"${@}"}
-  exit $?
+  rv=$?
+  exit $rv
 fi

--- a/tests/template.bsh
+++ b/tests/template.bsh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
+VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+
+begin_test "Test name"
+(
+  setup_test
+)
+end_test

--- a/tests/test-.just.bsh
+++ b/tests/test-.just.bsh
@@ -5,6 +5,7 @@
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 . "${VSI_COMMON_DIR}/linux/.just"
+. "${VSI_COMMON_DIR}/linux/compat.bsh"
 
 begin_test "just tab complete"
 (
@@ -55,7 +56,7 @@ begin_test "just tab complete"
   COMP_WORDS=(just)
   _just just '' just
   # Manually parse defaultify targets, so I quit breaking this test
-  ans1=($(sed -En '/^ *-[a-z|-]+\) *#.*/{s:^ *(-[a-z|-]+)\) *#.*:\1:; s/\|/'$'\\\n/g; p;}' "${VSI_COMMON_DIR}/linux/just_functions.bsh"))
+  ans1=($(sed -${sed_flag_rE}n '/^ *-[a-z|-]+\) *#.*/{s:^ *(-[a-z|-]+)\) *#.*:\1:; s/\|/'$'\\\n/g; p;}' "${VSI_COMMON_DIR}/linux/just_functions.bsh"))
   ans=(a -a apple b cat d dog -flag foo -jump -ocean -rope -sea snake -water "${ans1[@]}")
   # Resort it because macOS sorts weird. I mean REALLY weird. Must be the locale
   ans=($(IFS=$'\n'; sort <<< "${ans[*]}"))

--- a/tests/test-check_shell.bsh
+++ b/tests/test-check_shell.bsh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
+VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+
+begin_test "Test Check Shell"
+(
+  setup_test
+
+  check_shell bash
+  check_shell zsh bash
+
+  not check_shell csh
+  not check_shell csh sh
+)
+end_test

--- a/tests/test-circular_source.bsh
+++ b/tests/test-circular_source.bsh
@@ -96,7 +96,7 @@ begin_test "Looking for infinite source loops"
   for x in "${VSI_COMMON_DIR}/linux/"*; do
     case "${x}" in
       # Only "library" files should be checked, all other programs and non-bash files should be added to this exception list
-      */example_just|*/just_diff|*/just_entrypoint.sh|*/just_env|*/new_just|*/Just_wrap|*/git_safe_update|*.py|*.awk) ;;
+      */example_just|*/just_diff|*/just_entrypoint.sh|*/just_env|*/new_just|*/Just_wrap|*/git_safe_update|*.py|*.awk|*/check_shell) ;;
       *)
         ( timeout 5 bash -c "source \"${x}\"" )
         ;;

--- a/tests/test-container_functions.bsh
+++ b/tests/test-container_functions.bsh
@@ -35,34 +35,34 @@ begin_test "Container environment override"
   JUST_PROJECT_PREFIX=FOO
 
   # None
-  check_str "$(container_environment_override test_echo)" ""
+  check_str "$(OS= container_environment_override test_echo)" ""
 
   # Windows
   check_str "$(OS=Windows_NT container_environment_override test_echo)" ":JUST_HOST_WINDOWS@1:"
 
   # Only _DOCKER
   export FOO_DIR_DOCKER=/blah
-  check_str "$(container_environment_override test_echo)" ":FOO_DIR@/blah:"
+  check_str "$(OS= container_environment_override test_echo)" ":FOO_DIR@/blah:"
 
   # _DOCKER and "" should print
   export FOO_DIR=/stuff
   ans=":FOO_DIR_HOST@/stuff:"
   ans+=$'\n:FOO_DIR@/blah:'
-  check_str "$(container_environment_override test_echo)" "${ans}"
+  check_str "$(OS= container_environment_override test_echo)" "${ans}"
 
   # EXPORT_DOCKER
   ans+=$'\n:FOO_DIR_DOCKER@/blah:'
-  check_str "$(EXPORT_DOCKER=1 container_environment_override test_echo)" "${ans}"
+  check_str "$(EXPORT_DOCKER=1 OS= container_environment_override test_echo)" "${ans}"
 
   # Disable swap
   ans=":FOO_DIR@/stuff:"
   ans+=$'\n:FOO_DIR_DOCKER@/blah:'
-  check_str "$(JUST_DISABLE_ENVIRONMENT_SWAP=1 container_environment_override test_echo)" "${ans}"
+  check_str "$(JUST_DISABLE_ENVIRONMENT_SWAP=1 OS= container_environment_override test_echo)" "${ans}"
 
   # _HOST too. Issue #251
   export FOO_DIR_HOST=/hosty
   ans=":FOO_DIR@/blah:"
   ans+=$'\n:FOO_DIR_HOST@/hosty:'
-  check_str "$(container_environment_override test_echo)" "${ans}"
+  check_str "$(OS= container_environment_override test_echo)" "${ans}"
 )
 end_test

--- a/tests/test-container_functions.bsh
+++ b/tests/test-container_functions.bsh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
+. "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
+VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+. "${VSI_COMMON_DIR}/linux/container_functions.bsh"
+
+begin_test "Translate paths"
+(
+  setup_test
+
+  # Simple
+  [ "$(translate_path /foo/boo /foo /bar)" = "/bar/boo" ]
+
+  # Multiple
+  [ "$(translate_path /foo/boo /grey /gray /foo /bar /stuff /things)" = "/bar/boo" ]
+
+  # Miss
+  [ "$(translate_path /food/boo /grey /gray /foo /bar /stuff /things)" = "/food/boo" ]
+
+  # Windows Escaped style
+  [ "$(translate_path //foo/boo /grey /gray /foo /bar /stuff /things)" = "/bar/boo" ]
+)
+end_test

--- a/tests/test-container_functions.bsh
+++ b/tests/test-container_functions.bsh
@@ -22,3 +22,47 @@ begin_test "Translate paths"
   [ "$(translate_path //foo/boo /grey /gray /foo /bar /stuff /things)" = "/bar/boo" ]
 )
 end_test
+
+begin_test "Container environment override"
+(
+  setup_test
+
+  function test_echo()
+  {
+    echo ":${1}@${2}:"
+  }
+
+  JUST_PROJECT_PREFIX=FOO
+
+  # None
+  check_str "$(container_environment_override test_echo)" ""
+
+  # Windows
+  check_str "$(OS=Windows_NT container_environment_override test_echo)" ":JUST_HOST_WINDOWS@1:"
+
+  # Only _DOCKER
+  export FOO_DIR_DOCKER=/blah
+  check_str "$(container_environment_override test_echo)" ":FOO_DIR@/blah:"
+
+  # _DOCKER and "" should print
+  export FOO_DIR=/stuff
+  ans=":FOO_DIR_HOST@/stuff:"
+  ans+=$'\n:FOO_DIR@/blah:'
+  check_str "$(container_environment_override test_echo)" "${ans}"
+
+  # EXPORT_DOCKER
+  ans+=$'\n:FOO_DIR_DOCKER@/blah:'
+  check_str "$(EXPORT_DOCKER=1 container_environment_override test_echo)" "${ans}"
+
+  # Disable swap
+  ans=":FOO_DIR@/stuff:"
+  ans+=$'\n:FOO_DIR_DOCKER@/blah:'
+  check_str "$(JUST_DISABLE_ENVIRONMENT_SWAP=1 container_environment_override test_echo)" "${ans}"
+
+  # _HOST too. Issue #251
+  export FOO_DIR_HOST=/hosty
+  ans=":FOO_DIR@/blah:"
+  ans+=$'\n:FOO_DIR_HOST@/hosty:'
+  check_str "$(container_environment_override test_echo)" "${ans}"
+)
+end_test

--- a/tests/test-dir_tools.bsh
+++ b/tests/test-dir_tools.bsh
@@ -183,22 +183,22 @@ end_test
 begin_test "common prefix"
 (
   setup_test
-  [[ $(common_prefix "/home/swenson/spam" "/home/swen/spam") = /home/swen ]]
-  [[ $(common_prefix "/home/swen/spam" "/home/swen/eggs") = /home/swen/ ]]
-  [[ $(common_prefix "/home/swen/spam" "/home/swen/spam") = /home/swen/spam ]]
-  [[ $(common_prefix "home/swenson/spam" "home/swen/spam") = home/swen ]]
-  [[ $(common_prefix "/home/swen/spam" "/home/swen/eggs") = /home/swen/ ]]
-  [[ $(common_prefix "/home/swen/spam" "/home/swen/spam") = /home/swen/spam ]]
+  [ "$(common_prefix "/home/swenson/spam" "/home/swen/spam")" = "/home/swen" ]
+  [ "$(common_prefix "/home/swen/spam" "/home/swen/eggs")" = "/home/swen/" ]
+  [ "$(common_prefix "/home/swen/spam" "/home/swen/spam")" = "/home/swen/spam" ]
+  [ "$(common_prefix "home/swenson/spam" "home/swen/spam")" = "home/swen" ]
+  [ "$(common_prefix "/home/swen/spam" "/home/swen/eggs")" = "/home/swen/" ]
+  [ "$(common_prefix "/home/swen/spam" "/home/swen/spam")" = "/home/swen/spam" ]
 
 
   testlist=('' 'abc' 'Xbcd' 'Xb' 'XY' 'abcd' 'aXc' 'abd' 'ab' 'aX' 'abcX')
   for s1 in "${testlist[@]}"; do
     for s2 in "${testlist[@]}"; do
       p="$(common_prefix "${s1}" "${s2}")"
-      [[ ${s1::${#p}} = ${p} ]]
-      [[ ${s2::${#p}} = ${p} ]]
-      if [[ ${s1} != ${s2} ]]; then
-        [[ ${s1::${#p}+1} != ${s2::${#p}+1} ]]
+      [ "${s1::${#p}}" = "${p}" ]
+      [ "${s2::${#p}}" = "${p}" ]
+      if [ "${s1}" != "${s2}" ]; then
+        [ "${s1::${#p}+1}" != "${s2::${#p}+1}" ]
       fi
     done
   done

--- a/tests/test-docker_compose_override.bsh
+++ b/tests/test-docker_compose_override.bsh
@@ -262,7 +262,7 @@ setup_mock()
   {
     local last_arg=${!#}
 
-    if [[ ${last_arg} = "${TESTDIR}"* ]]; then
+    if [[ ${last_arg} = ${TESTDIR}* ]]; then
       echo "${linux_nfs} ${TESTDIR}/${last_arg:${#TESTDIR}+1:1}"
       return 0
     fi

--- a/tests/test-docker_compose_override.bsh
+++ b/tests/test-docker_compose_override.bsh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 . "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
+. "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 . "${VSI_COMMON_DIR}/linux/docker_functions.bsh" # Need to be sourced for docker_compose_override
@@ -118,7 +119,7 @@ begin_test "Just docker compose dynamic volumes"
   if [ "${OS-}" = "Windows_NT" ]; then
     [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
   else
-    [ "${override}" = "${ans}" ]
+    check_str "${override}" "${ans}"
   fi
 
   TEST_TEST1_VOLUMES=("${TESTDIR}/src:/source:rw")
@@ -127,7 +128,7 @@ begin_test "Just docker compose dynamic volumes"
   if [ "${OS-}" = "Windows_NT" ]; then
     [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
   else
-    [ "${override}" = "${ans}" ]
+    check_str "${override}" "${ans}"
   fi
 
   TEST_VOLUME_1="${TESTDIR}/foo:/bar"
@@ -136,7 +137,7 @@ begin_test "Just docker compose dynamic volumes"
   if [ "${OS-}" = "Windows_NT" ]; then
     [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
   else
-    [ "${override}" = "${ans}" ]
+    check_str "${override}" "${ans}"
   fi
 
   TEST_VOLUME_2="${TESTDIR}/foo2:/bar3"
@@ -145,7 +146,7 @@ begin_test "Just docker compose dynamic volumes"
   if [ "${OS-}" = "Windows_NT" ]; then
     [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
   else
-    [ "${override}" = "${ans}" ]
+    check_str "${override}" "${ans}"
   fi
 
   TEST_TEST1_VOLUME_1="${TESTDIR}/bar:/foo"
@@ -154,7 +155,7 @@ begin_test "Just docker compose dynamic volumes"
   if [ "${OS-}" = "Windows_NT" ]; then
     [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
   else
-    [ "${override}" = "${ans}" ]
+    check_str "${override}" "${ans}"
   fi
 
   TEST_TEST1_VOLUME_2="${TESTDIR}/bar2:/foo5"
@@ -163,7 +164,7 @@ begin_test "Just docker compose dynamic volumes"
   if [ "${OS-}" = "Windows_NT" ]; then
     [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
   else
-    [ "${override}" = "${ans}" ]
+    check_str "${override}" "${ans}"
   fi
 )
 end_test
@@ -180,7 +181,7 @@ begin_test "Just docker compose dynamic environment"
   ans+="$(envi TEST_ONE=2)$(envi TEST_ONE_HOST=1)"
   override="$(TEST_ONE_HOST=1 TEST_ONE_DOCKER=2 \
               generate_docker_compose_override TEST test1)"
-  [ "${override}" = "${ans}" ]
+  check_str "${override}" "${ans}"
 
   # Test with JUST_DISABLE_ENVIRONMENT_SWAP
   ans="$(head)$(service test1)$(environment)"
@@ -190,7 +191,7 @@ begin_test "Just docker compose dynamic environment"
   ans+="$(envi TEST_ONE_DOCKER=2)$(envi TEST_ONE_HOST=1)"
   override="$(TEST_ONE_HOST=1 TEST_ONE_DOCKER=2 JUST_DISABLE_ENVIRONMENT_SWAP=1 \
               generate_docker_compose_override TEST test1)"
-  [ "${override}" = "${ans}" ]
+  check_str "${override}" "${ans}"
 
   # Ignores non-project variables
   ans="$(head)$(service test1)"
@@ -199,7 +200,7 @@ begin_test "Just docker compose dynamic environment"
   fi
   override="$(TEST_ONE_HOST=1 TEST_ONE_DOCKER=2 \
               generate_docker_compose_override TEST2 test1)"
-  [ "${override}" = "${ans}" ]
+  check_str "${override}" "${ans}"
 )
 end_test
 
@@ -247,8 +248,12 @@ begin_test "Generate docker-compose override"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
+  ans+=$'\nvolumes:'
+  ans+=$'\n  vol1:'
+  ans+=$'\n  vol2:'
+  ans+=$'\n  vol3:'
 
-  [ "${override}" = "${ans}" ]
+  check_str "${override}" "${ans}"
 )
 end_test
 
@@ -304,7 +309,7 @@ begin_test "Generate docker-compose override on nfs"
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
 
-  [ "${override}" = "${ans}" ]
+  check_str "${override}" "${ans}"
 )
 end_test
 
@@ -346,7 +351,7 @@ begin_expected_fail_test "Issue #7 Scenario 1"
   fi
 
   begin_fail_zone
-  [ "${override}" = "${ans}" ]
+  check_str "${override}" "${ans}"
 )
 end_test
 
@@ -371,7 +376,7 @@ begin_test "Issue #7 Scenario 2"
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
 
-  [ "${override}" = "${ans}" ]
+  check_str "${override}" "${ans}"
 )
 end_test
 
@@ -398,7 +403,7 @@ begin_expected_fail_test "Issue #7 Scenario 3"
   fi
 
   begin_fail_zone
-  [ "${override}" = "${ans}" ]
+  check_str "${override}" "${ans}"
 )
 end_test
 

--- a/tests/test-docker_functions.bsh
+++ b/tests/test-docker_functions.bsh
@@ -364,10 +364,10 @@ begin_test "docker compose volumes"
   targets=("/mnt" "/src" "/opt" "/src" "/tmp2")
   flags=("" "" "" "" "")
   formats=(short long short long long)
-  cmp_elements_a DOCKER_VOLUME_SOURCES sources
-  cmp_elements_a DOCKER_VOLUME_TARGETS targets
-  cmp_elements_a DOCKER_VOLUME_FLAGS flags
-  cmp_elements_a DOCKER_VOLUME_FORMATS formats
+  check_a DOCKER_VOLUME_SOURCES "${sources[@]}"
+  check_a DOCKER_VOLUME_TARGETS "${targets[@]}"
+  check_a DOCKER_VOLUME_FLAGS "${flags[@]}"
+  check_a DOCKER_VOLUME_FORMATS "${formats[@]}"
 
   DOCKER_VOLUME_LINES=("S/test1:/test2:ro"
                        "Stest3:/test4:Z"
@@ -392,6 +392,40 @@ begin_test "docker compose volumes"
   cmp_elements_a DOCKER_VOLUME_SOURCES sources
   cmp_elements_a DOCKER_VOLUME_TARGETS targets
   cmp_elements_a DOCKER_VOLUME_FLAGS flags
+)
+end_test
+
+begin_test "docker compose volumes with missing fields"
+(
+  setup_test
+  sources=("/tmp" "/home/user/src" "test" "internal" "")
+  targets=("/mnt" "/src" "/opt" "/src" "/tmp2")
+  flags=(":ro" "" "" "" "")
+  formats=(short long short long long)
+
+  DOCKER_VOLUME_LINES_ORIG=("S/tmp:/mnt:ro"
+       "Lsource: /home/user/src" "ltarget: /src" "ltype: bind"
+       "Stest:/opt"
+       "Lsource: internal" "ltarget: /src" "ltype: volume"
+       "Ltarget: /tmp2" "ltype: tmpfs")
+
+  DOCKER_VOLUME_LINES=("${DOCKER_VOLUME_LINES_ORIG[@]}")
+  unset DOCKER_VOLUME_LINES[2]
+  docker-compose-volumes
+
+  check_a DOCKER_VOLUME_SOURCES "${sources[@]}"
+  check_a DOCKER_VOLUME_TARGETS "/mnt" "" "/opt" "/src" "/tmp2"
+  check_a DOCKER_VOLUME_FLAGS "${flags[@]}"
+  check_a DOCKER_VOLUME_FORMATS "${formats[@]}"
+
+  DOCKER_VOLUME_LINES[1]='Ltarget: /src'
+  docker-compose-volumes
+
+  check_a DOCKER_VOLUME_SOURCES "/tmp" "" "test" "internal" ""
+  check_a DOCKER_VOLUME_TARGETS "${targets[@]}"
+  check_a DOCKER_VOLUME_FLAGS "${flags[@]}"
+  check_a DOCKER_VOLUME_FORMATS "${formats[@]}"
+
 )
 end_test
 

--- a/tests/test-docker_functions.bsh
+++ b/tests/test-docker_functions.bsh
@@ -371,13 +371,65 @@ begin_test "Parse docker-compose args"
   export JUSTFILE="${TESTDIR}/Justfile"
 
   parse-docker-compose run test
+  check_a docker_compose_args
+  [ "${docker_compose_arguments}" = "run" ]
+  check_a docker_compose_arguments_args test
+
+  # Test all args that take an argument
+  for arg in -f -p -H -c --file --project-name --host --context --log-level \
+             --tlscacert --tlscert --tlskey --project-directory --env-file; do
+    parse-docker-compose "${arg}" foobar
+    check_a docker_compose_args "${arg}" foobar
+    [ "${docker_compose_arguments-}" = "" ]
+    check_a docker_compose_arguments_args
+
+    # Test = notation
+    parse-docker-compose "${arg}=foobar"
+    check_a docker_compose_args "${arg}=foobar"
+    [ "${docker_compose_arguments-}" = "" ]
+    check_a docker_compose_arguments_args
+  done
+
+  # Test single letter combine notation too
+  for arg in -f -p -H -c; do
+    parse-docker-compose "${arg}foobar"
+    check_a docker_compose_args "${arg}foobar"
+    [ "${docker_compose_arguments-}" = "" ]
+    check_a docker_compose_arguments_args
+  done
+
+  # Test all flags
+  for arg in --no-ansi -v --verbose --tls --skip-hostname-check --tlsverify --compatibility; do
+    parse-docker-compose "${arg}"
+    check_a docker_compose_args "${arg}"
+    [ "${docker_compose_arguments-}" = "" ]
+    check_a docker_compose_arguments_args
+  done
 
   parse-docker-compose --no-ansi -H=blah.json --verbose run -v /foo:/bar debian bash
-  a1=(--no-ansi -H=blah.json --verbose)
-  a2=(-v /foo:/bar debian bash)
-  cmp_elements_a docker_compose_args a1
+  check_a docker_compose_args --no-ansi -H=blah.json --verbose
   [ "${docker_compose_arguments}" = "run" ]
-  cmp_elements_a docker_compose_arguments_args a2
+  check_a docker_compose_arguments_args -v /foo:/bar debian bash
+)
+end_test
+
+begin_test "Parse docker compose project name"
+(
+  setup_test
+
+  parse-docker-compose --project-name foo
+  [ "${docker_compose_project_name}" = "foo" ]
+
+  parse-docker-compose --project-name foo run alpine
+  [ "${docker_compose_project_name}" = "foo" ]
+  parse-docker-compose -p bar run alpine
+  [ "${docker_compose_project_name}" = "bar" ]
+  parse-docker-compose -p foobar run alpine
+  [ "${docker_compose_project_name}" = "foobar" ]
+
+  # Make sure -p/--project-name wins
+  COMPOSE_PROJECT_NAME=foo parse-docker-compose -p bar run alpine
+  [ "${docker_compose_project_name}" = "bar" ]
 )
 end_test
 

--- a/tests/test-docker_functions.bsh
+++ b/tests/test-docker_functions.bsh
@@ -403,44 +403,44 @@ begin_test "Parse docker-compose args"
 
   parse-docker-compose run test
   check_a docker_compose_args
-  [ "${docker_compose_arguments}" = "run" ]
-  check_a docker_compose_arguments_args test
+  [ "${docker_compose_command}" = "run" ]
+  check_a docker_compose_command_args test
 
   # Test all args that take an argument
   for arg in -f -p -H -c --file --project-name --host --context --log-level \
              --tlscacert --tlscert --tlskey --project-directory --env-file; do
     parse-docker-compose "${arg}" foobar
     check_a docker_compose_args "${arg}" foobar
-    [ "${docker_compose_arguments-}" = "" ]
-    check_a docker_compose_arguments_args
+    [ "${docker_compose_command-}" = "" ]
+    check_a docker_compose_command_args
 
     # Test = notation
     parse-docker-compose "${arg}=foobar"
     check_a docker_compose_args "${arg}=foobar"
-    [ "${docker_compose_arguments-}" = "" ]
-    check_a docker_compose_arguments_args
+    [ "${docker_compose_command-}" = "" ]
+    check_a docker_compose_command_args
   done
 
   # Test single letter combine notation too
   for arg in -f -p -H -c; do
     parse-docker-compose "${arg}foobar"
     check_a docker_compose_args "${arg}foobar"
-    [ "${docker_compose_arguments-}" = "" ]
-    check_a docker_compose_arguments_args
+    [ "${docker_compose_command-}" = "" ]
+    check_a docker_compose_command_args
   done
 
   # Test all flags
   for arg in --no-ansi -v --verbose --tls --skip-hostname-check --tlsverify --compatibility; do
     parse-docker-compose "${arg}"
     check_a docker_compose_args "${arg}"
-    [ "${docker_compose_arguments-}" = "" ]
-    check_a docker_compose_arguments_args
+    [ "${docker_compose_command-}" = "" ]
+    check_a docker_compose_command_args
   done
 
   parse-docker-compose --no-ansi -H=blah.json --verbose run -v /foo:/bar debian bash
   check_a docker_compose_args --no-ansi -H=blah.json --verbose
-  [ "${docker_compose_arguments}" = "run" ]
-  check_a docker_compose_arguments_args -v /foo:/bar debian bash
+  [ "${docker_compose_command}" = "run" ]
+  check_a docker_compose_command_args -v /foo:/bar debian bash
 )
 end_test
 

--- a/tests/test-docker_functions.bsh
+++ b/tests/test-docker_functions.bsh
@@ -200,12 +200,43 @@ end_test
 begin_test "Parse docker args"
 (
   setup_test
+
+  # Normal case
   parse-docker --config=blah.json -D -v run -v /foo:/bar debian:9 bash
-  a1=(--config=blah.json -D -v)
-  a2=(-v /foo:/bar debian:9 bash)
-  cmp_elements_a docker_args a1
+  check_a docker_args --config=blah.json -D -v
   [ "${docker_command}" = "run" ]
-  cmp_elements_a docker_command_args a2
+  check_a docker_command_args -v /foo:/bar debian:9 bash
+
+  # Test all args that take an argument
+  for arg in -H -l --config --context --host --log-level --tlscacert --tlscert --tlskey; do
+    parse-docker "${arg}" foobar
+    declare -p docker_args docker_command docker_command_args
+    check_a docker_args "${arg}" foobar
+    [ "${docker_command-}" = "" ]
+    check_a docker_command_args
+
+    # Test = notation
+    parse-docker "${arg}=foobar"
+    check_a docker_args "${arg}=foobar"
+    [ "${docker_command-}" = "" ]
+    check_a docker_command_args
+  done
+
+  # Test single letter combine notation too
+  for arg in -H -l; do
+    parse-docker "${arg}foobar"
+    check_a docker_args "${arg}foobar"
+    [ "${docker_command-}" = "" ]
+    check_a docker_command_args
+  done
+
+  # Test all flags
+  for arg in -v --version --tls -D --debug --tlsverify; do
+    parse-docker "${arg}"
+    check_a docker_args "${arg}"
+    [ "${docker_command-}" = "" ]
+    check_a docker_command_args
+  done
 )
 end_test
 

--- a/tests/test-just_entrypoint_functions.bsh
+++ b/tests/test-just_entrypoint_functions.bsh
@@ -52,7 +52,7 @@ begin_test "default setup user"
 
   read_file passwd mocked_passwd
   read_file group mocked_group
-  check_a mocked_passwd "user:x:1000:1000::/home/user:`which bash`" "${init_passwd[@]}"
+  check_a mocked_passwd "user:x:1000:1000::/home/user:$(command -v bash)" "${init_passwd[@]}"
   check_a mocked_group "user:x:1000:" "${init_group[@]}"
   [ "$(cat mockout)" = $'mkdir -p /home/user\nchown 1000:1000 /home/user' ]
 )
@@ -73,7 +73,7 @@ begin_test "custom setup user"
 
   read_file passwd mocked_passwd
   read_file group mocked_group
-  check_a mocked_passwd "foo:x:100:0::/nothome/foobar:`which bash`" "${init_passwd[@]}"
+  check_a mocked_passwd "foo:x:100:0::/nothome/foobar:$(command -v bash)" "${init_passwd[@]}"
   check_a mocked_group "bar:x:102:foo" "open:x:101:foo" "${init_group[0]}" "daemon:x:1:root,foo"
   [ "$(cat mockout)" = $'mkdir -p /nothome/foobar\nchown 100:0 /nothome/foobar' ]
 )
@@ -90,7 +90,7 @@ begin_test "setup user only"
 
   read_file passwd mocked_passwd
   read_file group mocked_group
-  check_a mocked_passwd "user:x:1000:1000::/home/user:`which bash`" "${init_passwd[@]}"
+  check_a mocked_passwd "user:x:1000:1000::/home/user:$(command -v bash)" "${init_passwd[@]}"
   check_a mocked_group "${init_group[@]}"
   [ "$(cat mockout)" = $'mkdir -p /home/user\nchown 1000:1000 /home/user' ]
 )

--- a/tests/test-just_functions.bsh
+++ b/tests/test-just_functions.bsh
@@ -470,11 +470,11 @@ begin_test "defaultify DRYRUN trigger"
 
   [ "${DRYRUN}" = "" ]
   defaultify --dryrun
-  [ "${DRYRUN}" = "print_command just --wrap" ]
+  [ "${DRYRUN}" = "print_command_env just --wrap" ]
 
   DRYRUN=""
   defaultify -n
-  [ "${DRYRUN}" = "print_command just --wrap" ]
+  [ "${DRYRUN}" = "print_command_env just --wrap" ]
 )
 end_test
 

--- a/tests/test-just_functions.bsh
+++ b/tests/test-just_functions.bsh
@@ -828,3 +828,43 @@ begin_test "Need tty"
   SSH_TTY=windows-pty result="None" OS=Windows_NT need_tty
 )
 end_test
+
+begin_test "Translate Just Settings"
+(
+  setup_test
+
+  # Windows style escaped
+  JUST_SETTINGS=//c/foo/bar/////c/foo/car/////c/foo/external/stuff
+  translate_just_settings /c/foo /src
+  check_a JUST_SETTINGSS /src/bar /src/car /src/external/stuff
+
+  # Different combos of windows style escaped
+  JUST_SETTINGS=/c/foo/bar
+  translate_just_settings /c/foo //src
+  check_a JUST_SETTINGSS //src/bar
+
+  JUST_SETTINGS=//c/foo/bar
+  translate_just_settings /c/foo //src
+  check_a JUST_SETTINGSS //src/bar
+
+  JUST_SETTINGS=/c/foo/bar
+  translate_just_settings //c/foo //src
+  check_a JUST_SETTINGSS //src/bar
+
+  # Empty test
+  unset JUST_SETTINGS
+  translate_just_settings /test
+  # Make sure empty
+  check_a JUST_SETTINGSS
+
+  # Normal
+  JUST_SETTINGS=/foo/bar
+  translate_just_settings /foo /src
+  check_a JUST_SETTINGSS /src/bar
+
+  # Multiple
+  JUST_SETTINGS=/foo/bar////foo/car
+  translate_just_settings /foo /src
+  check_a JUST_SETTINGSS /src/bar /src/car
+)
+end_test

--- a/tests/test-just_wrap.bsh
+++ b/tests/test-just_wrap.bsh
@@ -228,7 +228,7 @@ begin_test "Interactive just_wrap"
         . '${VSI_COMMON_DIR}/linux/Just_wrap' "'${@+"${@}"}' > mywrap
   chmod 755 mywrap
 
-  session="${TRASHDIR////}"
+  session="${TRASHDIR//"/"/}"
 
   screen -dmS "${session}"
   # Macos compatibility, needs a literal newline
@@ -259,5 +259,5 @@ end_test
 function teardown()
 {
   # cleanup in case test fails
-  command -v screen >& /dev/null && screen -S "${TRASHDIR////}" -X quit >& /dev/null || :
+  command -v screen >& /dev/null && screen -S "${TRASHDIR//"/"/}" -X quit >& /dev/null || :
 }

--- a/tests/test-just_wrap.bsh
+++ b/tests/test-just_wrap.bsh
@@ -228,7 +228,7 @@ begin_test "Interactive just_wrap"
         . '${VSI_COMMON_DIR}/linux/Just_wrap' "'${@+"${@}"}' > mywrap
   chmod 755 mywrap
 
-  session="${TRASHDIR//"/"/}"
+  session="${TRASHDIR////}"
 
   screen -dmS "${session}"
   # Macos compatibility, needs a literal newline
@@ -259,5 +259,5 @@ end_test
 function teardown()
 {
   # cleanup in case test fails
-  command -v screen >& /dev/null && screen -S "${TRASHDIR//"/"/}" -X quit >& /dev/null || :
+  command -v screen >& /dev/null && screen -S "${TRASHDIR////}" -X quit >& /dev/null || :
 }

--- a/tests/test-linux_accounts.bsh
+++ b/tests/test-linux_accounts.bsh
@@ -42,7 +42,7 @@ begin_test "add to passwd"
 (
   setup_test
 
-  ans=("foo:x:1000:1000::/home/foo:$(which bash)")
+  ans=("foo:x:1000:1000::/home/foo:$(command -v bash)")
   add_to_passwd foo
   check_a passwd "${ans[@]}"
 
@@ -205,7 +205,7 @@ begin_test "add user"
   setup_test
   setup_mock
 
-  ans=("foo:x:1000:1000::/home/foo:$(which bash)"
+  ans=("foo:x:1000:1000::/home/foo:$(command -v bash)"
        "root:x:0:0:root:/root:/bin/bash"
        "daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin")
   anss=("^foo:\*:[0-9]*:0:99999:7:::$"
@@ -223,14 +223,14 @@ begin_test "add user"
     LINUX_ACCOUNTS_AUTOSAVE=0 add_user bar
     cmp passwd <(IFS=$'\n'; echo "${ans[*]}")
     write_user_data
-    ans=("bar:x:1000:1000::/home/bar:$(which bash)" "${ans[@]}")
+    ans=("bar:x:1000:1000::/home/bar:$(command -v bash)" "${ans[@]}")
     cmp passwd <(IFS=$'\n'; echo "${ans[*]}")
 
     [ ! -f shadow ]
   )
 
   # Shadow test
-  ans[0]="foo:x:1000:0::/home/foo:$(which bash)"
+  ans[0]="foo:x:1000:0::/home/foo:$(command -v bash)"
   echo "${ans[1]}" > passwd
   echo "${ans[2]}" >> passwd
   echo "root:*:17543:0:99999:7:::" > shadow

--- a/tests/test-lwhich.bsh
+++ b/tests/test-lwhich.bsh
@@ -43,7 +43,7 @@ test_lwhich()
   fi
 }
 
-if [ -e /etc/ld.so.cache ] || grep -q '/etc/ld\.so\.conf' `command -v ldconfig`; then
+if [ -e /etc/ld.so.cache ] || grep -q '/etc/ld\.so\.conf' "$(command -v ldconfig)" &> /dev/null; then
   if ${LDCONFIG-ldconfig} -p | !grep x86-64 &> /dev/null; then
     skip_next_test
   fi
@@ -58,7 +58,7 @@ begin_test "lwhich 64"
 )
 end_test
 
-if [ -e /etc/ld.so.cache ] || grep -q '/etc/ld\.so\.conf' `command -v ldconfig`; then
+if [ -e /etc/ld.so.cache ] || grep -q '/etc/ld\.so\.conf' "$(command -v ldconfig)" &> /dev/null; then
   if [ "$(${LDCONFIG-ldconfig} -p | grep -v 'x86-64' | wc -l)" -lt "2" ]; then
     skip_next_test
   fi
@@ -73,17 +73,19 @@ begin_test "lwhich 32"
 )
 end_test
 
+if [ -e /etc/ld.so.cache ] || grep -q '/etc/ld\.so\.conf' "$(command -v ldconfig)" &> /dev/null; then
+  filename="$(${LDCONFIG-ldconfig} -p | tail -n 1 | awk -F ' => ' '{print $2}')"
+else
+  filename="$(find /lib /usr/local/lib /usr/lib /usr/bin -maxdepth 1 \( -name \*.so -o -name \*.dylib -o -name \*.dll \) -print -quit 2>/dev/null || :)"
+fi
+if [ "${filename}" = "" ]; then
+  skip_next_test
+fi
 begin_test "lwhich LD_LIBRARY_PATH"
 (
   setup_test
 
   source "${VSI_COMMON_DIR}/linux/bin_utils.bsh"
-
-  if [ -e /etc/ld.so.cache ] || grep -q '/etc/ld\.so\.conf' `command -v ldconfig`; then
-    filename="$(${LDCONFIG-ldconfig} -p | tail -n 1 | awk -F ' => ' '{print $2}')"
-  else
-    filename="$(find /lib /usr/local/lib /usr/lib /usr/bin -maxdepth 1 \( -name \*.so -o -name \*.dylib -o -name \*.dll \) -print -quit 2>/dev/null || :)"
-  fi
 
   answer="${TESTDIR}/libqwertyuiop.so"
   bits=($(object_bits "${filename}"))

--- a/tests/test-lwhich.bsh
+++ b/tests/test-lwhich.bsh
@@ -43,8 +43,8 @@ test_lwhich()
   fi
 }
 
-if [ -e /etc/ld.so.cache ]; then
-  if ${LDCONFIG-ldconfig} -p | grep x86-64 &> /dev/null; then
+if [ -e /etc/ld.so.cache ] || grep -q '/etc/ld\.so\.conf' `command -v ldconfig`; then
+  if ${LDCONFIG-ldconfig} -p | !grep x86-64 &> /dev/null; then
     skip_next_test
   fi
 elif [ "$(uname -m)" != "x86_64" ]; then
@@ -58,7 +58,7 @@ begin_test "lwhich 64"
 )
 end_test
 
-if [ -e /etc/ld.so.cache ]; then
+if [ -e /etc/ld.so.cache ] || grep -q '/etc/ld\.so\.conf' `command -v ldconfig`; then
   if [ "$(${LDCONFIG-ldconfig} -p | grep -v 'x86-64' | wc -l)" -lt "2" ]; then
     skip_next_test
   fi
@@ -79,7 +79,7 @@ begin_test "lwhich LD_LIBRARY_PATH"
 
   source "${VSI_COMMON_DIR}/linux/bin_utils.bsh"
 
-  if [ -e /etc/ld.so.cache ]; then
+  if [ -e /etc/ld.so.cache ] || grep -q '/etc/ld\.so\.conf' `command -v ldconfig`; then
     filename="$(${LDCONFIG-ldconfig} -p | tail -n 1 | awk -F ' => ' '{print $2}')"
   else
     filename="$(find /lib /usr/local/lib /usr/lib /usr/bin -maxdepth 1 \( -name \*.so -o -name \*.dylib -o -name \*.dll \) -print -quit 2>/dev/null || :)"

--- a/tests/test-print_command.bsh
+++ b/tests/test-print_command.bsh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 . "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
+. "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 
@@ -8,12 +9,18 @@ function common_test()
 {
   [ "$(type -t print_command)" = "$1" ]
 
-  [ "$(print_command)" = "" ]
-  [ "$(print_command foo %s bar)" = "foo %s bar" ]
-  [ "$(print_command -n test -e foobar)" = "-n test -e foobar" ]
-  [ "$(print_command 'azAZ0-9_.:/=@%^,+-')" = "azAZ0-9_.:/=@%^,+-" ]
-  [ "$(print_command '!' \* \$ \# \@ \(\) \{\} \[\] \;)" = "'!' '*' '$' '#' @ '()' '{}' '[]' ';'" ]
-  [ "$(print_command echo test "this'this" "" "f o  o")" = "echo test 'this'\"'\"'this' '' 'f o  o'" ]
+  check_str "$(print_command)" \
+            ""
+  check_str "$(print_command foo %s bar)" \
+            "foo %s bar"
+  check_str "$(print_command -n test -e foobar)" \
+            "-n test -e foobar"
+  check_str "$(print_command 'azAZ0-9_.:/=@%^,+-')" \
+            "azAZ0-9_.:/=@%^,+-"
+  check_str "$(print_command '!' \* \$ \# \@ \(\) \{\} \[\] \;)" \
+            "'!' '*' '$' '#' @ '()' '{}' '[]' ';'"
+  check_str "$(print_command echo test "this'this" "" "f o  o")" \
+            "echo test 'this'\"'\"'this' '' 'f o  o'"
 }
 
 begin_test "print_command CLI"
@@ -40,15 +47,28 @@ begin_test "print_command_env"
   export B=2
   print_command_save_env
 
-  [ "$(print_command_env foo)" = "foo" ]
-  [ "$(print_command_env foo "b a  r")" = "foo 'b a  r'" ]
-  [ "$(A=3 print_command_env foo)" = "foo" ]
-  [ "$(B=3 print_command_env foo)" = "B=3 foo" ]
-  [ "$(C="b a  r" print_command_env foo)" = "C='b a  r' foo" ]
-  [ "$(unset A; print_command_env foo)" = "(unset A; foo)" ]
-  [ "$(export B="f  o o"; unset A; D=15 C="b a  r" print_command_env foo)" = "(unset A; B='f  o o' C='b a  r' D=15 foo)" ]
+  check_str "$(print_command_env foo)" \
+            "foo"
+  check_str "$(print_command_env foo "b a  r")" \
+            "foo 'b a  r'"
+  check_str "$(A=3 print_command_env foo)" \
+            "foo"
+  check_str "$(B=3 print_command_env foo)" \
+            "B=3 foo"
+  check_str "$(C="b a  r" print_command_env foo)" \
+            "C='b a  r' foo"
+  check_str "$(unset A; print_command_env foo)" \
+            "(unset A; foo)"
+  check_str "$(export B="f  o o"; unset A; D=15 C="b a  r" print_command_env foo)" \
+            "(unset A; B='f  o o' C='b a  r' D=15 foo)"
 
+  # Test child process
   export print_command_env
-  [ "$(B=15 bash -c "print_command_env foo bar")" = "B=15 foo bar" ]
+  check_str "$(B=15 bash -c "print_command_env foo bar")" \
+            "B=15 foo bar"
+
+  # Test cd
+  check_str "$(unset A; B=15 C="b a  r" bash -c "cd "${TRASHDIR}"; print_command_env foo bar")" \
+            "(cd ${TRASHDIR}; unset A; B=15 C='b a  r' foo bar)"
 )
 end_test

--- a/tests/test-print_command.bsh
+++ b/tests/test-print_command.bsh
@@ -20,7 +20,7 @@ function common_test()
   check_str "$(print_command '!' \* \$ \# \@ \(\) \{\} \[\] \;)" \
             "'!' '*' '$' '#' @ '()' '{}' '[]' ';'"
   check_str "$(print_command echo test "this'this" "" "f o  o")" \
-            "echo test 'this'\"'\"'this' '' 'f o  o'"
+            "echo test 'this'\''this' '' 'f o  o'"
 }
 
 begin_test "print_command CLI"
@@ -62,13 +62,43 @@ begin_test "print_command_env"
   check_str "$(export B="f  o o"; unset A; D=15 C="b a  r" print_command_env foo)" \
             "(unset A; B='f  o o' C='b a  r' D=15 foo)"
 
+  check_str "$(export C='!*$#@(){}[];'; print_command_env foo)" \
+            "C='!*\$#@(){}[];' foo"
+  check_str "$(export D="this'this" E="" F="f o  o"; print_command_env bar)" \
+            "D='this'\''this' E='' F='f o  o' bar"
+
   # Test child process
-  export print_command_env
+  export -f print_command_env
+  export -f quote_escape
+
   check_str "$(B=15 bash -c "print_command_env foo bar")" \
             "B=15 foo bar"
 
   # Test cd
   check_str "$(unset A; B=15 C="b a  r" bash -c "cd "${TRASHDIR}"; print_command_env foo bar")" \
             "(cd ${TRASHDIR}; unset A; B=15 C='b a  r' foo bar)"
+)
+end_test
+
+begin_test "print_command_env locally shadowed variable"
+(
+  setup_test
+  . "${VSI_COMMON_DIR}/linux/print_command"
+
+  export x=15
+  print_command_save_env
+  function foo()
+  {
+    local x
+
+    value="$(print_command_env hi)"
+
+    if [ "${BASH_VERSINFO[0]}" = "4" -a "${BASH_VERSINFO[1]}" -lt "3" ] || [ "${BASH_VERSINFO[0]}" -lt "4" ]; then
+      check_str "${value}" "(unset x; hi)"
+    else
+      check_str "${value}" "hi"
+    fi
+  }
+  foo
 )
 end_test

--- a/tests/test-print_command.bsh
+++ b/tests/test-print_command.bsh
@@ -10,9 +10,10 @@ function common_test()
 
   [ "$(print_command)" = "" ]
   [ "$(print_command foo %s bar)" = "foo %s bar" ]
+  [ "$(print_command -n test -e foobar)" = "-n test -e foobar" ]
   [ "$(print_command 'azAZ0-9_.:/=@%^,+-')" = "azAZ0-9_.:/=@%^,+-" ]
   [ "$(print_command '!' \* \$ \# \@ \(\) \{\} \[\] \;)" = "'!' '*' '$' '#' @ '()' '{}' '[]' ';'" ]
-  [ "$(print_command echo test "this'this" "f o  o")" = "echo test 'this'\"'\"'this' 'f o  o'" ]
+  [ "$(print_command echo test "this'this" "" "f o  o")" = "echo test 'this'\"'\"'this' '' 'f o  o'" ]
 }
 
 begin_test "print_command CLI"
@@ -27,5 +28,27 @@ begin_test "print_command"
   setup_test
   . "${VSI_COMMON_DIR}/linux/print_command"
   common_test function
+)
+end_test
+
+begin_test "print_command_env"
+(
+  setup_test
+  . "${VSI_COMMON_DIR}/linux/print_command"
+
+  export A=3
+  export B=2
+  print_command_save_env
+
+  [ "$(print_command_env foo)" = "foo" ]
+  [ "$(print_command_env foo "b a  r")" = "foo 'b a  r'" ]
+  [ "$(A=3 print_command_env foo)" = "foo" ]
+  [ "$(B=3 print_command_env foo)" = "B=3 foo" ]
+  [ "$(C="b a  r" print_command_env foo)" = "C='b a  r' foo" ]
+  [ "$(unset A; print_command_env foo)" = "(unset A; foo)" ]
+  [ "$(export B="f  o o"; unset A; D=15 C="b a  r" print_command_env foo)" = "(unset A; B='f  o o' C='b a  r' D=15 foo)" ]
+
+  export print_command_env
+  [ "$(B=15 bash -c "print_command_env foo bar")" = "B=15 foo bar" ]
 )
 end_test

--- a/tests/test-quotemire.bsh
+++ b/tests/test-quotemire.bsh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 
 . "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
+. "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 
 function common_test()
 {
-  [ "$(type -t quotemire)" = "$1" ]
-
-  [ "$(quotemire)" = "" ]
-  [ "$(quotemire "ssh server -l admin" "sudo -u foo" "echo hi")" = 'ssh server -l admin '"'"'sudo -u foo '"'"'"'"'"'"'"'"'echo hi'"'"'"'"'"'"'"'"''"'"'' ]
+  check_str "$(type -t quotemire)" "$1"
+  check_str "$(quotemire)" ""
+  check_str "$(quotemire "ssh server -l admin" "sudo -u foo" "echo hi")" \
+            'ssh server -l admin '\''sudo -u foo '\'\\\'\''echo hi'\'\\\'\'''"'"'' ]
 }
 
 begin_test "quotemire CLI"

--- a/tests/test-real_path.bsh
+++ b/tests/test-real_path.bsh
@@ -79,6 +79,8 @@ begin_test "compare real_path_manual with realpath"
 
   # Break the chain
   rm a
-  [ "$(real_path_manual d)" = "$(realpath d)" ]
+  ans="$(realpath d || :)"
+  # On busybox, a broken link chain will return only the first valid symlink rather than the last valid symlink like everywhere else in the world.
+  [ "${ans}" = "${TESTDIR}/cmp/c  c" ] || [ "$(real_path_manual d)" = "${ans}" ]
 )
 end_test

--- a/tests/test-set_flags.bsh
+++ b/tests/test-set_flags.bsh
@@ -68,7 +68,7 @@ begin_test "set unset and reset flag"
   unset_flag m
   unset_flag m
   reset_flag m
-  [[ ${-} =~ m ]] # Original state
+  [[ ${-} =~ m ]] || false # Original state
 )
 end_test
 

--- a/tests/test-test_utils.bsh
+++ b/tests/test-test_utils.bsh
@@ -129,7 +129,7 @@ begin_test "Test check string"
   # Make sure the rv is non-zero
   not check_str 1234567890 1234566890 &> /dev/null
   # Middles wrong
-  [[ $(check_str 1234567890 1234566890 2>&1 | xxd) = *$(ans 123456 7 890 123456 6 890 | xxd)* ]] || false
+  [[ $(check_str 1234567890 1234566890 2>&1) = *$(ans 123456 7 890 123456 6 890)* ]] || false
   [[ $(check_str 1234567890 1234576890 2>&1) = *$(ans 12345 67 890 12345 76 890)* ]] || false
   [[ $(check_str 1234567890 12345890 2>&1) = *$(ans 12345 67 890 12345 "" 890)* ]] || false
   [[ $(check_str 12345890 1234567890 2>&1) = *$(ans 12345 "" 890 12345 67 890)* ]] || false

--- a/tests/test-test_utils.bsh
+++ b/tests/test-test_utils.bsh
@@ -4,6 +4,91 @@
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
+begin_test "Test check array"
+(
+  setup_test
+
+  a1=()
+  a2=(11 22 33)
+  check_a a1
+  check_a a2 11 22 33
+
+  ans0=$'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ"$'\n'
+
+  not check_a a1 ""
+  check_str "$(check_a a1 "" 2>&1)" \
+            "${ans0}"$'a1=()\nArray had 1 too few values'
+  not check_a a2 11 22 33 44
+  check_str "$(check_a a2 11 22 33 44 2>&1)" \
+            "${ans0}"$'a2=(11 22 33)\nArray had 1 too few values'
+  not check_a a2 22 33
+  check_str "$(check_a a2 22 33 2>&1)" \
+            "${ans0}"$'Element 0 (a2[0]) is different:\n11 != 22'
+  not check_a a2 11 33
+  check_str "$(check_a a2 11 33 2>&1)" \
+            "${ans0}"$'Element 1 (a2[1]) is different:\n22 != 33'
+  not check_a a2 11 22
+  check_str "$(check_a a2 11 22 2>&1)" \
+            "${ans0}"$'a2=(11 22 33)\nArray had 1 too many values'
+
+  # Non contiguous case
+  unset a2[1]
+  not check_a a2 11 22
+  check_str "$(check_a a2 11 22 2>&1)" \
+            "${ans0}"$'Element 1 (a2[2]) is different:\n33 != 22'
+)
+end_test
+
+begin_test "Test regex check array"
+(
+  setup_test
+
+  a1=()
+  a2=(11 22 33)
+  check_ra a1
+  check_ra a2 11 22 33
+
+  check_ra a2 1+ '^[0-9]+$' 3
+  check_ra a2 2* . '^33$'
+  not check_ra a2 1+ '^[0-9]+$' 4
+
+  not check_ra a1 ""
+  not check_ra a2 11 22 33 44
+  not check_ra a2 22 33
+  not check_ra a2 11 22
+)
+end_test
+
+begin_test "Test contiguous array"
+(
+  setup_test
+  a1=(1 2 3)
+  contiguous_a a1
+
+  unset a1[0]
+  not contiguous_a a1
+
+  a1=(1 2 3)
+  unset a1[1]
+  not contiguous_a a1
+  a1+=(4)
+  not contiguous_a a1
+
+  a1=(1 2 3)
+  unset a1[2]
+  contiguous_a a1
+  unset a1[1]
+  contiguous_a a1
+  a1+=(4)
+  contiguous_a a1
+  unset a1[1]
+  unset a1[0]
+  contiguous_a a1
+  a1+=(4)
+  contiguous_a a1
+)
+end_test
+
 begin_test "Test check string"
 (
   setup_test
@@ -13,7 +98,9 @@ begin_test "Test check string"
   function ans()
   {
     echo $'\e[1;31m'"ERROR"$'\e[0m'": Strings differ"
+    echo "====================="
     echo "${1}"$'\e[1;31m'"${2}"$'\e[0m'"${3}"
+    echo "---------------------"
     echo "${4}"$'\e[1;31m'"${5}"$'\e[0m'"${6}"
   }
 
@@ -38,5 +125,9 @@ begin_test "Test check string"
   [ "$(check_str uvwxyz uvwxyZ 2>&1)" = "$(ans uvwxy z "" uvwxy Z "")" ]
   [ "$(check_str uvwxyz uvwxy 2>&1)" = "$(ans uvwxy z "" uvwxy "" "")" ]
   [ "$(check_str uvwxy uvwxyz 2>&1)" = "$(ans uvwxy "" "" uvwxy z "")" ]
+
+  # [ "$(check_str $'ERROR: Arrays differ\nArray had 1 too many values' $'ERROR: Arrays differ\na2=(11 22 33)\nArray had 1 too many values')" =
+  #   "$(ans $'ERROR: Arrays differ\n "" "Array had 1 too many values"
+  #          $'ERROR: Arrays differ\n "a2=(11 22 33)" "Array had 1 too many values")" ]
 )
 end_test

--- a/tests/test-test_utils.bsh
+++ b/tests/test-test_utils.bsh
@@ -105,7 +105,7 @@ begin_test "Test check string"
   }
 
   # Make sure the rv is non-zero
-  not check_str 1234567890 1234566890
+  not check_str 1234567890 1234566890 &> /dev/null
   # Middles wrong
   [ "$(check_str 1234567890 1234566890 2>&1)" = "$(ans 123456 7 890 123456 6 890)" ]
   [ "$(check_str 1234567890 1234576890 2>&1)" = "$(ans 12345 67 890 12345 76 890)" ]
@@ -126,8 +126,8 @@ begin_test "Test check string"
   [ "$(check_str uvwxyz uvwxy 2>&1)" = "$(ans uvwxy z "" uvwxy "" "")" ]
   [ "$(check_str uvwxy uvwxyz 2>&1)" = "$(ans uvwxy "" "" uvwxy z "")" ]
 
-  # [ "$(check_str $'ERROR: Arrays differ\nArray had 1 too many values' $'ERROR: Arrays differ\na2=(11 22 33)\nArray had 1 too many values')" =
-  #   "$(ans $'ERROR: Arrays differ\n "" "Array had 1 too many values"
-  #          $'ERROR: Arrays differ\n "a2=(11 22 33)" "Array had 1 too many values")" ]
+  # Corner case due to malformed for loop (, instead of &&)
+  [ "$(check_str 167890ab 167767890ab 2>&1)" = \
+    "$(ans 167 "" 890ab 167 767 890ab)" ]
 )
 end_test

--- a/tests/test-test_utils.bsh
+++ b/tests/test-test_utils.bsh
@@ -34,22 +34,19 @@ function common_check_array_test()
   ans="${ans0}Element 0 (a2[0]) is different:"
   ans+=$'\n11 !='"${2-} 22"
   ans+=$'\ndeclare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
-  [[ $(${1} a2 22 33 2>&1) = \
-     *"${ans}"* ]] || false
+  [[ $(${1} a2 22 33 2>&1) = *"${ans}"* ]] || false
 
   not ${1} a2 11 33 &> /dev/null
   ans="${ans0}Element 1 (a2[1]) is different:"
   ans+=$'\n22 !='"${2-} 33"
   ans+=$'\ndeclare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
-  [[ $(${1} a2 11 33 2>&1) = \
-     *"${ans}"* ]] || false
+  [[ $(${1} a2 11 33 2>&1) = *"${ans}"* ]] || false
 
   not ${1} a2 11 22 &> /dev/null
   ans="${ans0}a2=(11 22 33)"
   ans+=$'\nArray had 1 too many values'
   ans+=$'\ndeclare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
-  [[ $(${1} a2 11 22 2>&1) = \
-     *"${ans}"* ]] || false
+  [[ $(${1} a2 11 22 2>&1) = *"${ans}"* ]] || false
 
   # Non contiguous case
   unset a2[1]
@@ -57,8 +54,7 @@ function common_check_array_test()
   ans="${ans0}Element 1 (a2[2]) is different:"
   ans+=$'\n33 !='"${2-} 22"
   ans+=$'\ndeclare -a a2='"${bq}"'([0]="11" [2]="33")'"${bq}"
-  [[ $(${1} a2 11 22 2>&1) = \
-     *"${ans}"* ]] || false
+  [[ $(${1} a2 11 22 2>&1) = *"${ans}"* ]] || false
 }
 
 begin_test "Test check array"
@@ -134,26 +130,26 @@ begin_test "Test check string"
   # Make sure the rv is non-zero
   not check_str 1234567890 1234566890 &> /dev/null
   # Middles wrong
-  [[ $(check_str 1234567890 1234566890 2>&1) = *$(ans 123456 7 890 123456 6 890)* ]]
-  [[ $(check_str 1234567890 1234576890 2>&1) = *$(ans 12345 67 890 12345 76 890)* ]]
-  [[ $(check_str 1234567890 12345890 2>&1) = *$(ans 12345 67 890 12345 "" 890)* ]]
-  [[ $(check_str 12345890 1234567890 2>&1) = *$(ans 12345 "" 890 12345 67 890)* ]]
-  [[ $(check_str 1234555890 123455567890 2>&1) = *$(ans 1234555 "" 890 1234555 67 890)* ]]
-  [[ $(check_str 1234567890 1@34567890 2>&1) = *$(ans 1 2 34567890 1 @ 34567890)* ]]
-  [[ $(check_str 1234567890 12345678^0 2>&1) = *$(ans 12345678 9 0 12345678 ^ 0)* ]]
+  [[ $(check_str 1234567890 1234566890 2>&1) = *$(ans 123456 7 890 123456 6 890)* ]] | false
+  [[ $(check_str 1234567890 1234576890 2>&1) = *$(ans 12345 67 890 12345 76 890)* ]] | false
+  [[ $(check_str 1234567890 12345890 2>&1) = *$(ans 12345 67 890 12345 "" 890)* ]] | false
+  [[ $(check_str 12345890 1234567890 2>&1) = *$(ans 12345 "" 890 12345 67 890)* ]] | false
+  [[ $(check_str 1234555890 123455567890 2>&1) = *$(ans 1234555 "" 890 1234555 67 890)* ]] | false
+  [[ $(check_str 1234567890 1@34567890 2>&1) = *$(ans 1 2 34567890 1 @ 34567890)* ]] | false
+  [[ $(check_str 1234567890 12345678^0 2>&1) = *$(ans 12345678 9 0 12345678 ^ 0)* ]] | false
 
   # Beginning wrong
-  [[ $(check_str abcdef ABCdef 2>&1) = *$(ans "" abc def "" ABC def)* ]]
-  [[ $(check_str abcdef Abcdef 2>&1) = *$(ans "" a bcdef "" A bcdef)* ]]
-  [[ $(check_str abcdef bcdef 2>&1) = *$(ans "" a bcdef "" "" bcdef)* ]]
-  [[ $(check_str bcdef abcdef 2>&1) = *$(ans "" "" bcdef "" a bcdef)* ]]
+  [[ $(check_str abcdef ABCdef 2>&1) = *$(ans "" abc def "" ABC def)* ]] | false
+  [[ $(check_str abcdef Abcdef 2>&1) = *$(ans "" a bcdef "" A bcdef)* ]] | false
+  [[ $(check_str abcdef bcdef 2>&1) = *$(ans "" a bcdef "" "" bcdef)* ]] | false
+  [[ $(check_str bcdef abcdef 2>&1) = *$(ans "" "" bcdef "" a bcdef)* ]] | false
   # End wrong
-  [[ $(check_str uvwxyz uvwXYZ 2>&1) = *$(ans uvw xyz "" uvw XYZ "")* ]]
-  [[ $(check_str uvwxyz uvwxyZ 2>&1) = *$(ans uvwxy z "" uvwxy Z "")* ]]
-  [[ $(check_str uvwxyz uvwxy 2>&1) = *$(ans uvwxy z "" uvwxy "" "")* ]]
-  [[ $(check_str uvwxy uvwxyz 2>&1) = *$(ans uvwxy "" "" uvwxy z "")* ]]
+  [[ $(check_str uvwxyz uvwXYZ 2>&1) = *$(ans uvw xyz "" uvw XYZ "")* ]] | false
+  [[ $(check_str uvwxyz uvwxyZ 2>&1) = *$(ans uvwxy z "" uvwxy Z "")* ]] | false
+  [[ $(check_str uvwxyz uvwxy 2>&1) = *$(ans uvwxy z "" uvwxy "" "")* ]] | false
+  [[ $(check_str uvwxy uvwxyz 2>&1) = *$(ans uvwxy "" "" uvwxy z "")* ]] | false
 
   # Corner case due to malformed for loop (, instead of &&)
-  [[ $(check_str 167890ab 167767890ab 2>&1) = *$(ans 167 "" 890ab 167 767 890ab)* ]]
+  [[ $(check_str 167890ab 167767890ab 2>&1) = *$(ans 167 "" 890ab 167 767 890ab)* ]] | false
 )
 end_test

--- a/tests/test-test_utils.bsh
+++ b/tests/test-test_utils.bsh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
+VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+. "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
+
+begin_test "Test check string"
+(
+  setup_test
+
+  check_str 1234567890 1234567890
+
+  function ans()
+  {
+    echo $'\e[1;31m'"ERROR"$'\e[0m'": Strings differ"
+    echo "${1}"$'\e[1;31m'"${2}"$'\e[0m'"${3}"
+    echo "${4}"$'\e[1;31m'"${5}"$'\e[0m'"${6}"
+  }
+
+  # Make sure the rv is non-zero
+  not check_str 1234567890 1234566890
+  # Middles wrong
+  [ "$(check_str 1234567890 1234566890 2>&1)" = "$(ans 123456 7 890 123456 6 890)" ]
+  [ "$(check_str 1234567890 1234576890 2>&1)" = "$(ans 12345 67 890 12345 76 890)" ]
+  [ "$(check_str 1234567890 12345890 2>&1)" = "$(ans 12345 67 890 12345 "" 890)" ]
+  [ "$(check_str 12345890 1234567890 2>&1)" = "$(ans 12345 "" 890 12345 67 890)" ]
+  [ "$(check_str 1234555890 123455567890 2>&1)" = "$(ans 1234555 "" 890 1234555 67 890)" ]
+  [ "$(check_str 1234567890 1@34567890 2>&1)" = "$(ans 1 2 34567890 1 @ 34567890)" ]
+  [ "$(check_str 1234567890 12345678^0 2>&1)" = "$(ans 12345678 9 0 12345678 ^ 0)" ]
+
+  # Beginning wrong
+  [ "$(check_str abcdef ABCdef 2>&1)" = "$(ans "" abc def "" ABC def)" ]
+  [ "$(check_str abcdef Abcdef 2>&1)" = "$(ans "" a bcdef "" A bcdef)" ]
+  [ "$(check_str abcdef bcdef 2>&1)" = "$(ans "" a bcdef "" "" bcdef)" ]
+  [ "$(check_str bcdef abcdef 2>&1)" = "$(ans "" "" bcdef "" a bcdef)" ]
+  # End wrong
+  [ "$(check_str uvwxyz uvwXYZ 2>&1)" = "$(ans uvw xyz "" uvw XYZ "")" ]
+  [ "$(check_str uvwxyz uvwxyZ 2>&1)" = "$(ans uvwxy z "" uvwxy Z "")" ]
+  [ "$(check_str uvwxyz uvwxy 2>&1)" = "$(ans uvwxy z "" uvwxy "" "")" ]
+  [ "$(check_str uvwxy uvwxyz 2>&1)" = "$(ans uvwxy "" "" uvwxy z "")" ]
+)
+end_test

--- a/tests/test-test_utils.bsh
+++ b/tests/test-test_utils.bsh
@@ -3,6 +3,7 @@
 . "$(dirname "${BASH_SOURCE[0]}")/testlib.bsh"
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
+. "${VSI_COMMON_DIR}/linux/compat.bsh"
 
 function common_check_array_test()
 {
@@ -11,29 +12,53 @@ function common_check_array_test()
   ${1} a1
   ${1} a2 11 22 33
 
+  bq="${bash_declare_array_quote}"
+
   ans0=$'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ"$'\n'
 
   not ${1} a1 "" &> /dev/null
-  check_str "$(${1} a1 "" 2>&1)" \
-            "${ans0}"$'a1=()\nArray had 1 too few values'
+  ans="${ans0}a1=()"
+  ans+=$'\nArray had 1 too few values'
+  ans+=$'\ndeclare -a a1='"${bq}()${bq}"
+  [[ $(${1} a1 "" 2>&1) = \
+     *${ans}* ]] || false
+
   not ${1} a2 11 22 33 44 &> /dev/null
-  check_str "$(${1} a2 11 22 33 44 2>&1)" \
-            "${ans0}"$'a2=(11 22 33)\nArray had 1 too few values'
+  ans="${ans0}a2=(11 22 33)"
+  ans+=$'\nArray had 1 too few values'
+  ans+=$'\ndeclare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
+  [[ $(${1} a2 11 22 33 44 2>&1) = *"${ans}"* ]] || false
+  # When ans has a literal " in it, do you have to put quotes around it in [[]]
+
   not ${1} a2 22 33 &> /dev/null
-  check_str "$(${1} a2 22 33 2>&1)" \
-            "${ans0}"$'Element 0 (a2[0]) is different:\n11 !='"${2-} 22"
+  ans="${ans0}Element 0 (a2[0]) is different:"
+  ans+=$'\n11 !='"${2-} 22"
+  ans+=$'\ndeclare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
+  [[ $(${1} a2 22 33 2>&1) = \
+     *"${ans}"* ]] || false
+
   not ${1} a2 11 33 &> /dev/null
-  check_str "$(${1} a2 11 33 2>&1)" \
-            "${ans0}"$'Element 1 (a2[1]) is different:\n22 !='"${2-} 33"
+  ans="${ans0}Element 1 (a2[1]) is different:"
+  ans+=$'\n22 !='"${2-} 33"
+  ans+=$'\ndeclare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
+  [[ $(${1} a2 11 33 2>&1) = \
+     *"${ans}"* ]] || false
+
   not ${1} a2 11 22 &> /dev/null
-  check_str "$(${1} a2 11 22 2>&1)" \
-            "${ans0}"$'a2=(11 22 33)\nArray had 1 too many values'
+  ans="${ans0}a2=(11 22 33)"
+  ans+=$'\nArray had 1 too many values'
+  ans+=$'\ndeclare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
+  [[ $(${1} a2 11 22 2>&1) = \
+     *"${ans}"* ]] || false
 
   # Non contiguous case
   unset a2[1]
   not ${1} a2 11 22
-  check_str "$(${1} a2 11 22 2>&1)" \
-            "${ans0}"$'Element 1 (a2[2]) is different:\n33 !='"${2-} 22"
+  ans="${ans0}Element 1 (a2[2]) is different:"
+  ans+=$'\n33 !='"${2-} 22"
+  ans+=$'\ndeclare -a a2='"${bq}"'([0]="11" [2]="33")'"${bq}"
+  [[ $(${1} a2 11 22 2>&1) = \
+     *"${ans}"* ]] || false
 }
 
 begin_test "Test check array"
@@ -54,8 +79,10 @@ begin_test "Test regex check array"
   check_ra a2 1+ '^[0-9]+$' 3
   check_ra a2 2* . '^33$'
   not check_ra a2 1+ '^[0-9]+$' 4 &> /dev/null
-  check_str "$(check_ra a2 1+ '^[0-9]+$' 4 2>&1)" \
-            "${ans0}"$'Element 2 (a2[2]) is different:\n33 !=~ 4'
+  ans="${ans0}Element 2 (a2[2]) is different:"
+  ans+=$'\n33 !=~ 4'
+  ans+=$'\ndeclare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
+  [[ $(check_ra a2 1+ '^[0-9]+$' 4 2>&1) = *"${ans}"* ]] || false
 )
 end_test
 
@@ -107,27 +134,26 @@ begin_test "Test check string"
   # Make sure the rv is non-zero
   not check_str 1234567890 1234566890 &> /dev/null
   # Middles wrong
-  [ "$(check_str 1234567890 1234566890 2>&1)" = "$(ans 123456 7 890 123456 6 890)" ]
-  [ "$(check_str 1234567890 1234576890 2>&1)" = "$(ans 12345 67 890 12345 76 890)" ]
-  [ "$(check_str 1234567890 12345890 2>&1)" = "$(ans 12345 67 890 12345 "" 890)" ]
-  [ "$(check_str 12345890 1234567890 2>&1)" = "$(ans 12345 "" 890 12345 67 890)" ]
-  [ "$(check_str 1234555890 123455567890 2>&1)" = "$(ans 1234555 "" 890 1234555 67 890)" ]
-  [ "$(check_str 1234567890 1@34567890 2>&1)" = "$(ans 1 2 34567890 1 @ 34567890)" ]
-  [ "$(check_str 1234567890 12345678^0 2>&1)" = "$(ans 12345678 9 0 12345678 ^ 0)" ]
+  [[ $(check_str 1234567890 1234566890 2>&1) = *$(ans 123456 7 890 123456 6 890)* ]]
+  [[ $(check_str 1234567890 1234576890 2>&1) = *$(ans 12345 67 890 12345 76 890)* ]]
+  [[ $(check_str 1234567890 12345890 2>&1) = *$(ans 12345 67 890 12345 "" 890)* ]]
+  [[ $(check_str 12345890 1234567890 2>&1) = *$(ans 12345 "" 890 12345 67 890)* ]]
+  [[ $(check_str 1234555890 123455567890 2>&1) = *$(ans 1234555 "" 890 1234555 67 890)* ]]
+  [[ $(check_str 1234567890 1@34567890 2>&1) = *$(ans 1 2 34567890 1 @ 34567890)* ]]
+  [[ $(check_str 1234567890 12345678^0 2>&1) = *$(ans 12345678 9 0 12345678 ^ 0)* ]]
 
   # Beginning wrong
-  [ "$(check_str abcdef ABCdef 2>&1)" = "$(ans "" abc def "" ABC def)" ]
-  [ "$(check_str abcdef Abcdef 2>&1)" = "$(ans "" a bcdef "" A bcdef)" ]
-  [ "$(check_str abcdef bcdef 2>&1)" = "$(ans "" a bcdef "" "" bcdef)" ]
-  [ "$(check_str bcdef abcdef 2>&1)" = "$(ans "" "" bcdef "" a bcdef)" ]
+  [[ $(check_str abcdef ABCdef 2>&1) = *$(ans "" abc def "" ABC def)* ]]
+  [[ $(check_str abcdef Abcdef 2>&1) = *$(ans "" a bcdef "" A bcdef)* ]]
+  [[ $(check_str abcdef bcdef 2>&1) = *$(ans "" a bcdef "" "" bcdef)* ]]
+  [[ $(check_str bcdef abcdef 2>&1) = *$(ans "" "" bcdef "" a bcdef)* ]]
   # End wrong
-  [ "$(check_str uvwxyz uvwXYZ 2>&1)" = "$(ans uvw xyz "" uvw XYZ "")" ]
-  [ "$(check_str uvwxyz uvwxyZ 2>&1)" = "$(ans uvwxy z "" uvwxy Z "")" ]
-  [ "$(check_str uvwxyz uvwxy 2>&1)" = "$(ans uvwxy z "" uvwxy "" "")" ]
-  [ "$(check_str uvwxy uvwxyz 2>&1)" = "$(ans uvwxy "" "" uvwxy z "")" ]
+  [[ $(check_str uvwxyz uvwXYZ 2>&1) = *$(ans uvw xyz "" uvw XYZ "")* ]]
+  [[ $(check_str uvwxyz uvwxyZ 2>&1) = *$(ans uvwxy z "" uvwxy Z "")* ]]
+  [[ $(check_str uvwxyz uvwxy 2>&1) = *$(ans uvwxy z "" uvwxy "" "")* ]]
+  [[ $(check_str uvwxy uvwxyz 2>&1) = *$(ans uvwxy "" "" uvwxy z "")* ]]
 
   # Corner case due to malformed for loop (, instead of &&)
-  [ "$(check_str 167890ab 167767890ab 2>&1)" = \
-    "$(ans 167 "" 890ab 167 767 890ab)" ]
+  [[ $(check_str 167890ab 167767890ab 2>&1) = *$(ans 167 "" 890ab 167 767 890ab)* ]]
 )
 end_test

--- a/tests/test-test_utils.bsh
+++ b/tests/test-test_utils.bsh
@@ -4,58 +4,58 @@
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 . "$(dirname "${BASH_SOURCE[0]}")/test_utils.bsh"
 
-begin_test "Test check array"
-(
-  setup_test
-
+function common_check_array_test()
+{
   a1=()
   a2=(11 22 33)
-  check_a a1
-  check_a a2 11 22 33
+  ${1} a1
+  ${1} a2 11 22 33
 
   ans0=$'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ"$'\n'
 
-  not check_a a1 ""
-  check_str "$(check_a a1 "" 2>&1)" \
+  not ${1} a1 "" &> /dev/null
+  check_str "$(${1} a1 "" 2>&1)" \
             "${ans0}"$'a1=()\nArray had 1 too few values'
-  not check_a a2 11 22 33 44
-  check_str "$(check_a a2 11 22 33 44 2>&1)" \
+  not ${1} a2 11 22 33 44 &> /dev/null
+  check_str "$(${1} a2 11 22 33 44 2>&1)" \
             "${ans0}"$'a2=(11 22 33)\nArray had 1 too few values'
-  not check_a a2 22 33
-  check_str "$(check_a a2 22 33 2>&1)" \
-            "${ans0}"$'Element 0 (a2[0]) is different:\n11 != 22'
-  not check_a a2 11 33
-  check_str "$(check_a a2 11 33 2>&1)" \
-            "${ans0}"$'Element 1 (a2[1]) is different:\n22 != 33'
-  not check_a a2 11 22
-  check_str "$(check_a a2 11 22 2>&1)" \
+  not ${1} a2 22 33 &> /dev/null
+  check_str "$(${1} a2 22 33 2>&1)" \
+            "${ans0}"$'Element 0 (a2[0]) is different:\n11 !='"${2-} 22"
+  not ${1} a2 11 33 &> /dev/null
+  check_str "$(${1} a2 11 33 2>&1)" \
+            "${ans0}"$'Element 1 (a2[1]) is different:\n22 !='"${2-} 33"
+  not ${1} a2 11 22 &> /dev/null
+  check_str "$(${1} a2 11 22 2>&1)" \
             "${ans0}"$'a2=(11 22 33)\nArray had 1 too many values'
 
   # Non contiguous case
   unset a2[1]
-  not check_a a2 11 22
-  check_str "$(check_a a2 11 22 2>&1)" \
-            "${ans0}"$'Element 1 (a2[2]) is different:\n33 != 22'
+  not ${1} a2 11 22
+  check_str "$(${1} a2 11 22 2>&1)" \
+            "${ans0}"$'Element 1 (a2[2]) is different:\n33 !='"${2-} 22"
+}
+
+begin_test "Test check array"
+(
+  setup_test
+
+  common_check_array_test check_a
 )
 end_test
 
 begin_test "Test regex check array"
 (
   setup_test
+  common_check_array_test check_ra '~'
 
-  a1=()
   a2=(11 22 33)
-  check_ra a1
-  check_ra a2 11 22 33
 
   check_ra a2 1+ '^[0-9]+$' 3
   check_ra a2 2* . '^33$'
-  not check_ra a2 1+ '^[0-9]+$' 4
-
-  not check_ra a1 ""
-  not check_ra a2 11 22 33 44
-  not check_ra a2 22 33
-  not check_ra a2 11 22
+  not check_ra a2 1+ '^[0-9]+$' 4 &> /dev/null
+  check_str "$(check_ra a2 1+ '^[0-9]+$' 4 2>&1)" \
+            "${ans0}"$'Element 2 (a2[2]) is different:\n33 !=~ 4'
 )
 end_test
 

--- a/tests/test-test_utils.bsh
+++ b/tests/test-test_utils.bsh
@@ -20,8 +20,7 @@ function common_check_array_test()
   ans="${ans0}a1=()"
   ans+=$'\nArray had 1 too few values'
   ans+=$'\ndeclare -a a1='"${bq}()${bq}"
-  [[ $(${1} a1 "" 2>&1) = \
-     *${ans}* ]] || false
+  [[ $(${1} a1 "" 2>&1) = *${ans}* ]] || false
 
   not ${1} a2 11 22 33 44 &> /dev/null
   ans="${ans0}a2=(11 22 33)"
@@ -130,26 +129,26 @@ begin_test "Test check string"
   # Make sure the rv is non-zero
   not check_str 1234567890 1234566890 &> /dev/null
   # Middles wrong
-  [[ $(check_str 1234567890 1234566890 2>&1) = *$(ans 123456 7 890 123456 6 890)* ]] | false
-  [[ $(check_str 1234567890 1234576890 2>&1) = *$(ans 12345 67 890 12345 76 890)* ]] | false
-  [[ $(check_str 1234567890 12345890 2>&1) = *$(ans 12345 67 890 12345 "" 890)* ]] | false
-  [[ $(check_str 12345890 1234567890 2>&1) = *$(ans 12345 "" 890 12345 67 890)* ]] | false
-  [[ $(check_str 1234555890 123455567890 2>&1) = *$(ans 1234555 "" 890 1234555 67 890)* ]] | false
-  [[ $(check_str 1234567890 1@34567890 2>&1) = *$(ans 1 2 34567890 1 @ 34567890)* ]] | false
-  [[ $(check_str 1234567890 12345678^0 2>&1) = *$(ans 12345678 9 0 12345678 ^ 0)* ]] | false
+  [[ $(check_str 1234567890 1234566890 2>&1 | xxd) = *$(ans 123456 7 890 123456 6 890 | xxd)* ]] || false
+  [[ $(check_str 1234567890 1234576890 2>&1) = *$(ans 12345 67 890 12345 76 890)* ]] || false
+  [[ $(check_str 1234567890 12345890 2>&1) = *$(ans 12345 67 890 12345 "" 890)* ]] || false
+  [[ $(check_str 12345890 1234567890 2>&1) = *$(ans 12345 "" 890 12345 67 890)* ]] || false
+  [[ $(check_str 1234555890 123455567890 2>&1) = *$(ans 1234555 "" 890 1234555 67 890)* ]] || false
+  [[ $(check_str 1234567890 1@34567890 2>&1) = *$(ans 1 2 34567890 1 @ 34567890)* ]] || false
+  [[ $(check_str 1234567890 12345678^0 2>&1) = *$(ans 12345678 9 0 12345678 ^ 0)* ]] || false
 
   # Beginning wrong
-  [[ $(check_str abcdef ABCdef 2>&1) = *$(ans "" abc def "" ABC def)* ]] | false
-  [[ $(check_str abcdef Abcdef 2>&1) = *$(ans "" a bcdef "" A bcdef)* ]] | false
-  [[ $(check_str abcdef bcdef 2>&1) = *$(ans "" a bcdef "" "" bcdef)* ]] | false
-  [[ $(check_str bcdef abcdef 2>&1) = *$(ans "" "" bcdef "" a bcdef)* ]] | false
+  [[ $(check_str abcdef ABCdef 2>&1) = *$(ans "" abc def "" ABC def)* ]] || false
+  [[ $(check_str abcdef Abcdef 2>&1) = *$(ans "" a bcdef "" A bcdef)* ]] || false
+  [[ $(check_str abcdef bcdef 2>&1) = *$(ans "" a bcdef "" "" bcdef)* ]] || false
+  [[ $(check_str bcdef abcdef 2>&1) = *$(ans "" "" bcdef "" a bcdef)* ]] || false
   # End wrong
-  [[ $(check_str uvwxyz uvwXYZ 2>&1) = *$(ans uvw xyz "" uvw XYZ "")* ]] | false
-  [[ $(check_str uvwxyz uvwxyZ 2>&1) = *$(ans uvwxy z "" uvwxy Z "")* ]] | false
-  [[ $(check_str uvwxyz uvwxy 2>&1) = *$(ans uvwxy z "" uvwxy "" "")* ]] | false
-  [[ $(check_str uvwxy uvwxyz 2>&1) = *$(ans uvwxy "" "" uvwxy z "")* ]] | false
+  [[ $(check_str uvwxyz uvwXYZ 2>&1) = *$(ans uvw xyz "" uvw XYZ "")* ]] || false
+  [[ $(check_str uvwxyz uvwxyZ 2>&1) = *$(ans uvwxy z "" uvwxy Z "")* ]] || false
+  [[ $(check_str uvwxyz uvwxy 2>&1) = *$(ans uvwxy z "" uvwxy "" "")* ]] || false
+  [[ $(check_str uvwxy uvwxyz 2>&1) = *$(ans uvwxy "" "" uvwxy z "")* ]] || false
 
   # Corner case due to malformed for loop (, instead of &&)
-  [[ $(check_str 167890ab 167767890ab 2>&1) = *$(ans 167 "" 890ab 167 767 890ab)* ]] | false
+  [[ $(check_str 167890ab 167767890ab 2>&1) = *$(ans 167 "" 890ab 167 767 890ab)* ]] || false
 )
 end_test

--- a/tests/test-time_tools.bsh
+++ b/tests/test-time_tools.bsh
@@ -23,6 +23,7 @@ begin_test "get_time_seconds"
 end_test
 
 [ "${OS-}" = "Windows_NT" ] && skip_next_test
+command -v perl &> /dev/null || skip_next_test
 begin_test "macOS timeout substitute"
 (
   setup_test

--- a/tests/test-time_tools.bsh
+++ b/tests/test-time_tools.bsh
@@ -5,7 +5,8 @@
 VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 . "${VSI_COMMON_DIR}/linux/time_tools.bsh"
 
-begin_test "get_time_seconds"
+[[ ! $(date +%N) =~ ^[0-9]+$ ]] && skip_next_test
+begin_test "get_time_seconds fractional seconds"
 (
   setup_test
   time1="$(get_time_seconds)"
@@ -21,6 +22,24 @@ begin_test "get_time_seconds"
   [ "${t_diff}" -lt 8000 ]
 )
 end_test
+
+begin_test "get_time_seconds whole second"
+(
+  setup_test
+  time1="$(get_time_seconds)"
+  sleep 1
+  time2="$(get_time_seconds)"
+
+  t_diff="$(echo "${time1}" "${time2}" | awk '{printf "%.0f\n", ($2-$1)*1000}')"
+  [ "${t_diff}" -gt 990 ]
+  # 9000 is a ridiculous value, but when using an emulator on a virtual machine
+  # time delays can add up to a second or two. So basically 9000 serves as a
+  # upper bound to make sure something didn't go wrong and it's in the billions
+  # of milliseconds or something
+  [ "${t_diff}" -lt 9000 ]
+)
+end_test
+
 
 [ "${OS-}" = "Windows_NT" ] && skip_next_test
 command -v perl &> /dev/null || skip_next_test

--- a/tests/test_utils.bsh
+++ b/tests/test_utils.bsh
@@ -32,6 +32,8 @@
 #**
 function check_a()
 {
+  set +xv
+
   local check_a_indicies
   local check_a_name="${1}[@]"
   local check_a_values=(${!check_a_name+"${!check_a_name}"})
@@ -40,33 +42,13 @@ function check_a()
   local check_a_index
   shift 1
 
-  # for check_a_var in ${!check_a_name+"${!check_a_name}"}; do
-  #   if [ $# -eq 0 ]; then
-  #     echo ${!check_a_name+"${!check_a_name}"} >&2
-  #     echo "Array had too many values" >&2
-  #     return 3
-  #   fi
-  #   if [ "${check_a_var}" != "$1" ]; then
-  #     echo "${check_a_name}" >&2
-  #     echo "${check_a_var} != $1" >&2
-  #     return 1
-  #   fi
-  #   shift 1
-  # done
-  # if [ $# -eq 0 ]; then
-  #   return 0
-  # else
-  #   echo ${!check_a_name+"${!check_a_name}"} >&2
-  #   echo "Array had $# too few values" >&2
-  #   return 2
-  # fi
-
   for check_a_index in ${check_a_values[@]+"${!check_a_values[@]}"}; do
     if [ $# -eq 0 ]; then
       echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
       echo "${check_a_name}=(${check_a_values[@]+${check_a_values[@]}})" >&2
       echo "Array had $((${#check_a_values[@]} - check_a_index)) too many values" >&2
       declare -p "${check_a_name}" >&2
+      set -xv
       return 3
     fi
     if [ "${check_a_values[check_a_index]}" != "$1" ]; then
@@ -74,17 +56,20 @@ function check_a()
       echo "Element ${check_a_index} (${check_a_name}[${check_a_indicies[check_a_index]}]) is different:" >&2
       echo "${check_a_values[check_a_index]} != $1" >&2
       declare -p "${check_a_name}" >&2
+      set -xv
       return 1
     fi
     shift 1
   done
   if [ $# -eq 0 ]; then
+    set -xv
     return 0
   else
     echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
     echo "${check_a_name}=(${check_a_values[@]+${check_a_values[@]}})" >&2
     echo "Array had $# too few values" >&2
     declare -p "${check_a_name}" >&2
+    set -xv
     return 2
   fi
 }
@@ -96,6 +81,7 @@ function check_a()
 #**
 function check_ra()
 {
+  set +xv
   local check_a_indicies
   local check_a_name="${1}[@]"
   local check_a_values=(${!check_a_name+"${!check_a_name}"})
@@ -110,6 +96,7 @@ function check_ra()
       echo "${check_a_name}=(${check_a_values[@]+${check_a_values[@]}})" >&2
       echo "Array had $((${#check_a_values[@]} - check_a_index)) too many values" >&2
       declare -p "${check_a_name}" >&2
+      set -xv
       return 3
     fi
     if [[ ! ${check_a_values[check_a_index]} =~ $1 ]]; then
@@ -117,17 +104,20 @@ function check_ra()
       echo "Element ${check_a_index} (${check_a_name}[${check_a_indicies[check_a_index]}]) is different:" >&2
       echo "${check_a_values[check_a_index]} !=~ $1" >&2
       declare -p "${check_a_name}" >&2
+      set -xv
       return 1
     fi
     shift 1
   done
   if [ $# -eq 0 ]; then
+    set -xv
     return 0
   else
     echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
     echo "${check_a_name}=(${check_a_values[@]+${check_a_values[@]}})" >&2
     echo "Array had $# too few values" >&2
     declare -p "${check_a_name}" >&2
+    set -xv
     return 2
   fi
 }
@@ -148,16 +138,19 @@ function check_ra()
 #**
 function contiguous_a()
 {
+  set +xv
   # Verify array is contiguous
   local contiguous_a_indicies=()
   local contiguous_a_i
   eval 'contiguous_a_indicies=("${!'$1'[@]}")'
   # Returns the result of check_a
   check_a contiguous_a_indicies $(seq 0 1 $((${#contiguous_a_indicies[@]}-1)))
+  # check_a will set -sv for contiguous_a
 }
 
 function check_str()
 {
+  set +xv
   if [ "${1}" != "${2}" ]; then
     local -i start=0
     local -i i
@@ -192,6 +185,8 @@ function check_str()
     echo "${1::start}"$'\e[1;31m'"${1:start:i-start}"$'\e[0m'"${1:i}" >&2
     echo "---------------------" >&2
     echo "${2::start}"$'\e[1;31m'"${2:start:j-start}"$'\e[0m'"${2:j}" >&2
+    set -xv
     return 1
   fi
+  set -xv
 }

--- a/tests/test_utils.bsh
+++ b/tests/test_utils.bsh
@@ -161,7 +161,7 @@ function check_str()
 
     # This for loop matches the same notation as the previous for loop, but is
     # numerically identical to the following for loop, that is just cleaner
-    # for ((i=${#1}-1, j=${#2}-1; i>start-1,j>start-1; --i, --j)); do
+    # for ((i=${#1}-1, j=${#2}-1; i>start-1 && j>start-1; --i, --j)); do
     #   if [ "${1:i:1}" != "${2:j:1}" ]; then
     #     break
     #   fi
@@ -169,7 +169,7 @@ function check_str()
     # i+=1
     # j+=1
 
-    for ((i=${#1}, j=${#2}; i>start,j>start; --i, --j)); do
+    for ((i=${#1}, j=${#2}; i>start && j>start; --i, --j)); do
       if [ "${1:i-1:1}" != "${2:j-1:1}" ]; then
         break
       fi

--- a/tests/test_utils.bsh
+++ b/tests/test_utils.bsh
@@ -66,12 +66,14 @@ function check_a()
       echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
       echo "${check_a_name}=(${check_a_values[@]+${check_a_values[@]}})" >&2
       echo "Array had $((${#check_a_values[@]} - check_a_index)) too many values" >&2
+      declare -p "${check_a_name}" >&2
       return 3
     fi
     if [ "${check_a_values[check_a_index]}" != "$1" ]; then
       echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
       echo "Element ${check_a_index} (${check_a_name}[${check_a_indicies[check_a_index]}]) is different:" >&2
       echo "${check_a_values[check_a_index]} != $1" >&2
+      declare -p "${check_a_name}" >&2
       return 1
     fi
     shift 1
@@ -82,6 +84,7 @@ function check_a()
     echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
     echo "${check_a_name}=(${check_a_values[@]+${check_a_values[@]}})" >&2
     echo "Array had $# too few values" >&2
+    declare -p "${check_a_name}" >&2
     return 2
   fi
 }
@@ -106,12 +109,14 @@ function check_ra()
       echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
       echo "${check_a_name}=(${check_a_values[@]+${check_a_values[@]}})" >&2
       echo "Array had $((${#check_a_values[@]} - check_a_index)) too many values" >&2
+      declare -p "${check_a_name}" >&2
       return 3
     fi
     if [[ ! ${check_a_values[check_a_index]} =~ $1 ]]; then
       echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
       echo "Element ${check_a_index} (${check_a_name}[${check_a_indicies[check_a_index]}]) is different:" >&2
       echo "${check_a_values[check_a_index]} !=~ $1" >&2
+      declare -p "${check_a_name}" >&2
       return 1
     fi
     shift 1
@@ -122,6 +127,7 @@ function check_ra()
     echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
     echo "${check_a_name}=(${check_a_values[@]+${check_a_values[@]}})" >&2
     echo "Array had $# too few values" >&2
+    declare -p "${check_a_name}" >&2
     return 2
   fi
 }

--- a/tests/test_utils.bsh
+++ b/tests/test_utils.bsh
@@ -40,6 +40,27 @@ function check_a()
   local check_a_index
   shift 1
 
+  # for check_a_var in ${!check_a_name+"${!check_a_name}"}; do
+  #   if [ $# -eq 0 ]; then
+  #     echo ${!check_a_name+"${!check_a_name}"} >&2
+  #     echo "Array had too many values" >&2
+  #     return 3
+  #   fi
+  #   if [ "${check_a_var}" != "$1" ]; then
+  #     echo "${check_a_name}" >&2
+  #     echo "${check_a_var} != $1" >&2
+  #     return 1
+  #   fi
+  #   shift 1
+  # done
+  # if [ $# -eq 0 ]; then
+  #   return 0
+  # else
+  #   echo ${!check_a_name+"${!check_a_name}"} >&2
+  #   echo "Array had $# too few values" >&2
+  #   return 2
+  # fi
+
   for check_a_index in ${check_a_values[@]+"${!check_a_values[@]}"}; do
     if [ $# -eq 0 ]; then
       echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
@@ -63,27 +84,6 @@ function check_a()
     echo "Array had $# too few values" >&2
     return 2
   fi
-
-  # for check_a_var in ${!check_a_name+"${!check_a_name}"}; do
-  #   if [ $# -eq 0 ]; then
-  #     echo ${!check_a_name+"${!check_a_name}"} >&2
-  #     echo "Array had too many values" >&2
-  #     return 3
-  #   fi
-  #   if [ "${check_a_var}" != "$1" ]; then
-  #     echo "${check_a_name}" >&2
-  #     echo "${check_a_var} != $1" >&2
-  #     return 1
-  #   fi
-  #   shift 1
-  # done
-  # if [ $# -eq 0 ]; then
-  #   return 0
-  # else
-  #   echo ${!check_a_name+"${!check_a_name}"} >&2
-  #   echo "Array had $# too few values" >&2
-  #   return 2
-  # fi
 }
 
 #**
@@ -93,18 +93,25 @@ function check_a()
 #**
 function check_ra()
 {
+  local check_a_indicies
   local check_a_name="${1}[@]"
+  local check_a_values=(${!check_a_name+"${!check_a_name}"})
+  check_a_name="${1}"
+  eval 'check_a_indicies=("${!'$1'[@]}")'
+  local check_a_index
   shift 1
 
-  for check_a_var in ${!check_a_name+"${!check_a_name}"}; do
+  for check_a_index in ${check_a_values[@]+"${!check_a_values[@]}"}; do
     if [ $# -eq 0 ]; then
-      echo ${!check_a_name+"${!check_a_name}"} >&2
-      echo "Array had too many values" >&2
+      echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
+      echo "${check_a_name}=(${check_a_values[@]+${check_a_values[@]}})" >&2
+      echo "Array had $((${#check_a_values[@]} - check_a_index)) too many values" >&2
       return 3
     fi
-    if [[ ! "${check_a_var}" =~ $1 ]]; then
-      echo "${!check_a_name}" >&2
-      echo "${check_a_var} != $1" >&2
+    if [[ ! ${check_a_values[check_a_index]} =~ $1 ]]; then
+      echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
+      echo "Element ${check_a_index} (${check_a_name}[${check_a_indicies[check_a_index]}]) is different:" >&2
+      echo "${check_a_values[check_a_index]} !=~ $1" >&2
       return 1
     fi
     shift 1
@@ -112,7 +119,8 @@ function check_ra()
   if [ $# -eq 0 ]; then
     return 0
   else
-    echo ${!check_a_name+"${!check_a_name}"} >&2
+    echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
+    echo "${check_a_name}=(${check_a_values[@]+${check_a_values[@]}})" >&2
     echo "Array had $# too few values" >&2
     return 2
   fi

--- a/tests/test_utils.bsh
+++ b/tests/test_utils.bsh
@@ -32,18 +32,25 @@
 #**
 function check_a()
 {
+  local check_a_indicies
   local check_a_name="${1}[@]"
+  local check_a_values=(${!check_a_name+"${!check_a_name}"})
+  check_a_name="${1}"
+  eval 'check_a_indicies=("${!'$1'[@]}")'
+  local check_a_index
   shift 1
 
-  for check_a_var in ${!check_a_name+"${!check_a_name}"}; do
+  for check_a_index in ${check_a_values[@]+"${!check_a_values[@]}"}; do
     if [ $# -eq 0 ]; then
-      echo ${!check_a_name+"${!check_a_name}"} >&2
-      echo "Array had too many values" >&2
+      echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
+      echo "${check_a_name}=(${check_a_values[@]+${check_a_values[@]}})" >&2
+      echo "Array had $((${#check_a_values[@]} - check_a_index)) too many values" >&2
       return 3
     fi
-    if [ "${check_a_var}" != "$1" ]; then
-      echo "${check_a_name}" >&2
-      echo "${check_a_var} != $1" >&2
+    if [ "${check_a_values[check_a_index]}" != "$1" ]; then
+      echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
+      echo "Element ${check_a_index} (${check_a_name}[${check_a_indicies[check_a_index]}]) is different:" >&2
+      echo "${check_a_values[check_a_index]} != $1" >&2
       return 1
     fi
     shift 1
@@ -51,10 +58,32 @@ function check_a()
   if [ $# -eq 0 ]; then
     return 0
   else
-    echo ${!check_a_name+"${!check_a_name}"} >&2
+    echo $'\e[1;31m'"ERROR"$'\e[0m'": Arrays differ" >&2
+    echo "${check_a_name}=(${check_a_values[@]+${check_a_values[@]}})" >&2
     echo "Array had $# too few values" >&2
     return 2
   fi
+
+  # for check_a_var in ${!check_a_name+"${!check_a_name}"}; do
+  #   if [ $# -eq 0 ]; then
+  #     echo ${!check_a_name+"${!check_a_name}"} >&2
+  #     echo "Array had too many values" >&2
+  #     return 3
+  #   fi
+  #   if [ "${check_a_var}" != "$1" ]; then
+  #     echo "${check_a_name}" >&2
+  #     echo "${check_a_var} != $1" >&2
+  #     return 1
+  #   fi
+  #   shift 1
+  # done
+  # if [ $# -eq 0 ]; then
+  #   return 0
+  # else
+  #   echo ${!check_a_name+"${!check_a_name}"} >&2
+  #   echo "Array had $# too few values" >&2
+  #   return 2
+  # fi
 }
 
 #**
@@ -121,6 +150,7 @@ function check_str()
     local -i j
 
     echo $'\e[1;31m'"ERROR"$'\e[0m'": Strings differ" >&2
+    echo "=====================" >&2
 
     for ((i=0; i<${#1}; ++i)); do
       if [ "${1:i:1}" != "${2:i:1}" ]; then
@@ -146,6 +176,7 @@ function check_str()
     done
 
     echo "${1::start}"$'\e[1;31m'"${1:start:i-start}"$'\e[0m'"${1:i}" >&2
+    echo "---------------------" >&2
     echo "${2::start}"$'\e[1;31m'"${2:start:j-start}"$'\e[0m'"${2:j}" >&2
     return 1
   fi

--- a/tests/test_utils.bsh
+++ b/tests/test_utils.bsh
@@ -112,3 +112,41 @@ function contiguous_a()
   # Returns the result of check_a
   check_a contiguous_a_indicies $(seq 0 1 $((${#contiguous_a_indicies[@]}-1)))
 }
+
+function check_str()
+{
+  if [ "${1}" != "${2}" ]; then
+    local -i start=0
+    local -i i
+    local -i j
+
+    echo $'\e[1;31m'"ERROR"$'\e[0m'": Strings differ" >&2
+
+    for ((i=0; i<${#1}; ++i)); do
+      if [ "${1:i:1}" != "${2:i:1}" ]; then
+        break
+      fi
+    done
+    start="${i}"
+
+    # This for loop matches the same notation as the previous for loop, but is
+    # numerically identical to the following for loop, that is just cleaner
+    # for ((i=${#1}-1, j=${#2}-1; i>start-1,j>start-1; --i, --j)); do
+    #   if [ "${1:i:1}" != "${2:j:1}" ]; then
+    #     break
+    #   fi
+    # done
+    # i+=1
+    # j+=1
+
+    for ((i=${#1}, j=${#2}; i>start,j>start; --i, --j)); do
+      if [ "${1:i-1:1}" != "${2:j-1:1}" ]; then
+        break
+      fi
+    done
+
+    echo "${1::start}"$'\e[1;31m'"${1:start:i-start}"$'\e[0m'"${1:i}" >&2
+    echo "${2::start}"$'\e[1;31m'"${2:start:j-start}"$'\e[0m'"${2:j}" >&2
+    return 1
+  fi
+}

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -205,7 +205,7 @@ skipped=0
 #
 # .. rubric:: Examples
 #
-# .. code:: bash
+# .. code-block:: bash
 #
 #    TESTLIB_SKIP_TESTS='^New Just$|foo'
 #    # Skip "New Just" and anything with "foo" it is, e.g. "food"

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -296,7 +296,8 @@ atexit ()
   fi
 
   if [ "${failures}" -gt 0 ]; then
-    exit 1
+    # Make the exit code 123, to be consistent with xargs' behavior
+    exit 123
   else
     exit 0
   fi
@@ -306,7 +307,7 @@ trap_chain "atexit" EXIT
 
 if [ -z "${TESTLIB_PS4+set}" ]; then
   if declare -p BASH_SOURCE &> /dev/null; then
-    PS4=$'+${BASH_SOURCE[0]##*/}:${LINENO})\t'
+    PS4=$'+${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}()}\t'
   else # Else sh probably
     # Not as accurate, but better than nothing
     PS4=$'+${0##*/}:${LINENO})\t'

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -701,6 +701,13 @@ function testlib_print_test_trace()
   (
     if [ "${TESTLIB_REDIRECT_OUTPUT}" -ge "1" ]; then
 
+      if ! command -v column &> /dev/null; then
+        function column()
+        {
+          cat -
+        }
+      fi
+
       if [ "${err}" = "${xtrace}" ]; then
         echo "-- stderr --"
       else

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -32,7 +32,7 @@
 # - Pause before deleting temporary directories if there is a failure for inspection: :envvar:`TESTLIB_KEEP_PAUSE_AFTER_ERROR`
 # - Run only a single test by its description: :envvar:`TESTLIB_RUN_SINGLE_TEST`
 # - Regular expression to skip tests by description: :envvar:`TESTLIB_SKIP_TESTS`
-# - Control stderr/stdout redirection :envvar:`TESTLIB_REDIRECT_OUTPUT`
+# - Controlled stderr/stdout redirection :envvar:`TESTLIB_REDIRECT_OUTPUT`
 # - Stop testing after ``N`` failures :envvar:`TESTLIB_STOP_AFTER_FAILS`
 # - Custom PS4 in trace using :envvar:`TESTLIB_PS4`
 # - Ability to conditionally skip a test by calling :func:`skip_next_test` in any condition check

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -34,17 +34,17 @@ set_array_default VSI_COMMON_BASH_TEST_3_2_VOLUMES "${VSI_COMMON_DOCKER_HOST}":/
 set_array_default VSI_COMMON_TEST_OSES \
   clearlinux:latest \
   amazonlinux:latest \
-; : \
-  debian:8 \
   debian:9 \
+  debian:10 \
   ubuntu:14.04 \
-  ubuntu:18.04 \
-  fedora:27 \
-  fedora:29 \
-  fedora@sha256:be2618fc719743b4ea5a2d3c4166d6efffe0e856e510856bd703188ba37ee040 \
+  ubuntu:20.04 \
+  fedora:31 \
+  fedora:32 \
+  fedora:rawhide \
+  centos:8 \
   centos:7 \
-  centos:6.9 \
-  centos:5.11 \
+  centos:6 \
+; : \
   gidikern/rhel-oracle-jre:1.8.0_60 \
   mstormo/suse:11.4 \
   opensuse/leap:15.1 \

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -31,6 +31,36 @@ set_array_default VSI_COMMON_BASH_TEST_4_1_VOLUMES "${VSI_COMMON_DOCKER_HOST}":/
 set_array_default VSI_COMMON_BASH_TEST_4_0_VOLUMES "${VSI_COMMON_DOCKER_HOST}":/var/run/docker.sock
 set_array_default VSI_COMMON_BASH_TEST_3_2_VOLUMES "${VSI_COMMON_DOCKER_HOST}":/var/run/docker.sock
 
+set_array_default VSI_COMMON_TEST_OSES \
+  clearlinux:latest \
+  amazonlinux:latest \
+; : \
+  debian:8 \
+  debian:9 \
+  ubuntu:14.04 \
+  ubuntu:18.04 \
+  fedora:27 \
+  fedora:29 \
+  fedora@sha256:be2618fc719743b4ea5a2d3c4166d6efffe0e856e510856bd703188ba37ee040 \
+  centos:7 \
+  centos:6.9 \
+  centos:5.11 \
+  gidikern/rhel-oracle-jre:1.8.0_60 \
+  mstormo/suse:11.4 \
+  opensuse/leap:15.1 \
+  opensuse/leap:42.3 \
+  opensuse/tumbleweed@sha256:e65e914b993b205cb8d03c7fd1f6fbe477ca4cd61cfa4265d4c9a8f5dcb7deaa \
+  vcatechnology/linux-mint:17 \
+  vcatechnology/linux-mint:18.2 \
+  ringo/scientific:6.3 \
+  ringo/scientific:7.2 \
+  busybox:1.28.0 \
+  alpine@sha256:46e71df1e5191ab8b8034c5189e325258ec44ea739bba1e5645cff83c9048ff1 \
+  vbatts/slackware:14.2 \
+  gentoo/stage3-amd64:20170726 \
+  binhex/arch-base:20170510-01 \
+  mwcampbell/muslbase@sha256:1f8c912c69874329aefbcaa4d2171daa0be832d50180e7d5d494d512e98ce236
+
 ###############################################################################
 # Non-VSI_COMMON Settings
 ###############################################################################

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -48,9 +48,8 @@ set_array_default VSI_COMMON_TEST_OSES \
   opensuse/leap:42.3 \
   opensuse/leap:15.2 \
   opensuse/tumbleweed \
+  linuxmintd/mint20-amd64 \
   ; : \
-  vcatechnology/linux-mint:17 \
-  vcatechnology/linux-mint:18.2 \
   ringo/scientific:6.3 \
   ringo/scientific:7.2 \
   busybox:1.28.0 \
@@ -60,6 +59,8 @@ set_array_default VSI_COMMON_TEST_OSES \
   binhex/arch-base:20170510-01 \
   mwcampbell/muslbase@sha256:1f8c912c69874329aefbcaa4d2171daa0be832d50180e7d5d494d512e98ce236
 
+  # linuxmintd/mint18-amd64 \
+  # linuxmintd/mint19-amd64 \
 # richxsl/rhel7:latest
 
 ###############################################################################

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -44,12 +44,11 @@ set_array_default VSI_COMMON_TEST_OSES \
   centos:8 \
   centos:7 \
   centos:6 \
-; : \
-  gidikern/rhel-oracle-jre:1.8.0_60 \
   mstormo/suse:11.4 \
-  opensuse/leap:15.1 \
   opensuse/leap:42.3 \
-  opensuse/tumbleweed@sha256:e65e914b993b205cb8d03c7fd1f6fbe477ca4cd61cfa4265d4c9a8f5dcb7deaa \
+  opensuse/leap:15.2 \
+  opensuse/tumbleweed \
+  ; : \
   vcatechnology/linux-mint:17 \
   vcatechnology/linux-mint:18.2 \
   ringo/scientific:6.3 \
@@ -60,6 +59,8 @@ set_array_default VSI_COMMON_TEST_OSES \
   gentoo/stage3-amd64:20170726 \
   binhex/arch-base:20170510-01 \
   mwcampbell/muslbase@sha256:1f8c912c69874329aefbcaa4d2171daa0be832d50180e7d5d494d512e98ce236
+
+# richxsl/rhel7:latest
 
 ###############################################################################
 # Non-VSI_COMMON Settings

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -14,8 +14,8 @@ source "${VSI_COMMON_DIR}/linux/just_version.bsh"
 : ${VSI_COMMON_SPHINX_DIR=${VSI_COMMON_DIR}/docs}
 : ${VSI_COMMON_SPHINX_SRC_DIR=${VSI_COMMON_DIR}}
 set_array_default VSI_COMMON_SPHINX_EXCLUDE_DIRS docs
-set_array_default VSI_COMMON_SPHINX_AUTODOC_DIRS python/vsi
-set_array_default VSI_COMMON_SPHINX_AUTODOC_OUTPUT_DIRS python
+set_array_default VSI_COMMON_SPHINX_AUTODOC_DIRS python/vsi linux
+set_array_default VSI_COMMON_SPHINX_AUTODOC_OUTPUT_DIRS python linux/python_scripts
 set_array_default VSI_COMMON_SPHINX_AUTODOC_EXCLUDE_DIRS python/vsi/test python/vsi/utils
 : ${VSI_COMMON_SPHINX_PRECOMPILE_SCRIPT=${JUST_PATH_ESC}/docs/custom_prebuild.bsh}
 

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -49,19 +49,18 @@ set_array_default VSI_COMMON_TEST_OSES \
   opensuse/leap:15.2 \
   opensuse/tumbleweed \
   linuxmintd/mint20-amd64 \
-  ; : \
-  ringo/scientific:6.3 \
-  ringo/scientific:7.2 \
-  busybox:1.28.0 \
-  alpine@sha256:46e71df1e5191ab8b8034c5189e325258ec44ea739bba1e5645cff83c9048ff1 \
-  vbatts/slackware:14.2 \
-  gentoo/stage3-amd64:20170726 \
-  binhex/arch-base:20170510-01 \
-  mwcampbell/muslbase@sha256:1f8c912c69874329aefbcaa4d2171daa0be832d50180e7d5d494d512e98ce236
+  alpine:latest \
+  vbatts/slackware:latest \
+  gentoo/stage3-amd64:latest \
+  binhex/arch-base:latest \
 
-  # linuxmintd/mint18-amd64 \
-  # linuxmintd/mint19-amd64 \
-# richxsl/rhel7:latest
+  # Something is going wrong with the lwhich tests on: busybox:latest \
+
+  # Unnecessary:
+  # linuxmintd/mint18-amd64
+  # linuxmintd/mint19-amd64
+  # richxsl/rhel7:latest
+  # mwcampbell/muslbase@latest # This one is also too hard to get working
 
 ###############################################################################
 # Non-VSI_COMMON Settings


### PR DESCRIPTION
First set of commits for unit test spiral

- Added many uses of `JUST_IGNORE_EXIT_CODE`
- Started to add multiple OS check for vsi_common (in addition to testing each version of bash specifically)
- Added makeself plugin
- Attempted to add pyinstaller plugin, but it is not currently working, and commented out
- Refactor to use `quote_escape` more
- Removed `print_bash_stack` from `just` and made it it's own module
- Added `check_shell` as a language agnostic way to check to see if you are running `bash` (or any other shells by name) or not. Now all `setup.env` files should contain the sh/bash/csh/ksh/fish/ash/zsh/dash compatible check `test -f ./linux/check_shell && ./linux/check_shell bash zsh` which will only works when sourcing `setup.env` from the CWD, but that's how most people do it that way, so it will work _most_ of the time. This is only a courtesy check anyways, so it doesn't have to be 100%, and there's no compatible way that I could figure out to use `BASH_SOURCE` to get the sourced file's path. It's pointless to use a BASH feature to determine if this is not bash.
- Added an environment variable version of `print_command` that can detect changes in the environment
- Fixed `date` feature test in `time_tools.bsh` to be more compatible
- `yarp.awk` no longer uses GNU array length feature, but manually tracks array length instead. More compatible
- Added unit test template
- Use `compat.bsh` more
- Fixed many bad tests using `[[ ]]`
- Adapting `check_str` some
- Other unit test improvements