### PR TITLE
disable circleci for windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ workflows:
   vsi_common:
     jobs:
       - run_bash_and_os_tests
-      - run_windows_test
+      # - run_windows_test  # limited availability for open-source projects
       - compile_docs
       - deploy_docs:
           requires:


### PR DESCRIPTION
Disable windows CircleCI build, as there is limited availability for open-source builds at this time.