### PR TITLE
just_install_functions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,8 +48,6 @@ install:
 
   # - '"C:\Program Files\Docker\Docker\DockerCli.exe" -SwitchLinuxEngine'
   # - docker-switch-linux # Suggested way to do the exact same command above
-  # Add unzip for just_install_functions::cmake-install
-  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S unzip"
 
 # This is how you select "Script mode" instead of "MSBuild" mode. There MUST
 # be something in build_script, else it doesn't count :(

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,8 @@ install:
   - C:\msys64\usr\bin\bash -lc "cat ~/.bashrc ~/.bash_profile"
   # - '"C:\Program Files\Docker\Docker\DockerCli.exe" -SwitchLinuxEngine'
   # - docker-switch-linux # Suggested way to do the exact same command above
+  # Add unzip for just_install_functions::cmake-install
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S unzip"
 
 # This is how you select "Script mode" instead of "MSBuild" mode. There MUST
 # be something in build_script, else it doesn't count :(
@@ -51,6 +53,7 @@ test_script:
   # anyways but ignore their failures.  Also, trace shtest.
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && source setup.env && just test"
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && source setup.env && just test int git_mirror"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && source setup.env && just test int just_install_functions"
   # - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && source setup.env && just test int_appveyor"
   # Appveyor only has Docker with linux containers in closed beta/"Premium" service :()
 

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -71,7 +71,6 @@ function cmake-install()
 
   # download zip/tar
   make_temp_path temp_dir -d
-  # temp_dir="$(mktemp -d)" && echo "temp_dir=${temp_dir}"
 
   local cmake_id
   local cmake_url="https://cmake.org/files/v${cmake_ver%.*}/"
@@ -86,7 +85,7 @@ function cmake-install()
     cmake_url+="${cmake_id}.tar.gz"
   fi
 
-  echo "Downloading cmake from <${cmake_url}>..."
+  echo "Downloading cmake from <${cmake_url}>..." >&2
   local cmake_file="${temp_dir}/$(basename "${cmake_url}")"
   download_to_stdout "${cmake_url}" > "${cmake_file}"
 
@@ -95,7 +94,7 @@ function cmake-install()
   install_dir="$(cd "${install_dir}"; pwd)"
 
   # unzip or untar
-  echo "Extracting cmake archive..."
+  echo "Extracting cmake archive..." >&2
   if [ "${OS-}" = "Windows_NT" ]; then
     unzip -oq "${cmake_file}" -x "*/doc/**" -d "${install_dir}"
   else
@@ -110,7 +109,7 @@ function cmake-install()
   # outputs: executable & version
   cmake_exe="${CMAKE}"
   cmake_version="$("${CMAKE}" --version | awk 'NR==1{print $3}')"
-  echo "CMake ${cmake_version} installed at \"${cmake_exe}\""
+  echo "CMake ${cmake_version} installed at \"${cmake_exe}\"" >&2
 
   # Make sure python meets request
   if ! meet_requirements "${cmake_version}" "==${cmake_ver}"; then
@@ -224,7 +223,7 @@ function conda-python-install()
 
   # download conda
   if [ "${download_conda}" = "1" ]; then
-    echo "Downloading miniconda..."
+    echo "Downloading miniconda..." >&2
 
     local conda_url="https://repo.anaconda.com/miniconda/"
     if [ "${OS-}" = "Windows_NT" ]; then
@@ -241,7 +240,7 @@ function conda-python-install()
 
   # install conda
   if [ "${install_conda}" = "1" ]; then
-    echo "Installing miniconda..."
+    echo "Installing miniconda..." >&2
     local conda_dir="${temp_dir}/conda"
     if [ "${OS-}" = "Windows_NT" ]; then
       MSYS2_ARG_CONV_EXCL="*" "${CONDA_INSTALLER}" /NoRegistry=1 /InstallationType=JustMe /S /D="$(cygpath -aw "${conda_dir}")"
@@ -254,7 +253,7 @@ function conda-python-install()
   fi
 
   # install python
-  echo "Installing python..."
+  echo "Installing python..." >&2
   "${CONDA}" create -y -p "${python_dir}" "python==${python_ver}"
   local python_exe_footer
   if [ "${OS-}" = "Windows_NT" ]; then
@@ -272,10 +271,10 @@ function conda-python-install()
   # (note python may write --version to stderr)
   python_exe="${PYTHON}"
   python_version="$("${python_exe}" --version 2>&1 | awk '{print $2}')"
-  echo "Python ${python_version} installed at \"${python_exe}\""
+  echo "Python ${python_version} installed at \"${python_exe}\"" >&2
 
   if [ -n "${python_activate-}" ]; then
-    echo "Activate python environment via <source \"${python_activate}\""
+    echo "Activate python environment via <source \"${python_activate}\"" >&2
   fi
 
   # Make sure python meets request
@@ -384,7 +383,7 @@ function pipenv-install()
     [ -f "${python_activate}" ] && source "${python_activate}"
 
     # install via 30_get-pipenv
-    echo "Installing pipenv..."
+    echo "Installing pipenv..." >&2
     source "${VSI_COMMON_DIR}/docker/recipes/30_get-pipenv"
     PIPENV_PYTHON="${PYTHON}"
     PIPENV_VERSION="${pipenv_ver}"
@@ -404,7 +403,7 @@ function pipenv-install()
   # outputs: pipenv executable & version
   pipenv_exe="${PIPENV}"
   pipenv_version="$("${PIPENV}" --version | awk '{print $3}' | sed 's|$\r||g' )"
-  echo "Pipenv ${pipenv_version} installed at \"${pipenv_exe}\""
+  echo "Pipenv ${pipenv_version} installed at \"${pipenv_exe}\"" >&2
 
   # Make sure pipenv meets requirements
   if ! meet_requirements "${pipenv_version}" "==${pipenv_ver}"; then

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -103,7 +103,12 @@ function cmake-install()
 
   # executable
   local cmake_dir="${install_dir}/${cmake_id}"
-  local cmake_exe_footer="/bin/cmake"
+  local cmake_exe_footer
+  if [[ ${OSTYPE-} = darwin* ]]; then
+    cmake_exe_footer="CMake.app/Contents/bin/cmake"
+  else
+    cmake_exe_footer="/bin/cmake"
+  fi
   local CMAKE="${cmake_dir}/${cmake_exe_footer}"
 
   # outputs: executable & version

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -25,15 +25,13 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 #
 # .. file:: just_install_functions.bsh
 #
