### PR TITLE
just_install_functions update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ before_install:
 script:
   - source setup.env && just test
   - just test int git_mirror
+  - just test int just_install_functions

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -159,7 +159,7 @@ function cmake-install()
 #             * [``--conda {CONDA}``] - Conda executable
 #             * [``--conda-installer {INSTALLER}``] - Conda installer
 #             * [``--download``] - Download miniconda
-#             * [``--package``] - An additional package to be installed, may be called multiple times
+#             * [``--package {package}``] - An additional package to be installed, may be called multiple times
 #
 # :Output: * python_exe - Python executable
 #          * python_version - Python version

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -159,6 +159,7 @@ function cmake-install()
 #             * [``--conda {CONDA}``] - Conda executable
 #             * [``--conda-installer {INSTALLER}``] - Conda installer
 #             * [``--download``] - Download miniconda
+#             * [``--package``] - An additional package to be installed, may be called multiple times
 #
 # :Output: * python_exe - Python executable
 #          * python_version - Python version
@@ -174,6 +175,7 @@ function conda-python-install()
   local CONDA  # conda executable
   local CONDA_INSTALLER  # conda installer
   local prefer_download=0  # prefer conda download if no CONDA|CONDA_INSTALLER
+  local packages=()
 
   parse_args conda_python_extra_args \
       --dir install_dir: \
@@ -181,6 +183,7 @@ function conda-python-install()
       --conda CONDA: \
       --conda-installer CONDA_INSTALLER: \
       --download prefer_download \
+      --package +packages: \
       -- ${@+"${@}"}
 
   # directory check
@@ -259,7 +262,7 @@ function conda-python-install()
 
   # install python
   echo "Installing python..." >&2
-  "${CONDA}" create -y -p "${python_dir}" "python==${python_ver}"
+  "${CONDA}" create -y -p "${python_dir}" "python==${python_ver}" "${packages[@]}"
   local python_exe_footer
   if [ "${OS-}" = "Windows_NT" ]; then
     python_exe_footer="python.exe"
@@ -277,10 +280,6 @@ function conda-python-install()
   python_exe="${PYTHON}"
   python_version="$("${python_exe}" --version 2>&1 | awk '{print $2}')"
   echo "Python ${python_version} installed at \"${python_exe}\"" >&2
-
-  if [ -n "${python_activate-}" ]; then
-    echo "Activate python environment via <source \"${python_activate}\"" >&2
-  fi
 
   # Make sure python meets request
   if ! meet_requirements "${python_version}" "==${python_ver}"; then
@@ -340,6 +339,7 @@ function conda-python-install()
 # :Arguments: * [``--dir {dir}``] - Pipenv install directory
 #             * [``--version {version}``] - Pipenv version for install (default=``${PIPENV_VERSION:-2020.8.13}``)
 #             * [``--python {PYTHON}``] - Python executable (default=(python3|python|python2))
+#             * [``--python-activate {script}``] - Optional python activation script, for example as created by :func:`conda-python-install`
 #
 # :Output: * pipenv_exe - Pipenv executable
 #          * pipenv_version - Pipenv version
@@ -353,11 +353,13 @@ function pipenv-install()
   local install_dir  # install directory
   local pipenv_ver="${PIPENV_VERSION:-2020.8.13}"  # pipenv version
   local PYTHON  # python executable
+  local python_activate
 
   parse_args pipenv_extra_args \
       --dir install_dir: \
       --version pipenv_ver: \
       --python PYTHON: \
+      --python-activate python_activate: \
       -- ${@+"${@}"}
 
   # check for pipenv directory
@@ -375,6 +377,13 @@ function pipenv-install()
     return 1
   fi
 
+  # optional python_activate script
+  if [ -n "${python_activate-}" ] && [ ! -f "${python_activate}" ]; then
+    echo "Pipenv install cannot find \"${python_activate}\"" >&2
+    local JUST_IGNORE_EXIT_CODES=1
+    return 1
+  fi
+
   # create pipenv directory
   pipenv_dir="${install_dir}/pipenv-${pipenv_ver}"
   mkdir -p "${pipenv_dir}"
@@ -384,8 +393,7 @@ function pipenv-install()
   # run in subshell, as sourced files are only needed temporarily
   (
     # "activate" python if created via the "conda-python-install" function
-    local python_activate="$(dirname "${PYTHON}")/python_${JUST_INSTALL_ACTIVATE_BASENAME}"
-    [ -f "${python_activate}" ] && source "${python_activate}"
+    [ -n "${python_activate-}" ] && source "${python_activate}"
 
     # install via 30_get-pipenv
     echo "Installing pipenv..." >&2

--- a/tests/int/test-just_install_functions.bsh
+++ b/tests/int/test-just_install_functions.bsh
@@ -23,8 +23,10 @@ begin_test "cmake-install"
 (
   setup_test
 
+  # redirect mktemp commands to $TESTDIR (does not work on macs)
+  [ "${VSI_OS}" != "darwin" ] && export TMPDIR="${TESTDIR}"
+
   # environment
-  export TMPDIR="${TESTDIR}" # redirect mktemp commands to $TESTDIR
   export JUST_INSTALL_ACTIVATE_BASENAME="test_just_activate.bsh"
 
   # version info
@@ -58,8 +60,10 @@ begin_test "conda-python-install and pipenv-install"
 (
   setup_test
 
+  # redirect mktemp commands to $TESTDIR (does not work on macs)
+  [ "${VSI_OS}" != "darwin" ] && export TMPDIR="${TESTDIR}"
+
   # environment
-  export TMPDIR="${TESTDIR}" # redirect mktemp commands to $TESTDIR
   export JUST_INSTALL_ACTIVATE_BASENAME="test_just_activate.bsh"
 
   # --python--

--- a/tests/int/test-just_install_functions.bsh
+++ b/tests/int/test-just_install_functions.bsh
@@ -87,9 +87,6 @@ begin_test "conda-python-install and pipenv-install"
 
   # --pipenv--
 
-  # activate python environment
-  source "${python_activate}"
-
   # version info
   PIPENV_VER="2020.6.2"
   PIPENV_VER_FULL="pipenv, version ${PIPENV_VER}"
@@ -98,7 +95,8 @@ begin_test "conda-python-install and pipenv-install"
   pipenv-install \
       --dir "${TESTDIR}" \
       --version "${PIPENV_VER}" \
-      --python "${python_exe}"
+      --python "${python_exe}" \
+      --python-activate "${python_activate}"
 
   # validate outputs
   [ "${pipenv_version}" = "${PIPENV_VER}" ]

--- a/tests/int/test-just_install_functions.bsh
+++ b/tests/int/test-just_install_functions.bsh
@@ -23,7 +23,7 @@ begin_test "cmake-install"
 (
   setup_test
 
-  # redirect mktemp commands to $TESTDIR (does not work on macs)
+  # redirect mktemp commands to $TESTDIR (does not work on a mac)
   [ "${VSI_OS}" != "darwin" ] && export TMPDIR="${TESTDIR}"
 
   # environment
@@ -60,7 +60,7 @@ begin_test "conda-python-install and pipenv-install"
 (
   setup_test
 
-  # redirect mktemp commands to $TESTDIR (does not work on macs)
+  # redirect mktemp commands to $TESTDIR (does not work on a mac)
   [ "${VSI_OS}" != "darwin" ] && export TMPDIR="${TESTDIR}"
 
   # environment


### PR DESCRIPTION
Minor updates to `just_install_functions`
- `conda-python-install` optional input for additional packages
- `pipenv-install` optional input for python activation script
- Activate travis test for mac
- update test for travis & new build pattern