### PR TITLE
Intersphinx

### DIFF
--- a/docker/vsi_common/sphinx.Justfile
+++ b/docker/vsi_common/sphinx.Justfile
@@ -122,6 +122,18 @@ function caseify()
 
       exec pipenv run make SPHINXOPTS="${SPHINXOPTS-}" html
       ;;
+    intersphinx) # Show links from one intersphinx mapping
+      # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#showing-all-links-of-an-intersphinx-mapping-file
+      cd /docs
+      INPUT="${1}"
+      URL="$(pipenv run python -c "import conf,posixpath; url=posixpath.join(conf.intersphinx_mapping['${INPUT}'][0], 'objects.inv'); print(url)" 2>/dev/null || echo "${INPUT}")"
+      echo "Fetch intersphinx mapping from <${URL}>..."
+      exec pipenv run python -m sphinx.ext.intersphinx "${URL}"
+      ;;
+    intersphinx-list) # List available intersphinx mapping
+      cd /docs
+      exec pipenv run python -c "import conf,json; print(json.dumps(conf.intersphinx_mapping, indent=2))"
+      ;;
     nopipenv) # Run command not in pipenv
       exec "${@}"
       ;;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ extensions = [
 intersphinx_mapping = {
     'ipython': ('https://ipython.readthedocs.io/en/stable/', None),
     'matplotlib': ('https://matplotlib.org/', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'numpy': ('https://numpy.org/doc/stable', None),
     'python': ('https://docs.python.org/3.7', None),
 }
 

--- a/linux/just_files/just_sphinx_functions.bsh
+++ b/linux/just_files/just_sphinx_functions.bsh
@@ -234,6 +234,18 @@ function _sphinx_docker_compose()
 #
 # :Arguments: * [``-n`` | ``--nit``] - Add ``-n`` to ``SPHINXOPTS`` for ``sphinx-build``
 #             * [``-E`` | ``--all``] - Adds ``-a`` and ``-E`` to ``SPHINXOPTS`` for ``sphinx-build``. This will force all files to be rebuilt
+
+# .. command:: sphinx_intersphinx
+#
+# Show all links from a single intersphinx mapping file. This is helpful when searching for the root cause of a broken Intersphinx link in a documentation project.
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#showing-all-links-of-an-intersphinx-mapping-file
+#
+# :Arguments: ``$1`` - String identifier from ``intersphinx_mapping`` dictionary in project ``docs/conf.py`` file. Alternatively, users may enter a full URL for query.
+
+# .. command:: sphinx_intersphinx-list
+#
+# Display available intersphinx mapping dictionary from project ``docs/conf.py` file.
+
 #**
 function docs_defaultify()
 {
@@ -346,6 +358,13 @@ function docs_defaultify()
       if [ "${sphinx_clean}" = "1" ]; then
         git clean -fdX "${docs_dir}"
       fi
+      ;;
+    sphinx_intersphinx) # Show links from intersphinx mapping
+      _sphinx_docker_compose run sphinx intersphinx ${@+"${@}"}
+      extra_args+=$#
+      ;;
+    sphinx_intersphinx-list) # List available intersphinx mapping
+      _sphinx_docker_compose run sphinx intersphinx-list
       ;;
     *)
       plugin_not_found=1

--- a/linux/just_files/just_sphinx_functions.bsh
+++ b/linux/just_files/just_sphinx_functions.bsh
@@ -215,37 +215,34 @@ function _sphinx_docker_compose()
 # #. If the ``docs`` directory doesn't exist yet, run :cmd:`sphinx_setup`
 # #. :cmd:`sphinx_compile`
 #
-
 # .. command:: sphinx_build
 #
 # Builds the default docker image for compiling sphinx documentation. By default, the image name used is :envvar:`SPHINX_COMPILE_IMAGE` or ``vsiri/sphinxdocs:compile`` if unset. If an image name other than the default is set, then :cmd:`sphinx_build` should not be used, instead use your own :file:`Justfile` targets to build the image.
 #
-
 # .. command:: sphinx_setup
 #
 # Runs ``sphinx-quickstart`` to setup a new sphinx projects. It is intended to have the build directory inside the source directory, so other configurations are not supported, although *may* work with some configuration.
 #
 # After running :cmd:`sphinx_setup`, the makefiles, ``conf.py``, ``index.rst``, and any other rst files should be ``git add`` to your repo. However, ``*.auto.rst`` files do not need to be added, as these are auto generated every time, and can safely be added to your ``.gitignore`` file
 #
-
 # .. command:: sphinx_compile
 #
 # Compiles the sphinx documentation into html using ``sphinx-build`` via ``make``
 #
 # :Arguments: * [``-n`` | ``--nit``] - Add ``-n`` to ``SPHINXOPTS`` for ``sphinx-build``
 #             * [``-E`` | ``--all``] - Adds ``-a`` and ``-E`` to ``SPHINXOPTS`` for ``sphinx-build``. This will force all files to be rebuilt
-
+#
 # .. command:: sphinx_intersphinx
 #
 # Show all links from a single intersphinx mapping file. This is helpful when searching for the root cause of a broken Intersphinx link in a documentation project.
-# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#showing-all-links-of-an-intersphinx-mapping-file
+# More information on intersphinx capabilities available `here <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#showing-all-links-of-an-intersphinx-mapping-file>`_.
 #
-# :Arguments: ``$1`` - String identifier from ``intersphinx_mapping`` dictionary in project ``docs/conf.py`` file. Alternatively, users may enter a full URL for query.
-
+# :Arguments: ``$1`` - String identifier from ``intersphinx_mapping`` dictionary in project ``conf.py`` file. Alternatively, users may enter a full URL for query.
+#
 # .. command:: sphinx_intersphinx-list
 #
-# Display available intersphinx mapping dictionary from project ``docs/conf.py` file.
-
+# Display available intersphinx mapping dictionary from project ``conf.py`` file.
+#
 #**
 function docs_defaultify()
 {


### PR DESCRIPTION
New `intersphinx` convenience functions for `just_sphinx_functions`, letting users display contents of intersphinx mapping files.  This is helpful when searching for the root cause of a broken intersphinx link in a documentation project.  

Additionally update intersphinx mapping for numpy.