-# Install plugin for just. Installation routines are designed to be installed
-# to isolated standalone locations, for example ``/your/path/python-3.7.9``.
+# Install plugin for just. Installation routines are designed to be installed to isolated standalone locations, for example ``/your/path/python-3.7.9``.
 #**
 
 #**
 # .. envvar:: JUST_INSTALL_ACTIVATE_BASENAME
 #
-# File basename for utility activation. Users may source anactivation
-# file to create useful environment variables and add the utility to $PATH.
+# File basename for utility activation. Users may source anactivation file to create useful environment variables and add the utility to $PATH.
 #
 #**
 
@@ -67,7 +65,8 @@ function cmake-install()
   # directory check
   if [ -z "${install_dir-}" ] ; then
     echo "CMake install must specify --dir" >& 2
-    exit 1
+    local JUST_IGNORE_EXIT_CODES=1
+    return 1
   fi
 
   # download zip/tar
@@ -100,17 +99,12 @@ function cmake-install()
   if [ "${OS-}" = "Windows_NT" ]; then
     unzip -oq "${cmake_file}" -x "*/doc/**" -d "${install_dir}"
   else
-    tar -xf "${cmake_file}" --exclude="doc" -C "${install_dir}"
+    tar -xf "${cmake_file}" --exclude="*/doc" -C "${install_dir}"
   fi
 
   # executable
   local cmake_dir="${install_dir}/${cmake_id}"
-  local cmake_exe_footer
-  if [ "${OS-}" = "Windows_NT" ]; then
-    cmake_exe_footer="bin/cmake.exe"
-  else
-    cmake_exe_footer="bin/cmake"
-  fi
+  local cmake_exe_footer="/bin/cmake"
   local CMAKE="${cmake_dir}/${cmake_exe_footer}"
 
   # outputs: executable & version
@@ -121,7 +115,8 @@ function cmake-install()
   # Make sure python meets request
   if ! meet_requirements "${cmake_version}" "==${cmake_ver}"; then
     echo "CMake version ${cmake_version} is not the requested version ${cmake_ver}" >&2
-    exit 1
+    local JUST_IGNORE_EXIT_CODES=1
+    return 1
   fi
 
   # cmake activate
@@ -187,7 +182,8 @@ function conda-python-install()
   # directory check
   if [ -z "${install_dir-}" ] ; then
     echo "Conda python install must specify --dir" >& 2
-    exit 1
+    local JUST_IGNORE_EXIT_CODES=1
+    return 1
   fi
 
   # conda download & install requirements
@@ -230,13 +226,13 @@ function conda-python-install()
   if [ "${download_conda}" = "1" ]; then
     echo "Downloading miniconda..."
 
-    local conda_url
+    local conda_url="https://repo.anaconda.com/miniconda/"
     if [ "${OS-}" = "Windows_NT" ]; then
-      conda_url="https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe"
+      conda_url+="Miniconda3-latest-Windows-x86_64.exe"
     elif [[ ${OSTYPE-} = darwin* ]]; then
-      conda_url="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+      conda_url+="Miniconda3-latest-MacOSX-x86_64.sh"
     else
-      conda_url="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+      conda_url+="Miniconda3-latest-Linux-x86_64.sh"
     fi
 
     CONDA_INSTALLER="${temp_dir}/$(basename "${conda_url}")"
@@ -264,7 +260,11 @@ function conda-python-install()
   if [ "${OS-}" = "Windows_NT" ]; then
     python_exe_footer="python.exe"
   else
-    python_exe_footer="bin/python"
+    if [ -f "${python_dir}/bin/python3" ]; then
+      python_exe_footer="bin/python3"
+    else
+      python_exe_footer="bin/python"
+    fi
   fi
   local PYTHON="${python_dir}/${python_exe_footer}"
 
@@ -281,7 +281,8 @@ function conda-python-install()
   # Make sure python meets request
   if ! meet_requirements "${python_version}" "==${python_ver}"; then
     echo "Python version ${python_version} is not the requested version ${python_ver}" >&2
-    exit 1
+    local JUST_IGNORE_EXIT_CODES=1
+    return 1
   fi
 
 
@@ -333,8 +334,8 @@ function conda-python-install()
 # Install a virtualenv containing pipenv.
 #
 # :Arguments: * [``--dir {dir}``] - Pipenv install directory
-#             * [``--ver {ver}``] - Pipenv version for install (default=``${PIPENV_VERSION:-2018.11.26}``)
-#             * [``--python {PYTHON}``] - Python executable (default=(python3|python|python3))
+#             * [``--ver {ver}``] - Pipenv version for install (default=``${PIPENV_VERSION:-2020.8.13}``)
+#             * [``--python {PYTHON}``] - Python executable (default=(python3|python|python2))
 #
 # :Output: * pipenv_exe - Pipenv executable
 #          * pipenv_version - Pipenv version
