### PR TITLE
appveyor environment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ image:
 environment:
   matrix:
   - MSYSTEM: MINGW64
-    PATH: C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%
   JUST_IS_TTY: 1
 
 # clone_script:
@@ -27,17 +26,26 @@ environment:
 # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 install:
-  # This goes here https://www.appveyor.com/docs/how-to/private-git-sub-modules/
+  # Submodules are added in install
+  # see https://www.appveyor.com/docs/how-to/private-git-sub-modules/
   - git submodule update --init --recursive
+
+  # Fix for https://github.com/msys2/MSYS2-packages/issues/1967
+  # https://www.msys2.org/news/#2020-05-31-update-fails-with-could-not-open-file
   - C:\msys64\usr\bin\bash -lc "cd /tmp; curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U --config <(echo) /tmp/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy"
-  # Fix for https://github.com/msys2/MSYS2-packages/issues/1967
-  # https://www.msys2.org/news/#2020-05-31-update-fails-with-could-not-open-file
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sydd pacman"
-  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S git"
-  - C:\msys64\usr\bin\bash -lc "cat ~/.bashrc ~/.bash_profile"
+
+  # additional packages for test
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S unzip"
+
+  # debugging outputs
+  - C:\msys64\usr\bin\bash -lc "cat ~/.bashrc"
+  - C:\msys64\usr\bin\bash -lc "cat ~/.bash_profile"
+  - C:\msys64\usr\bin\bash -lc "echo $PATH"
+
   # - '"C:\Program Files\Docker\Docker\DockerCli.exe" -SwitchLinuxEngine'
   # - docker-switch-linux # Suggested way to do the exact same command above
 


### PR DESCRIPTION
appveyor has not run `just test int git_mirror` as unzip was not installed.  After installing unzip, additional environment modifications are necessary to successfully run the test.

- remove extra git install (git & git-lfs already available)
- remove extra path modification (`MSYSTEM: MINGW64` already modifies path)

