### PR TITLE
ci_load for multi-stage recipes

### DIFF
--- a/linux/just_files/just_ci_functions.bsh
+++ b/linux/just_files/just_ci_functions.bsh
@@ -1,0 +1,88 @@
+#!/usr/bin/env false bash
+
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return 0
+fi
+
+source "${VSI_COMMON_DIR}/linux/just_files/just_docker_functions.bsh"
+
+#*# just/plugins/just_ci_functions
+
+JUST_DEFAULTIFY_FUNCTIONS+=(ci_defaultify)
+JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
+
+#**
+# =========================
+# J.U.S.T. CI Functions
+# =========================
+#
+# .. default-domain:: bash
+#
+# .. file:: just_ci_functions.bsh
+#
+# CI plugin for just
+#**
+
+#**
+# .. command:: ci_load-recipes
+#
+# :Arguments: [``$1``]... - Recipe names to load
+#
+# Runs `ci_load.py` for specified docker recipes. Handles loading of both single and multi-stage recipes. Note recipes are not pushed back to the recipe cache (``ci_load.py --no-push ...``).
+#
+# .. command:: ci_load-recipes-auto
+#
+# :Arguments: ``$1``... - Dockerfiles to parse
+#
+# Scans Dockerfiles for ``vsiri/recipe:`` images, and calls :cmd:`ci_load-recipes` on the recipes discovered. Accepts multiple files and ``-`` for stdin
+#
+# .. command:: ci_load-services
+#
+# :Arguments: ``$1`` - Docker compose yaml file
+#             ``$2`` - Main docker-compose service
+#             [``$3``]... - Optional `ci_load.py` inputs
+#
+# Runs `ci_load.py` for specified docker services. Recipes are expected to be loaded prior to call via ``just ci load-recipes-auto``.
+#
+#**
+
+function ci_defaultify()
+{
+  arg=$1
+  shift 1
+  case $arg in
+    ci_load-recipes) # Load recipes from dockerhub cache
+      for recipe in ${@+"${@}"}; do
+        python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
+            --recipe-repo "IGNORE-RECIPE-REPO" \
+            --cache-repo "vsiri/ci_cache_recipes" \
+            --no-push \
+            "${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml" \
+            "${recipe}"
+      done
+      extra_args=$#
+      ;;
+    ci_load-recipes-auto) # Load recipes used in specified Dockerfiles from \
+                          # dockerhub cache. "-" for stdin; multiple files \
+                          # (via wildcards) accepted
+      if [ "$#" = "0" ]; then
+        source "${VSI_COMMON_DIR}/linux/colors.bsh"
+        echo "${RED}ERROR:${NC} You must pass at least one argument to ci load recipes-auto" >&2
+        return 1
+      fi
+      local recipes=($(get_docker_recipes ${@+"${@}"}))
+      justify ci_load-recipes "${recipes[@]}"
+      extra_args=$#
+      ;;
+    ci_load-services) # Load services from dockerhub cache
+      python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
+          --recipe-repo "IGNORE-RECIPE-REPO" \
+          --cache-repo "vsiri/ci_cache" \
+          ${@+"${@}"}
+      extra_args=$#
+      ;;
+    *)
+      plugin_not_found=1
+      ;;
+  esac
+}

--- a/linux/just_files/just_docker_functions.bsh
+++ b/linux/just_files/just_docker_functions.bsh
@@ -296,26 +296,6 @@ function get_docker_recipes()
 #
 # Scans Dockerfiles for ``vsiri/recipe:`` images, and calls :cmd:`build_recipes` on the recipes discovered. Accepts multiple files and ``-`` for stdin
 #
-# .. command:: ci_load_recipes
-#
-# :Arguments: [``$1``]... - Recipe names to load
-#
-# Runs `ci_load.py` for specified docker recipes. Handles loading of both single and multi-stage recipes. Note recipes are not pushed back to the recipe cache (``ci_load.py --no-push ...``).
-#
-# .. command:: ci_load_recipes-auto
-#
-# :Arguments: ``$1``... - Dockerfiles to parse
-#
-# Scans Dockerfiles for ``vsiri/recipe:`` images, and calls :cmd:`ci_load_recipes` on the recipes discovered. Accepts multiple files and ``-`` for stdin
-#
-# .. command:: ci_load_services
-#
-# :Arguments: ``$1`` - Docker compose yaml file
-#             ``$2`` - Main docker-compose service
-#             [``$3``]... - Optional `ci_load.py` inputs
-#
-# Runs `ci_load.py` for specified docker services. Recipes are expected to be loaded prior to call via ``just ci load recipes-auto``.
-#
 # .. command:: log
 #
 # :Arguments: [``$1``]... - Service names