@@ -346,7 +347,7 @@ function conda-python-install()
 function pipenv-install()
 {
   local install_dir  # install directory
-  local pipenv_ver="${PIPENV_VERSION:-2018.11.26}"  # pipenv version
+  local pipenv_ver="${PIPENV_VERSION:-2020.8.13}"  # pipenv version
   local PYTHON  # python executable
 
   parse_args pipenv_extra_args \
@@ -358,14 +359,16 @@ function pipenv-install()
   # check for pipenv directory
   if [ -z "${install_dir}" ]; then
     echo "Pipenv install must specify --dir" >& 2
-    exit 1
+    local JUST_IGNORE_EXIT_CODES=1
+    return 1
   fi
 
   # search for python if not specified
   : ${PYTHON:="$( (command -v python3 || command -v python || command -v python2) | head -n 1)"}
   if [ ! -f "${PYTHON}" ]; then
     echo "Pipenv install cannot find python executable" >&2
-    exit 1
+    local JUST_IGNORE_EXIT_CODES=1
+    return 1
   fi
 
   # create pipenv directory
@@ -406,7 +409,8 @@ function pipenv-install()
   # Make sure pipenv meets requirements
   if ! meet_requirements "${pipenv_version}" "==${pipenv_ver}"; then
     echo "Pipenv version ${pipenv_version} does not match request ${pipenv_ver}" >&2
-    exit 1
+    local JUST_IGNORE_EXIT_CODES=1
+    return 1
   fi
 
   # pipenv activate

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -1,0 +1,431 @@
+#!/usr/bin/env false bash
+
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return 0
+fi
+
+# dependencies
+source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
+source "${VSI_COMMON_DIR}/linux/command_tools.bsh"
+source "${VSI_COMMON_DIR}/linux/requirements.bsh"
+source "${VSI_COMMON_DIR}/linux/uwecho.bsh"
+source "${VSI_COMMON_DIR}/linux/web_tools.bsh"
+
+#*# just/plugins/just_install_functions
+
+JUST_DEFAULTIFY_FUNCTIONS+=(install_defaultify)
+JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
+
+#**
+# =============================
+# J.U.S.T. Install CI Functions
+# =============================
+#
+# .. default-domain:: bash
+#
+# .. file:: just_install_functions.bsh
+#
+# Install plugin for just. Installation routines are designed to be installed
+# to portable standalone locations, for example ``/your/path/python-3.7.9``.
+#**
+
+#**
+# .. function:: cmake-install
+#
+# Install CMake.
+#
+# :Arguments: * [``--dir {dir}``] - CMake install directory
+#             * [``--ver {ver}``] - CMake version for install (default=``${CMAKE_VERSION:-3.16.3}``)
+#
+# :Output: * cmake_exe - CMake executable
+#          * cmake_version - CMake version
+#          * cmake_extra_args - number of arguments consumed
+#**
+
+function cmake-install()
+{
+  local install_dir  # install directory
+  local cmake_ver="${CMAKE_VERSION:-3.16.3}"  # cmake version
+
+  parse_args cmake_extra_args \
+      --dir install_dir: \
+      --ver cmake_ver: \
+      -- ${@+"${@}"}
+
+  # directory check
+  if [ -z "${install_dir-}" ] ; then
+    echo "CMake install must specify --dir" >& 2
+    exit 1
+  fi
+
+  # download zip/tar
+  make_temp_path temp_dir -d
+  # temp_dir="$(mktemp -d)" && echo "temp_dir=${temp_dir}"
+
+  local cmake_id
+  local cmake_url="https://cmake.org/files/v${cmake_ver%.*}/"
+  if [ "${OS-}" = "Windows_NT" ]; then
+    cmake_id="cmake-${cmake_ver}-win64-x64"
+    cmake_url+="${cmake_id}.zip"
+  elif [[ ${OSTYPE-} = darwin* ]]; then
+    cmake_id="cmake-${cmake_ver}-Darwin-x86_64"
+    cmake_url+="${cmake_id}.tar.gz"
+  else
+    cmake_id="cmake-${cmake_ver}-Linux-x86_64"
+    cmake_url+="${cmake_id}.tar.gz"
+  fi
+
+  echo "Downloading cmake from <${cmake_url}>..."
+  local cmake_file="${temp_dir}/$(basename "${cmake_url}")"
+  download_to_stdout "${cmake_url}" > "${cmake_file}"
+
+  # create output directory
+  mkdir -p "${install_dir}"
+  install_dir="$(cd "${install_dir}"; pwd)"
+
+  # unzip or untar
+  echo "Extracting cmake archive..."
+  if [ "${OS-}" = "Windows_NT" ]; then
+    unzip -oq "${cmake_file}" -x "*/doc/**" -d "${install_dir}"
+  else
+    tar -xf "${cmake_file}" --exclude="doc" -C "${install_dir}"
+  fi
+
+  # executable
+  local CMAKE
+  if [ "${OS-}" = "Windows_NT" ]; then
+    CMAKE="${install_dir}/${cmake_id}/bin/cmake.exe"
+  else
+    CMAKE="${install_dir}/${cmake_id}/bin/cmake"
+  fi
+
+  # outputs: executable & version
+  cmake_exe="${CMAKE}"
+  cmake_version="$("${CMAKE}" --version | awk 'NR==1{print $3}')"
+  echo "CMake ${cmake_version} installed at \"${cmake_exe}\""
+
+  # Make sure python meets request
+  if ! meet_requirements "${cmake_version}" "==${cmake_ver}"; then
+    echo "CMake version ${cmake_version} is not the requested version ${cmake_ver}" >&2
+    exit 1
+  fi
+}
+
+
+#**
+# .. function:: conda-python-install
+#
+# Install python via conda.
+#
+# The conda executable is selected as per the following preference order:
+# * ``--conda``
+# * temporary conda installed from ``conda-installer``
+# * if ``--download``: temporary miniconda3 download
+# * else: system level conda if available, then temporary miniconda3 download
+#
+# :Arguments: * [``--dir {dir}``] - Python install directory
+#             * [``--ver {ver}``] - Python version for install (default=``${PYTHON_VERSION:-3.6.9}``)
+#             * [``--conda {CONDA}``] - Conda executable
+#             * [``--conda-installer {INSTALLER}``] - Conda installer
+#             * [``--download``] - Download miniconda
+#
+# :Output: * python_exe - Python executable
+#          * python_version - Python version
+#          * conda_python_extra_args - number of arguments consumed
+#          * python_activate - Bash file to mimic "conda activate"
+#
+#**
+
+function conda-python-install()
+{
+  local install_dir  # install directory
+  local python_ver="${PYTHON_VERSION:-3.6.9}"  # python version
+  local CONDA  # conda executable
+  local CONDA_INSTALLER  # conda installer
+  local prefer_download=0  # prefer conda download if no CONDA|CONDA_INSTALLER
+
+  parse_args conda_python_extra_args \
+      --dir install_dir: \
+      --ver python_ver: \
+      --conda CONDA: \
+      --conda-installer CONDA_INSTALLER: \
+      --download prefer_download \
+      -- ${@+"${@}"}
+
+  # directory check
+  if [ -z "${install_dir-}" ] ; then
+    echo "Conda python install must specify --dir" >& 2
+    exit 1
+  fi
+
+  # conda download & install requirements
+  local download_conda=0
+  local install_conda=0
+
+  if [ -n "${CONDA:+set}" ]; then
+    # use provided conda
+    :
+  elif [ -n "${CONDA_INSTALL:+set}" ]; then
+    # use provided conda installer
+    install_conda=1
+  elif [ "${prefer_download}" == "1" ]; then
+    # download is preferred
+    download_conda=1
+    install_conda=1
+  else
+    CONDA="$( ( (command -v conda3 || command -v conda || command -v conda2) | head -n 1) || :)"
+    if [ -n "${CONDA:+set}" ]; then
+      # use system conda
+      :
+    else
+      # otherwise default to download
+      download_conda=1
+      install_conda=1
+    fi
+  fi
+
+  # temporary conda directory
+  if [ "${install_conda}" = "1" ]; then
+    # make_temp_path temp_dir -d
+    temp_dir="$(mktemp -d)" && echo "temp_dir=${temp_dir}"
+  fi
+
+  # download conda
+  if [ "${download_conda}" = "1" ]; then
+    echo "Downloading miniconda..."
+
+    local conda_url
+    if [ "${OS-}" = "Windows_NT" ]; then
+      conda_url="https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe"
+    elif [[ ${OSTYPE-} = darwin* ]]; then
+      conda_url="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+    else
+      conda_url="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+    fi
+
+    CONDA_INSTALLER="${temp_dir}/$(basename "${conda_url}")"
+    download_to_stdout "${conda_url}" > "${CONDA_INSTALLER}"
+  fi
+
+  # install conda
+  if [ "${install_conda}" = "1" ]; then
+    echo "Installing miniconda..."
+    local conda_dir="${temp_dir}/conda"
+    if [ "${OS-}" = "Windows_NT" ]; then
+      MSYS2_ARG_CONV_EXCL="*" "${CONDA_INSTALLER}" /NoRegistry=1 /InstallationType=JustMe /S /D="$(cygpath -aw "${conda_dir}")"
+      CONDA="${conda_dir}/_conda"
+      # CONDA="${conda_temp_dir}/conda/Scripts/conda"
+    else
+      bash "${CONDA_INSTALLER}" -b -p "${conda_dir}" -s
+      CONDA="${conda_dir}/bin/conda"
+    fi
+  fi
+
+  # create output directory
+  install_dir="${install_dir}/python-${python_ver}"
+  mkdir -p "${install_dir}"
+  install_dir="$(cd "${install_dir}"; pwd)"
+
+  # install python
+  echo "Installing python..."
+  "${CONDA}" create -y -p "${install_dir}" "python==${python_ver}"
+  local PYTHON
+  if [ "${OS-}" = "Windows_NT" ]; then
+    PYTHON="${install_dir}/python.exe"
+  else
+    PYTHON="${install_dir}/bin/python"
+  fi
+
+  # python activation - users may source this file to mimic conda
+  # activation, ensuring appropriate path setup for python functions
+  #
+  # Without sourcing this file, a subsequent call of 'just install pipenv'
+  # will likely fail with the error:
+  #   urllib.error.URLError: <urlopen error unknown url type: https>
+  # as python cannot find necessary libraries
+  if [ "${OS-}" = "Windows_NT" ]; then
+    python_activate="${install_dir}/_python_activate.bsh"
+    uwecho '#!/usr/bin/env bash
+            set -eu
+
+            # python directory (folder where this file resides)
+            this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
+
+            # additional paths for python as per "conda activate"
+            # https://github.com/conda/conda/blob/master/conda/shell/condabin/_conda_activate.bat#L23
+            MORE_PATHS=(
+                "${this_dir}"
+                "${this_dir}/Library/mingw-w64/bin"
+                "${this_dir}/Library/usr/bin"
+                "${this_dir}/Library/bin"
+                "${this_dir}/Scripts"
+                "${this_dir}/bin"
+            )
+            MORE_PATH="$(IFS=':'; echo "${MORE_PATHS[*]}")"
+
+            # update path
+            PATH="${MORE_PATH}:${PATH}"
+            ' >> "${python_activate}"
+  fi
+
+  # output: python executable & version
+  # (note python may write --version to stderr)
+  python_exe="${PYTHON}"
+  python_version="$("${python_exe}" --version 2>&1 | awk '{print $2}')"
+  echo "Python ${python_version} installed at \"${python_exe}\""
+
+  if [ -n "${python_activate-}" ]; then
+    echo "Activate python environment via <source \"${python_activate}\""
+  fi
+
+  # Make sure python meets request
+  if ! meet_requirements "${python_version}" "==${python_ver}"; then
+    echo "Python version ${python_version} is not the requested version ${python_ver}" >&2
+    exit 1
+  fi
+}
+
+
+#**
+# .. function:: pipenv-install
+#
+# Install a virtualenv containing pipenv.
+#
+# :Arguments: * [``--dir {dir}``] - Pipenv install directory
+#             * [``--ver {ver}``] - Pipenv version for install (default=``${PIPENV_VERSION:-2018.11.26}``)
+#             * [``--python {PYTHON}``] - Python executable (default=(python3|python|python3))
+#
+# :Output: * pipenv_exe - Pipenv executable
+#          * pipenv_version - Pipenv version
+#          * pipenv_extra_args - number of arguments consumed
+#
+#**
+
+function pipenv-install()
+{
+  local install_dir  # install directory
+  local pipenv_ver="${PIPENV_VERSION:-2018.11.26}"  # pipenv version
+  local PYTHON  # python executable
+
+  parse_args pipenv_extra_args \
+      --dir install_dir: \
+      --ver pipenv_ver: \
+      --python PYTHON: \
+      -- ${@+"${@}"}
+
+  # check for pipenv directory
+  if [ -z "${install_dir}" ]; then
+    echo "Pipenv install must specify --dir" >& 2
+    exit 1
+  fi
+
+  # search for python if not specified
+  : ${PYTHON:="$( (command -v python3 || command -v python || command -v python2) | head -n 1)"}
+  if [ ! -f "${PYTHON}" ]; then
+    echo "Pipenv install cannot find python executable" >&2
+    exit 1
+  fi
+
+  # dtermine if a "_python_activate.bsh" file exists, as created by the
+  # function "conda-python-install"
+  local python_activate="$(dirname "${PYTHON}")/_python_activate.bsh"
+  if [ ! -f "${python_activate}" ]; then
+    python_activate=
+  fi
+
+  # create pipenv directory
+  install_dir="${install_dir}/pipenv-${pipenv_ver}"
+  mkdir -p "${install_dir}"
+  install_dir="$(cd "${install_dir}"; pwd)"
+
+  # pipenv install via 30_get-pipenv
+  # run in subshell, as sourced files are only needed temporarily
+  (
+    # "activate" python if created via the "conda-python-install" function
+    local python_activate="$(dirname "${PYTHON}")/_python_activate.bsh"
+    [ -f "${python_activate}" ] && source "${python_activate}"
+
+    # install via 30_get-pipenv
+    echo "Installing pipenv..."
+    source "${VSI_COMMON_DIR}/docker/recipes/30_get-pipenv"
+    PIPENV_PYTHON="${PYTHON}"
+    PIPENV_VERSION="${pipenv_ver}"
+    PIPENV_VIRTUALENV="${install_dir}"
+    install_pipenv
+  )
+
+  # pipenv executable
+  local PIPENV
+  if [ "${OS-}" = "Windows_NT" ]; then
+    PIPENV="${install_dir}/Scripts/pipenv"
+  else
+    PIPENV="${install_dir}/bin/pipenv"
+  fi
+
+  # outputs: pipenv executable & version
+  pipenv_exe="${PIPENV}"
+  pipenv_version="$("${PIPENV}" --version | awk '{print $3}' | sed 's|$\r||g' )"
+  echo "Pipenv ${pipenv_version} installed at \"${pipenv_exe}\""
+
+  # Make sure pipenv meets requirements
+  if ! meet_requirements "${pipenv_version}" "==${pipenv_ver}"; then
+    echo "Pipenv version ${pipenv_version} does not match request ${pipenv_ver}" >&2
+    exit 1
+  fi
+}
+
+
+#**
+# .. command:: install_cmake
+#
+# Install CMake
+#
+# .. seealso::
+#
+#   :func:`cmake-install`
+#
+
+# .. command:: install_conda-python
+#
+# Install python via conda
+#
+# .. seealso::
+#
+#   :func:`conda-python-install`
+#
+# .. command:: install_pipenv
+#
+
+# Install a virtualenv containing pipenv
+#
+# .. seealso::
+#
+#   :func:`pipenv-install`
+#
+
+#**
+
+function install_defaultify()
+{
+  arg=$1
+  shift 1
+  case $arg in
+
+    install_cmake) # Install CMake
+      cmake-install ${@+"${@}"}
+      extra_args=cmake_extra_args
+      ;;
+    install_conda-python) # Install python via conda
+      conda-python-install ${@+"${@}"}
+      extra_args=conda_python_extra_args
+      ;;
+    install_pipenv) # Install a virtualenv containing pipenv
+      pipenv-install ${@+"${@}"}
+      extra_args=pipenv_extra_args
+      ;;
+    *)
+      plugin_not_found=1
+      ;;
+
+  esac
+}

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -92,11 +92,12 @@ function cmake-install()
   fi
 
   # executable
