### PR TITLE
meet_requirements ==

### DIFF
--- a/linux/requirements.bsh
+++ b/linux/requirements.bsh
@@ -32,7 +32,7 @@ source "${VSI_COMMON_DIR}/linux/compat.bsh"
 # * Supports versions of any length, ``1``, ``1.0``, ``1.0.0.0.0.0``, etc...
 # * Supports an alpha version after the last number, ``1.0.2rc5``
 # * Supported version rules:
-#   * ``=`` - Does version equal this version. ``1`` is the same as ``1.0.0``, but not ``1.0.0p1``
+#   * ``==``, ``=``- Does version equal this version. ``1`` is the same as ``1.0.0``, but not ``1.0.0p1``
 #   * ``!=`` - Does the version not equal this version
 #   * ``<`` - Is this version less than this version
 #   * ``<=`` - Is this version less than or equal to this version
@@ -91,8 +91,13 @@ function _meet_requirements()
 
   while (( $# )); do
     case "${1}" in
+      ==*)
+        if ! version_eq "${version}" "${1:2}"; then
+          return 1
+        fi
+        ;;
       =*)
-        if not version_eq "${version}" "${1:1}"; then
+        if ! version_eq "${version}" "${1:1}"; then
           return 1
         fi
         ;;

--- a/tests/test-requirements.bsh
+++ b/tests/test-requirements.bsh
@@ -16,6 +16,9 @@ begin_test "meet_requirements"
   meet_requirements 1 ~1 || rv=$?
   [ "${rv}" = "2" ]
 
+  # ==
+  meet_requirements 1 ==1
+  not meet_requirements 1 ==1.1
   # =
   meet_requirements 1 =1
   not meet_requirements 1 =1.1
@@ -40,6 +43,10 @@ begin_test "meet_requirements"
   not meet_requirements 1 '>=1.1'
   meet_requirements 1 '>=1'
   meet_requirements 1.1 '>=1'
+
+  # == and !=
+  not meet_requirements 1.0.0 ==1.0.0 !=1.0.0
+  meet_requirements 1.0.0 ==1.0.0 !=1.0.1
 
   # = and !=
   not meet_requirements 1.0.0 =1.0.0 !=1.0.0


### PR DESCRIPTION
`meet_requirements` add `==*` option for improved compatibility with pip-style requirements.  New unit tests for `==*`.

Remove `not` command from `meet_requirements` - in my understanding, `not` is only available in the testing library and not available at runtime.  Note any utility using the `not` command may succeed at test time but fail at runtime.