@@ -394,36 +374,6 @@ function docker_defaultify()
       if [ "${#recipes[@]}" != "0" ]; then
         justify build recipes "${recipes[@]}"
       fi
-      extra_args=$#
-      ;;
-    ci_load_recipes) # Load recipes from dockerhub cache
-      for recipe in ${@+"${@}"}; do
-        python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
-            --recipe-repo "IGNORE-RECIPE-REPO" \
-            --cache-repo "vsiri/ci_cache_recipes" \
-            --no-push \
-            "${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml" \
-            "${recipe}"
-      done
-      extra_args=$#
-      ;;
-    ci_load_recipes-auto) # Load recipes used in specified Dockerfiles from \
-                          # dockerhub cache. "-" for stdin; multiple files \
-                          # (via wildcards) accepted
-      if [ "$#" = "0" ]; then
-        source "${VSI_COMMON_DIR}/linux/colors.bsh"
-        echo "${RED}ERROR:${NC} You must pass at least one argument to ci load recipes-auto" >&2
-        return 1
-      fi
-      local recipes=($(get_docker_recipes ${@+"${@}"}))
-      justify ci_load_recipes "${recipes[@]}"
-      extra_args=$#
-      ;;
-    ci_load_services) # Load services from dockerhub cache
-      python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
-          --recipe-repo "IGNORE-RECIPE-REPO" \
-          --cache-repo "vsiri/ci_cache" \
-          ${@+"${@}"}
       extra_args=$#
       ;;
     docker_clean) # Delete a docker volume. The next container to use this \

--- a/linux/just_files/just_docker_functions.bsh
+++ b/linux/just_files/just_docker_functions.bsh
@@ -296,6 +296,26 @@ function get_docker_recipes()
 #
 # Scans Dockerfiles for ``vsiri/recipe:`` images, and calls :cmd:`build_recipes` on the recipes discovered. Accepts multiple files and ``-`` for stdin
 #
+# .. command:: ci_load_recipes
+#
+# :Arguments: [``$1``]... - Recipe names to load
+#
+# Runs :cmd:`ci_load` for specified docker recipes. Handles loading of both single and multi-stage recipes. Note recipes are not pushed back to the recipe cache (``ci_load.py --no-push ...``).
+#
+# .. command:: ci_load_recipes-auto
+#
+# :Arguments: ``$1``... - Dockerfiles to parse
+#
+# Scans Dockerfiles for ``vsiri/recipe:`` images, and calls :cmd:`ci_load` on the recipes discovered. Accepts multiple files and ``-`` for stdin
+#
+# .. command:: ci_load_services
+#
+# :Arguments: ``$1`` - Docker compose yaml file
+#             ``$2`` - Main docker-compose service
+#             [``$3``]... - Optional :cmd:`ci_load` inputs
+#
+# Runs :cmd:`ci_load` for specified docker services. Recipes are expected to be loaded prior to call via ``just ci load recipes-auto``.
+#
 # .. command:: log
 #
 # :Arguments: [``$1``]... - Service names
@@ -374,6 +394,36 @@ function docker_defaultify()
       if [ "${#recipes[@]}" != "0" ]; then
         justify build recipes "${recipes[@]}"
       fi