+  local cmake_dir="${install_dir}/${cmake_id}"
   local CMAKE
   if [ "${OS-}" = "Windows_NT" ]; then
-    CMAKE="${install_dir}/${cmake_id}/bin/cmake.exe"
+    CMAKE="${cmake_dir}/bin/cmake.exe"
   else
-    CMAKE="${install_dir}/${cmake_id}/bin/cmake"
+    CMAKE="${cmake_dir}/bin/cmake"
   fi
 
   # outputs: executable & version
@@ -184,10 +185,14 @@ function conda-python-install()
     fi
   fi
 
+  # create output directory
+  local python_dir="${install_dir}/python-${python_ver}"
+  mkdir -p "${python_dir}"
+  python_dir="$(cd "${python_dir}"; pwd)"
+
   # temporary conda directory
   if [ "${install_conda}" = "1" ]; then
-    # make_temp_path temp_dir -d
-    temp_dir="$(mktemp -d)" && echo "temp_dir=${temp_dir}"
+    make_temp_path temp_dir -d
   fi
 
   # download conda
@@ -221,19 +226,14 @@ function conda-python-install()
     fi
   fi
 
-  # create output directory
-  install_dir="${install_dir}/python-${python_ver}"
-  mkdir -p "${install_dir}"
-  install_dir="$(cd "${install_dir}"; pwd)"
-
   # install python
   echo "Installing python..."
