### PR TITLE
ci_load version

### DIFF
--- a/linux/just_files/just_ci_functions.bsh
+++ b/linux/just_files/just_ci_functions.bsh
@@ -24,6 +24,54 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 #**
 
 #**
+# .. envvar:: JUST_CI_CACHE_REPO
+#
+# Dockerhub repository for CI service cache.
+#
+# .. seealso::
+#
+#   :cmd:`ci_load-services`
+#**
+
+: ${JUST_CI_CACHE_REPO="vsiri/ci_cache"}
+
+#**
+# .. envvar:: JUST_CI_CACHE_VERSION
+#
+# Version for CI service cache.
+#
+# .. seealso::
+#
+#   :cmd:`ci_load-services`
+#**
+
+: ${JUST_CI_CACHE_VERSION=}
+
+#**
+# .. envvar:: JUST_CI_RECIPE_REPO
+#
+# Dockerhub repository for CI recipe cache.
+#
+# .. seealso::
+#
+#   :cmd:`ci_load-recipes`, :cmd:`ci_load-recipes-auto`
+#**
+
+: ${JUST_CI_RECIPE_REPO="vsiri/ci_cache_recipes"}
+
+#**
+# .. envvar:: JUST_CI_RECIPE_VERSION
+#
+# Version for CI recipe cache.
+#
+# .. seealso::
+#
+#   :cmd:`ci_load-recipes`, :cmd:`ci_load-recipes-auto`
+#**
+
+: ${JUST_CI_RECIPE_VERSION=}
+
+#**
 # .. command:: ci_load-recipes
 #
 # :Arguments: [``$1``]... - Recipe names to load
@@ -54,8 +102,9 @@ function ci_defaultify()
     ci_load-recipes) # Load recipes from dockerhub cache
       for recipe in ${@+"${@}"}; do
         python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
-            --recipe-repo "IGNORE-RECIPE-REPO" \
-            --cache-repo "vsiri/ci_cache_recipes" \
+            --recipe-repo "IGNORE" \
+            ${JUST_CI_RECIPE_REPO:+ --cache-repo "${JUST_CI_RECIPE_REPO}"} \
+            ${JUST_CI_RECIPE_VERSION:+ --cache-version "${JUST_CI_RECIPE_VERSION}"} \
             --no-push \
             "${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml" \
             "${recipe}"
@@ -76,8 +125,9 @@ function ci_defaultify()
       ;;
     ci_load-services) # Load services from dockerhub cache
       python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
-          --recipe-repo "IGNORE-RECIPE-REPO" \
-          --cache-repo "vsiri/ci_cache" \
+          --recipe-repo "IGNORE" \
+          ${JUST_CI_CACHE_REPO:+ --cache-repo "${JUST_CI_CACHE_REPO}"} \
+          ${JUST_CI_CACHE_VERSION:+ --cache-version "${JUST_CI_CACHE_VERSION}"} \
           ${@+"${@}"}
       extra_args=$#
       ;;


### PR DESCRIPTION
Allow ci_load versioning - this is useful to "clear" the cache (set a new version that is not in the dockerhub cache) without actually removing any images from dockerhub. 

Add new `JUST_CI_*` variables to control version & docherhub repo for both the recipe and service cache.