+      extra_args=$#
+      ;;
+    ci_load_recipes) # Load recipes from dockerhub cache
+      for recipe in ${@+"${@}"}; do
+        python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
+            --recipe-repo "IGNORE-RECIPE-REPO" \
+            --cache-repo "vsiri/ci_cache_recipes" \
+            --no-push \
+            "${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml" \
+            "${recipe}"
+      done
+      extra_args=$#
+      ;;
+    ci_load_recipes-auto) # Load recipes used in specified Dockerfiles from \
+                          # dockerhub cache. "-" for stdin; multiple files \
+                          # (via wildcards) accepted
+      if [ "$#" = "0" ]; then
+        source "${VSI_COMMON_DIR}/linux/colors.bsh"
+        echo "${RED}ERROR:${NC} You must pass at least one argument to ci load recipes-auto" >&2
+        return 1
+      fi
+      local recipes=($(get_docker_recipes ${@+"${@}"}))
+      justify ci_load_recipes "${recipes[@]}"
+      extra_args=$#
+      ;;
+    ci_load_services) # Load services from dockerhub cache
+      python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
+          --recipe-repo "IGNORE-RECIPE-REPO" \
+          --cache-repo "vsiri/ci_cache" \
+          ${@+"${@}"}
       extra_args=$#
       ;;
     docker_clean) # Delete a docker volume. The next container to use this \

--- a/linux/just_files/just_docker_functions.bsh
+++ b/linux/just_files/just_docker_functions.bsh
@@ -300,21 +300,21 @@ function get_docker_recipes()
 #
 # :Arguments: [``$1``]... - Recipe names to load
 #
-# Runs :cmd:`ci_load` for specified docker recipes. Handles loading of both single and multi-stage recipes. Note recipes are not pushed back to the recipe cache (``ci_load.py --no-push ...``).
+# Runs `ci_load.py` for specified docker recipes. Handles loading of both single and multi-stage recipes. Note recipes are not pushed back to the recipe cache (``ci_load.py --no-push ...``).
 #
 # .. command:: ci_load_recipes-auto
 #
 # :Arguments: ``$1``... - Dockerfiles to parse
 #
-# Scans Dockerfiles for ``vsiri/recipe:`` images, and calls :cmd:`ci_load` on the recipes discovered. Accepts multiple files and ``-`` for stdin
+# Scans Dockerfiles for ``vsiri/recipe:`` images, and calls :cmd:`ci_load_recipes` on the recipes discovered. Accepts multiple files and ``-`` for stdin
 #
 # .. command:: ci_load_services
 #
 # :Arguments: ``$1`` - Docker compose yaml file
 #             ``$2`` - Main docker-compose service
-#             [``$3``]... - Optional :cmd:`ci_load` inputs
+#             [``$3``]... - Optional `ci_load.py` inputs
 #
-# Runs :cmd:`ci_load` for specified docker services. Recipes are expected to be loaded prior to call via ``just ci load recipes-auto``.
+# Runs `ci_load.py` for specified docker services. Recipes are expected to be loaded prior to call via ``just ci load recipes-auto``.
 #
 # .. command:: log
 #


### PR DESCRIPTION
While `ci_load.py` handles multi-stage services very well, it does not handle multi-stage **recipes** such as `recipe_gdal`.  The final `ONBUILD` stage of a recipe is successfully loaded, but preceding recipe stages are not loaded.

Rather than update `ci_load.py` to also handle multi-stage recipes, we can instead combine `ci_load.py` with the recipe cache now on dockerhub @ [vsiri/ci_cache_recipes](https://hub.docker.com/repository/docker/vsiri/ci_cache_recipes) to introduce a new ci_load pattern inspired by `build_recipes-auto`.

We separate recipe (`ci_load_recipes-auto`) and service (`ci_load_services`) load to ensure all recipe & service multi-stage docker caches are correctly cached.  Projects may add the following to their just file to include ci_load capabilities:

```
ci_load)
  justify ci load_recipes-auto "<PATH_TO_DOCKERFILE>"
  justify ci load_services "<PATH_TO_DOCKER_COMPOSE_YML>" <MAIN_SERVICE> [<OTHER_SERVICE_1> ...] ${@+"${@}"}
  extra_args=$#
  ;;
```

Additional notes:
- `ci_load_recipes` uses the `ci_load.py --no-push...` option, as the `vsiri/ci_cache_recipe` cache is expected to only be updated by the [docker_recipes](https://github.com/VisionSystemsInc/docker_recipes/) repo
- For existing projects, the first rebuild may take a while as CI adjusts to the new `vsiri/ci_cache_recipe` cache.
- While this PR does not touch `ci_load.py`, it does offer the opportunity to simplify that script by eliminating the need for special recipe handling.