-  "${CONDA}" create -y -p "${install_dir}" "python==${python_ver}"
+  "${CONDA}" create -y -p "${python_dir}" "python==${python_ver}"
   local PYTHON
   if [ "${OS-}" = "Windows_NT" ]; then
-    PYTHON="${install_dir}/python.exe"
+    PYTHON="${python_dir}/python.exe"
   else
-    PYTHON="${install_dir}/bin/python"
+    PYTHON="${python_dir}/bin/python"
   fi
 
   # python activation - users may source this file to mimic conda
@@ -244,7 +244,7 @@ function conda-python-install()
   #   urllib.error.URLError: <urlopen error unknown url type: https>
   # as python cannot find necessary libraries
   if [ "${OS-}" = "Windows_NT" ]; then
-    python_activate="${install_dir}/_python_activate.bsh"
+    python_activate="${python_dir}/_python_activate.bsh"
     uwecho '#!/usr/bin/env bash
             set -eu
 
@@ -326,7 +326,7 @@ function pipenv-install()
     exit 1
   fi
 
-  # dtermine if a "_python_activate.bsh" file exists, as created by the
+  # determine if a "_python_activate.bsh" file exists, as created by the
   # function "conda-python-install"
   local python_activate="$(dirname "${PYTHON}")/_python_activate.bsh"
   if [ ! -f "${python_activate}" ]; then
@@ -334,9 +334,9 @@ function pipenv-install()
   fi
 
   # create pipenv directory
-  install_dir="${install_dir}/pipenv-${pipenv_ver}"
-  mkdir -p "${install_dir}"
-  install_dir="$(cd "${install_dir}"; pwd)"
+  pipenv_dir="${install_dir}/pipenv-${pipenv_ver}"
+  mkdir -p "${pipenv_dir}"
+  pipenv_dir="$(cd "${pipenv_dir}"; pwd)"
 
   # pipenv install via 30_get-pipenv
   # run in subshell, as sourced files are only needed temporarily
@@ -350,16 +350,16 @@ function pipenv-install()
     source "${VSI_COMMON_DIR}/docker/recipes/30_get-pipenv"
     PIPENV_PYTHON="${PYTHON}"
     PIPENV_VERSION="${pipenv_ver}"
-    PIPENV_VIRTUALENV="${install_dir}"
+    PIPENV_VIRTUALENV="${pipenv_dir}"
     install_pipenv
   )
 
   # pipenv executable
   local PIPENV
   if [ "${OS-}" = "Windows_NT" ]; then
-    PIPENV="${install_dir}/Scripts/pipenv"
+    PIPENV="${pipenv_dir}/Scripts/pipenv"
   else
-    PIPENV="${install_dir}/bin/pipenv"
+    PIPENV="${pipenv_dir}/bin/pipenv"
   fi
 
   # outputs: pipenv executable & version

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -43,7 +43,7 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 # Install CMake.
 #
 # :Arguments: * [``--dir {dir}``] - CMake install directory
-#             * [``--ver {ver}``] - CMake version for install (default=``${CMAKE_VERSION:-3.16.3}``)
+#             * [``--version {version}``] - CMake version for install (default=``${CMAKE_VERSION:-3.16.3}``)
 #
 # :Output: * cmake_exe - CMake executable
 #          * cmake_version - CMake version
@@ -59,7 +59,7 @@ function cmake-install()
 
   parse_args cmake_extra_args \
       --dir install_dir: \
-      --ver cmake_ver: \
+      --version cmake_ver: \
       -- ${@+"${@}"}
 
   # directory check
@@ -151,7 +151,7 @@ function cmake-install()
 # * else: system level conda if available, then temporary miniconda3 download
 #
 # :Arguments: * [``--dir {dir}``] - Python install directory
-#             * [``--ver {ver}``] - Python version for install (default=``${PYTHON_VERSION:-3.6.9}``)
+#             * [``--version {version}``] - Python version for install (default=``${PYTHON_VERSION:-3.6.9}``)
 #             * [``--conda {CONDA}``] - Conda executable
 #             * [``--conda-installer {INSTALLER}``] - Conda installer
 #             * [``--download``] - Download miniconda
@@ -173,7 +173,7 @@ function conda-python-install()
 
   parse_args conda_python_extra_args \
       --dir install_dir: \
-      --ver python_ver: \
+      --version python_ver: \
       --conda CONDA: \
       --conda-installer CONDA_INSTALLER: \
       --download prefer_download \
@@ -334,7 +334,7 @@ function conda-python-install()
 # Install a virtualenv containing pipenv.
 #
 # :Arguments: * [``--dir {dir}``] - Pipenv install directory
-#             * [``--ver {ver}``] - Pipenv version for install (default=``${PIPENV_VERSION:-2020.8.13}``)
+#             * [``--version {version}``] - Pipenv version for install (default=``${PIPENV_VERSION:-2020.8.13}``)
 #             * [``--python {PYTHON}``] - Python executable (default=(python3|python|python2))
 #
 # :Output: * pipenv_exe - Pipenv executable
@@ -352,7 +352,7 @@ function pipenv-install()
 
   parse_args pipenv_extra_args \
       --dir install_dir: \
-      --ver pipenv_ver: \
+      --version pipenv_ver: \
       --python PYTHON: \
       -- ${@+"${@}"}
 

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -26,8 +26,18 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 # .. file:: just_install_functions.bsh
 #
 # Install plugin for just. Installation routines are designed to be installed
-# to portable standalone locations, for example ``/your/path/python-3.7.9``.
+# to isolated standalone locations, for example ``/your/path/python-3.7.9``.
 #**
+
+#**
+# .. envvar:: JUST_INSTALL_ACTIVATE_BASENAME
+#
+# File basename for utility activation. Users may source anactivation
+# file to create useful environment variables and add the utility to $PATH.
+#
+#**
+
+: ${JUST_INSTALL_ACTIVATE_BASENAME="just_activate.bsh"}
 
 #**
 # .. function:: cmake-install
@@ -40,6 +50,8 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 # :Output: * cmake_exe - CMake executable
 #          * cmake_version - CMake version
 #          * cmake_extra_args - number of arguments consumed
+#          * cmake_activate - Bash file to activate cmake environment
+#
 #**
 
 function cmake-install()
@@ -93,12 +105,13 @@ function cmake-install()
 
   # executable
   local cmake_dir="${install_dir}/${cmake_id}"
-  local CMAKE
+  local cmake_exe_footer
   if [ "${OS-}" = "Windows_NT" ]; then
-    CMAKE="${cmake_dir}/bin/cmake.exe"
+    cmake_exe_footer="bin/cmake.exe"
   else
-    CMAKE="${cmake_dir}/bin/cmake"
+    cmake_exe_footer="bin/cmake"
   fi
+  local CMAKE="${cmake_dir}/${cmake_exe_footer}"
 
   # outputs: executable & version
   cmake_exe="${CMAKE}"
@@ -110,6 +123,24 @@ function cmake-install()
     echo "CMake version ${cmake_version} is not the requested version ${cmake_ver}" >&2
     exit 1
   fi
+
+  # cmake activate
+  cmake_activate="${cmake_dir}/cmake_${JUST_INSTALL_ACTIVATE_BASENAME}"
+  uwecho '#!/usr/bin/env bash
+          set -eu
+
+          # folder where this file resides
+          CMAKE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
+          ' > "${cmake_activate}"
+  uwecho "
+          # executable & version
+          CMAKE_EXE=\"\${CMAKE_DIR}/${cmake_exe_footer}\"
+          CMAKE_VER=\"${cmake_version}\"
+          " >> "${cmake_activate}"
+  uwecho '
+          # update PATH
+          PATH="$(dirname "${CMAKE_EXE}"):${PATH}"
+          ' >> "${cmake_activate}"
 }
 
 
@@ -133,7 +164,7 @@ function cmake-install()
 # :Output: * python_exe - Python executable
 #          * python_version - Python version
 #          * conda_python_extra_args - number of arguments consumed
-#          * python_activate - Bash file to mimic "conda activate"
+#          * python_activate - Bash file to activate python environment
 #
 #**
 
@@ -229,44 +260,13 @@ function conda-python-install()
   # install python
   echo "Installing python..."
   "${CONDA}" create -y -p "${python_dir}" "python==${python_ver}"
-  local PYTHON
+  local python_exe_footer
   if [ "${OS-}" = "Windows_NT" ]; then
-    PYTHON="${python_dir}/python.exe"
+    python_exe_footer="python.exe"
   else
-    PYTHON="${python_dir}/bin/python"
+    python_exe_footer="bin/python"
   fi
-
-  # python activation - users may source this file to mimic conda
-  # activation, ensuring appropriate path setup for python functions
-  #
-  # Without sourcing this file, a subsequent call of 'just install pipenv'
-  # will likely fail with the error:
-  #   urllib.error.URLError: <urlopen error unknown url type: https>
-  # as python cannot find necessary libraries
-  if [ "${OS-}" = "Windows_NT" ]; then
-    python_activate="${python_dir}/_python_activate.bsh"
-    uwecho '#!/usr/bin/env bash
-            set -eu
-
-            # python directory (folder where this file resides)
-            this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
-
-            # additional paths for python as per "conda activate"
-            # https://github.com/conda/conda/blob/master/conda/shell/condabin/_conda_activate.bat#L23
-            MORE_PATHS=(
-                "${this_dir}"
-                "${this_dir}/Library/mingw-w64/bin"
-                "${this_dir}/Library/usr/bin"
-                "${this_dir}/Library/bin"
-                "${this_dir}/Scripts"
-                "${this_dir}/bin"
-            )
-            MORE_PATH="$(IFS=':'; echo "${MORE_PATHS[*]}")"
-
-            # update path
-            PATH="${MORE_PATH}:${PATH}"
-            ' >> "${python_activate}"
-  fi
+  local PYTHON="${python_dir}/${python_exe_footer}"
 
   # output: python executable & version
   # (note python may write --version to stderr)
@@ -283,6 +283,47 @@ function conda-python-install()
     echo "Python version ${python_version} is not the requested version ${python_ver}" >&2
     exit 1
   fi
+
+
+  # python activation - users may source this file to mimic conda
+  # activation, ensuring appropriate path setup for python functions
+  #
+  # Without sourcing this file, a subsequent call of 'just install pipenv'
+  # may fail with errors such as:
+  #   urllib.error.URLError: <urlopen error unknown url type: https>
+  # as python cannot find necessary libraries
+  python_activate="${python_dir}/python_${JUST_INSTALL_ACTIVATE_BASENAME}"
+  uwecho '#!/usr/bin/env bash
+          set -eu
+
+          # folder where this file resides
+          PYTHON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
+          ' > "${python_activate}"
+  uwecho "
+          # executable & version
+          PYTHON_EXE=\"\${PYTHON_DIR}/${python_exe_footer}\"
+          PYTHON_VER=\"${python_version}\"
+          " >> "${python_activate}"
+
+  if [ "${OS-}" = "Windows_NT" ]; then
+    uwecho '
+            # additional paths for python as per "conda activate"
+            # https://github.com/conda/conda/blob/master/conda/shell/condabin/_conda_activate.bat#L23
+            MORE_PATHS=(
+                "${PYTHON_DIR}"
+                "${PYTHON_DIR}/Library/mingw-w64/bin"
+                "${PYTHON_DIR}/Library/usr/bin"
+                "${PYTHON_DIR}/Library/bin"
+                "${PYTHON_DIR}/Scripts"
+                "${PYTHON_DIR}/bin"
+            )
+            MORE_PATH="$(IFS=':'; echo "${MORE_PATHS[*]}")"
+
+            # update PATH
+            PATH="${MORE_PATH}:${PATH}"
+            ' >> "${python_activate}"
+  fi
+
 }
 
 
@@ -298,6 +339,7 @@ function conda-python-install()
 # :Output: * pipenv_exe - Pipenv executable
 #          * pipenv_version - Pipenv version
 #          * pipenv_extra_args - number of arguments consumed
+#          * pipenv_activate - Bash file to activate pipenv environment
 #
 #**
 
@@ -326,13 +368,6 @@ function pipenv-install()
     exit 1
   fi
 
-  # determine if a "_python_activate.bsh" file exists, as created by the
-  # function "conda-python-install"
-  local python_activate="$(dirname "${PYTHON}")/_python_activate.bsh"
-  if [ ! -f "${python_activate}" ]; then
-    python_activate=
-  fi
-
   # create pipenv directory
   pipenv_dir="${install_dir}/pipenv-${pipenv_ver}"
   mkdir -p "${pipenv_dir}"
@@ -342,7 +377,7 @@ function pipenv-install()
   # run in subshell, as sourced files are only needed temporarily
   (
     # "activate" python if created via the "conda-python-install" function
-    local python_activate="$(dirname "${PYTHON}")/_python_activate.bsh"
+    local python_activate="$(dirname "${PYTHON}")/python_${JUST_INSTALL_ACTIVATE_BASENAME}"
     [ -f "${python_activate}" ] && source "${python_activate}"
 
     # install via 30_get-pipenv
@@ -355,12 +390,13 @@ function pipenv-install()
   )
 
   # pipenv executable
-  local PIPENV
+  local pipenv_exe_footer
   if [ "${OS-}" = "Windows_NT" ]; then
-    PIPENV="${pipenv_dir}/Scripts/pipenv"
+    pipenv_exe_footer="Scripts/pipenv"
   else
-    PIPENV="${pipenv_dir}/bin/pipenv"
+    pipenv_exe_footer="bin/pipenv"
   fi
+  local PIPENV="${pipenv_dir}/${pipenv_exe_footer}"
 
   # outputs: pipenv executable & version
   pipenv_exe="${PIPENV}"
@@ -372,6 +408,24 @@ function pipenv-install()
     echo "Pipenv version ${pipenv_version} does not match request ${pipenv_ver}" >&2
     exit 1
   fi
+
+  # pipenv activate
+  pipenv_activate="${pipenv_dir}/pipenv_${JUST_INSTALL_ACTIVATE_BASENAME}"
+  uwecho '#!/usr/bin/env bash
+          set -eu
+
+          # folder where this file resides
+          PIPENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
+          ' > "${pipenv_activate}"
+  uwecho "
+          # executable & version
+          PIPENV_EXE=\"\${PIPENV_DIR}/${pipenv_exe_footer}\"
+          PIPENV_VER=\"${pipenv_version}\"
+          " >> "${pipenv_activate}"
+  uwecho '
+          # update PATH
+          PATH="$(dirname "${PIPENV_EXE}"):${PATH}"
+          ' >> "${pipenv_activate}"
 }
 
 

--- a/tests/int/test-just_install_functions.bsh
+++ b/tests/int/test-just_install_functions.bsh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# Note all just_install_functions.bsh test are currently enabled only for windows.  Tests currently fail on most linux test images, as the installed tools often rely on glibc and a valid download utility (e.g., wget).
+
+if [ -z ${VSI_COMMON_DIR+set} ]; then
+  VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+fi
+
+source "${VSI_COMMON_DIR}/tests/testlib.bsh"
+source "${VSI_COMMON_DIR}/linux/just_files/just_install_functions.bsh"
+
+# test cmake install
+[ "${OS-}" = "Windows_NT" ] || skip_next_test
+begin_test "cmake-install"
+(
+  setup_test
+
+  # environment
+  export TMPDIR="${TESTDIR}" # redirect mktemp commands to $TESTDIR
+  export JUST_INSTALL_ACTIVATE_BASENAME="test_just_activate.bsh"
+
+  # version info
+  CMAKE_VER="3.18.2"
+  CMAKE_VER_FULL=$'cmake version 3.18.2\n\nCMake suite maintained and supported by Kitware (kitware.com/cmake).'
+
+  # install
+  cmake-install \
+      --dir "${TESTDIR}" \
+      --ver "${CMAKE_VER}"
+
+  # output version
+  [ "${cmake_version}" = "${CMAKE_VER}" ]
+
+  # executable version
+  RESULT="$("${cmake_exe}" --version)"
+  [ "$RESULT" = "${CMAKE_VER_FULL}" ]
+
+  # activate version
+  RESULT="$(source "${cmake_activate}"; "${CMAKE_EXE}" --version)"
+  [ "$RESULT" = "${CMAKE_VER_FULL}" ]
+
+)
+end_test
+
+
+# test conda-python-install & pipenv-install
+# test in sequence according to typical usage - install oython then pipenv
+[ "${OS-}" = "Windows_NT" ] || skip_next_test
+begin_test "conda-python-install and pipenv-install"
+(
+  setup_test
+
+  # environment
+  export TMPDIR="${TESTDIR}" # redirect mktemp commands to $TESTDIR
+  export JUST_INSTALL_ACTIVATE_BASENAME="test_just_activate.bsh"
+
+  # --python--
+
+  # version info
+  PYTHON_VER="3.7.9"
+  PYTHON_VER_FULL="Python 3.7.9"
+
+  # install
+  conda-python-install \
+      --dir "${TESTDIR}" \
+      --ver "${PYTHON_VER}" \
+      --download
+
+  # output version
+  [ "${python_version}" = "${PYTHON_VER}" ]
+
+  # executable version
+  RESULT="$("${python_exe}" --version 2>&1)"
+  [ "$RESULT" = "${PYTHON_VER_FULL}" ]
+
+  # activate version
+  RESULT="$(source "${python_activate}"; "${PYTHON_EXE}" --version 2>&1)"
+  [ "$RESULT" = "${PYTHON_VER_FULL}" ]
+
+  # --pipenv--
+
+  # activate python environment
+  source "${python_activate}"
+
+  # version info
+  PIPENV_VER="2020.6.2"
+  PIPENV_VER_FULL=$'pipenv, version 2020.6.2\r'
+
+  # install
+  pipenv-install \
+      --dir "${TESTDIR}" \
+      --ver "${PIPENV_VER}" \
+      --python "${python_exe}"
+
+  # validate outputs
+  [ "${pipenv_version}" = "${PIPENV_VER}" ]
+
+  # executable version
+  RESULT="$("${pipenv_exe}" --version)"
+  printf "RESULT\n%q\n" "${RESULT}"
+  [ "$RESULT" = "${PIPENV_VER_FULL}" ]
+
+  # activate version
+  RESULT="$(source "${pipenv_activate}"; "${PIPENV_EXE}" --version)"
+  [ "$RESULT" = "${PIPENV_VER_FULL}" ]
+
+)
+end_test

--- a/tests/int/test-just_install_functions.bsh
+++ b/tests/int/test-just_install_functions.bsh
@@ -44,7 +44,7 @@ end_test
 
 
 # test conda-python-install & pipenv-install
-# test in sequence according to typical usage - install oython then pipenv
+# test in sequence according to typical usage - install python then pipenv
 [ "${OS-}" = "Windows_NT" ] || skip_next_test
 begin_test "conda-python-install and pipenv-install"
 (

--- a/tests/int/test-just_install_functions.bsh
+++ b/tests/int/test-just_install_functions.bsh
@@ -26,7 +26,7 @@ begin_test "cmake-install"
   # install
   cmake-install \
       --dir "${TESTDIR}" \
-      --ver "${CMAKE_VER}"
+      --version "${CMAKE_VER}"
 
   # output version
   [ "${cmake_version}" = "${CMAKE_VER}" ]
@@ -63,7 +63,7 @@ begin_test "conda-python-install and pipenv-install"
   # install
   conda-python-install \
       --dir "${TESTDIR}" \
-      --ver "${PYTHON_VER}" \
+      --version "${PYTHON_VER}" \
       --download
 
   # output version
@@ -89,7 +89,7 @@ begin_test "conda-python-install and pipenv-install"
   # install
   pipenv-install \
       --dir "${TESTDIR}" \
-      --ver "${PIPENV_VER}" \
+      --version "${PIPENV_VER}" \
       --python "${python_exe}"
 
   # validate outputs

--- a/tests/int/test-just_install_functions.bsh
+++ b/tests/int/test-just_install_functions.bsh
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
 
-# Note all just_install_functions.bsh test are currently enabled only for windows.  Tests currently fail on most linux test images, as the installed tools often rely on glibc and a valid download utility (e.g., wget).
+#**
+# .. envvar:: VSI_FORCE_TEST_JUST_INSTALL_FUNCTIONS
+#
+# Force testing of functions in :file:`just_install_functions.bsh`.
+#
+#**
 
 if [ -z ${VSI_COMMON_DIR+set} ]; then
   VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
+source "${VSI_COMMON_DIR}/linux/common_source.sh"
 source "${VSI_COMMON_DIR}/linux/just_files/just_install_functions.bsh"
 
+
 # test cmake install
-[ "${OS-}" = "Windows_NT" ] || skip_next_test
+# alpine musl won't run the cmake executable
+[ "${VSI_OS}" = "linux" ] && [ "${VSI_MUSL}" = "1" ] && [ -z "${VSI_FORCE_TEST_JUST_INSTALL_FUNCTIONS+set}" ] && skip_next_test
 begin_test "cmake-install"
 (
   setup_test
@@ -43,9 +51,9 @@ begin_test "cmake-install"
 end_test
 
 
-# test conda-python-install & pipenv-install
-# test in sequence according to typical usage - install python then pipenv
-[ "${OS-}" = "Windows_NT" ] || skip_next_test
+# test conda-python-install & pipenv-install: test in sequence according to typical usage - install python then pipenv
+# alpine musl won't run the miniconda executable
+[ "${VSI_OS}" = "linux" ] && [ "${VSI_MUSL}" = "1" ] && [ -z "${VSI_FORCE_INSTALL_FUNCTIONS_TEST+set}" ] && skip_next_test
 begin_test "conda-python-install and pipenv-install"
 (
   setup_test
@@ -58,7 +66,7 @@ begin_test "conda-python-install and pipenv-install"
 
   # version info
   PYTHON_VER="3.7.9"
-  PYTHON_VER_FULL="Python 3.7.9"
+  PYTHON_VER_FULL="Python ${PYTHON_VER}"
 
   # install
   conda-python-install \
@@ -84,7 +92,7 @@ begin_test "conda-python-install and pipenv-install"
 
   # version info
   PIPENV_VER="2020.6.2"
-  PIPENV_VER_FULL=$'pipenv, version 2020.6.2\r'
+  PIPENV_VER_FULL="pipenv, version ${PIPENV_VER}"
 
   # install
   pipenv-install \
@@ -96,12 +104,11 @@ begin_test "conda-python-install and pipenv-install"
   [ "${pipenv_version}" = "${PIPENV_VER}" ]
 
   # executable version
-  RESULT="$("${pipenv_exe}" --version)"
-  printf "RESULT\n%q\n" "${RESULT}"
+  RESULT="$("${pipenv_exe}" --version | sed 's|$\r||g')"
   [ "$RESULT" = "${PIPENV_VER_FULL}" ]
 
   # activate version
-  RESULT="$(source "${pipenv_activate}"; "${PIPENV_EXE}" --version)"
+  RESULT="$(source "${pipenv_activate}"; "${PIPENV_EXE}" --version | sed 's|$\r||g')"
   [ "$RESULT" = "${PIPENV_VER_FULL}" ]
 
 )


### PR DESCRIPTION
New just targets for `just_install_functions` to create isolated sandbox installations of python (installed via conda), pipenv (installed via `30_get-pipenv` an isolated virtualenv), and cmake.  Intended use is to create isolated environments (primarily for windows) that do not conflict with system-level programs.