### PR TITLE
Fix `sed_flag_i`

### DIFF
--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -72,7 +72,7 @@ function load_vsi_compat()
   fi
 
   #**
-  # .. variable:: sed_flag_rE
+  # .. var:: sed_flag_rE
   #
   # Flag to enable extended regex support in sed. The GNU flag is ``-r``, while the BSD flag is ``-E``. macOS does not support ``-r`` and GNU sed prior to 4.2 does not accept ``-E``. Using this variable should always yield the correct flag.
   #
@@ -95,7 +95,7 @@ function load_vsi_compat()
   fi
 
   #**
-  # .. variable:: sed_flag_i
+  # .. var:: sed_flag_i
   #
   # When using inplace replacement on sed, the macOS version requires an argument to the ``-i`` flag, the extension added to the output file. The GNU version does not support this. Using this flag will perform an inplace replacement with no added extension. The :var:`sed_flag_i` must come last when combined with other flags (see example below).
   #
@@ -131,7 +131,7 @@ function load_vsi_compat()
   #
   # The following variables will help cope with the difference in the ``date`` command as seamlessly as possible.
   #
-  # .. variable:: date_feature_nanoseconds
+  # .. var:: date_feature_nanoseconds
   #
   # Non-GNU versions of ``date`` do not support the nanosecond sequence for a date format (e.g. BSD and busybox).
   #
@@ -150,21 +150,21 @@ function load_vsi_compat()
   #
   # The following variables will help cope with the difference in bash versions as seamlessly as possible.
   #
-  # .. variable:: bash_behavior_declare_array_quote
+  # .. var:: bash_behavior_declare_array_quote
   #
   # In bash version 4.3 and older, ``declare -p`` of an array adds an extra ``'`` around the array. This variable stores the state of that variable
   #
   # :Value: * **(null)** - Bash 4.4 or newer
   #         * ``'`` - Bash 4.3 or older
   #
-  # .. variable:: bash_feature_parameter_transformation
+  # .. var:: bash_feature_parameter_transformation
   #
   # Does bash support Parameter Transformations, e.g. ``${var@a}``
   #
   # :Value: * ``0`` - Bash does support parameter transformations (Bash 4.4 or newer)
   #         * ``1`` - Bash does not support parameter transformations
   #
-  # .. variable:: bash_feature_declare_array_escape_special_characters
+  # .. var:: bash_feature_declare_array_escape_special_characters
   #
   # Starting in bash 4.4, ``declare -p`` of an array, will escape special characters such as tab (``\t``) and newline (``\n``)
   #
@@ -189,21 +189,21 @@ function load_vsi_compat()
   fi
 
   #**
-  # .. variable:: bash_feature_declare_name_reffing
+  # .. var:: bash_feature_declare_name_reffing
   #
   # Do bash variables support name reffing
   #
   # :Value: * ``0`` - Bash does support name reffing (Bash 4.3 or newer)
   #         * ``1`` - Bash does not support name reffing
   #
-  # .. variable:: bash_feature_declare_print_function
+  # .. var:: bash_feature_declare_print_function
   #
   # Does ``declare`` support printing a function via ``declare -pf function_name``. Work around include: ``declare -F`` to list all functions and ``type function_name``, however the first line needs to be removed.
   #
   # :Value: * ``0`` - ``declare`` supports printing a function
   #         * ``1`` - ``declare`` does not support printing a specific function.
   #
-  # .. variable:: bash_bug_local_shadow_exported_variable
+  # .. var:: bash_bug_local_shadow_exported_variable
   #
   # In bash 4.2 and older, a local variable can shadow an exported variable, obscuring it from children processes. This is a confusing behavior that has to occasionally be corrected.
   #
@@ -240,7 +240,7 @@ function load_vsi_compat()
   fi
 
   # TODO: Cannot reliable replicate this, table for now
-  # .. variable:: bash_behavior_strict_posix_functions
+  # .. var:: bash_behavior_strict_posix_functions
   # Bash 4.2 and older is stricter when it comes to exported functions that are not POSIX compliant, when running with the ``--posix`` flag. Workaround, unexport functions that would cause an issue.
   # # My notes say 4.2, by unit tests say 5.1?!
   # if [ "${bash_minor_version}" -ge "51" ]; then
@@ -250,7 +250,7 @@ function load_vsi_compat()
   # fi
 
   #**
-  # .. variable:: bash_feature_declare_global
+  # .. var:: bash_feature_declare_global
   #
   # Does bash support declaring global variables with the ``declare`` command.
   #
@@ -266,14 +266,14 @@ function load_vsi_compat()
   fi
 
   #**
-  # .. variable:: bash_feature_printf_array_assignment
+  # .. var:: bash_feature_printf_array_assignment
   #
   # Does ``printf -v`` support storing to array variables
   #
   # :Value: * ``0`` - ``printf`` does support storing to arrays (Bash 4.1 or newer)
   #         * ``1`` - ``printf`` only supports storing to non-array variables
   #
-  # .. variable:: bash_feature_allocate_file_descriptor
+  # .. var:: bash_feature_allocate_file_descriptor
   #
   # Does ``exec {varname}>&1`` work.
   #
@@ -292,21 +292,21 @@ function load_vsi_compat()
   fi
 
   #**
-  # .. variable:: bash_feature_associative_array
+  # .. var:: bash_feature_associative_array
   #
   # Does bash have associative arrays
   #
   # :Value: * ``0`` Bash does have associative arrays (4.0 or newer)
   #         * ``1`` Bash does not have associative arrays (3.2)
   #
-  # .. variable:: bash_feature_bashpid
+  # .. var:: bash_feature_bashpid
   #
   # Does bash have a ``BASHPID`` variable. This is more accurate than ``$$`` when it comes to subshells.
   #
   # :Value: * ``0`` Bash sets ``BASHPID``
   #         * ``1`` Only ``$$`` is set, see :func:`signal_tools.bash set_bashpid`
   #
-  # .. variable:: bash_feature_case_modification
+  # .. var:: bash_feature_case_modification
   #
   # Does bash support ``${x^}/${x^^}/${x,}/${x,,}`` parameter substitution
   #
@@ -316,7 +316,7 @@ function load_vsi_compat()
   # .. seealso::
   #    :func:`string_tools.bsh lowercase`, :func:`string_tools.bsh uppercase`
   #
-  # .. variable:: bash_bug_unassigned_variable_set_to_null
+  # .. var:: bash_bug_unassigned_variable_set_to_null
   #
   # There is a bug, fixed in bash 4.0, that causes an unassigned variable to be set to null
   #
@@ -401,7 +401,7 @@ function load_vsi_compat()
   IFS="" __bash_bug_at_expansion_null_ifs bash bug
 
   #**
-  # .. variable:: bash_feature_bashpid_read_only
+  # .. var:: bash_feature_bashpid_read_only
   #
   # The ``BASHPID`` variable is only only protected as read only in bash 4. Bash 5 releases this restriction (but does not release the restriction for any other read only variable)
   #
@@ -415,7 +415,7 @@ function load_vsi_compat()
   fi
 
   #**
-  # .. variable:: bash_behavior_regex_special_characters_non_literal
+  # .. var:: bash_behavior_regex_special_characters_non_literal
   #
   # Most instances of bash require special characters to be literal in regular expressions (e.g. ``$'\n'``). However, on operating systems such as alpine, a special character will be matched based in its non-literal form (e.g. ``"\n"``). This has nothing to do with the version of bash, but rather how it was compiled (regex might come from g++'s implementation).
   #
@@ -433,7 +433,7 @@ function load_vsi_compat()
   fi
 
   #**
-  # .. variable:: bash_bug_regex_null_string
+  # .. var:: bash_bug_regex_null_string
   #
   # Most instances of bash allow a null string to be a valid regular expression, basically any string matches. However, on operating systems such as macOS, it fails to compile the regular expression, and does not match correctly, giving the opposite answer as all other operating systems. This has nothing to do with the version of bash, but rather how it was compiled (regex might come from g++'s implementation).
   #
@@ -449,21 +449,21 @@ function load_vsi_compat()
   fi
 
   #**
-  # .. variable:: bash_bug_declare_fails_local_declared_unset_variable
+  # .. var:: bash_bug_declare_fails_local_declared_unset_variable
   #
   # Bash 4.3 has a bug where ``declare -p var`` fails if a local variable is declared, but unset. The workaround is to find the variable in ``declare -p``
   #
   # :Value: * ``0`` - Has declare fails bug
   #         * ``1`` - Does not have the declare fails bug
   #
-  # .. variable:: bash_bug_declare_fails_global_declared_unset_variable
+  # .. var:: bash_bug_declare_fails_global_declared_unset_variable
   #
   # Bash 4.0 to 4.3 has a bug where ``declare -p var`` fails if a global variable is declared, but has no set value. The workaround is to find the variable in ``declare -p``
   #
   # :Value: * ``0`` - Has declare fails bug
   #         * ``1`` - Does not have the declare fails bug
   #
-  # .. variable:: bash_bug_declared_unset_value
+  # .. var:: bash_bug_declared_unset_value
   #
   # Bash 3.2 through 4.1 has a confusing behavior where unset declared variables appear to be set to null ``""`` instead of unset, in the output of ``declare -p``. However these versions of bash do indeed have an "unset but declared state", it just can't be queried using the output of ``declare -p``.
   #
@@ -531,7 +531,7 @@ function load_vsi_compat()
   fi
 
   #**
-  # .. variable:: bash_bug_substitute_empty_funcname
+  # .. var:: bash_bug_substitute_empty_funcname
   #
   # ``FUNCNAME`` is the only builtin array in bash that is likely to be declared but unset (when stack depth is zero). In bash 4.3 and 4.4, there is a bug where an using parameter expansion on ``FUNCNAME`` when unset will incorrectly expand (e.g. ``${FUNCNAME[@]+example}``). This could be due to funcname not really being empty in global scope, but just doesn't show up as populated until in its first function scope
   #
@@ -546,7 +546,7 @@ function load_vsi_compat()
   fi
 
   #**
-  # .. variable:: bash_bug_ifs_array_slice_expansion
+  # .. var:: bash_bug_ifs_array_slice_expansion
   #
   # In some versions of bash (3.2 is the only known version), ``@`` expanding an array and slicing it when IFS is not space will fail to expand into multiple arguments.
   #

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -95,9 +95,9 @@ function load_vsi_compat()
   fi
 
   #**
-  # .. var:: sed_flag_i
+  # .. var:: sed_flags_i
   #
-  # When using inplace replacement on sed, the macOS version requires an argument to the ``-i`` flag, the extension added to the output file. The GNU version does not support this. Using this flag will perform an inplace replacement with no added extension. The :var:`sed_flag_i` must come last when combined with other flags (see example below).
+  # When using inplace replacement on sed, the macOS version requires an argument to the ``-i`` flag, the extension added to the output file. The GNU version does not support this. Using this flag will perform an inplace replacement with no added extension. The :var:`sed_flags_i` cannot be combined with other flags (see example below).
   #
   # .. note::
   #
@@ -107,22 +107,23 @@ function load_vsi_compat()
   #
   # .. code-block:: bash
   #
-  #   sed -${sed_flag_i} 's|foo|bar|' some_file.txt
-  #   # You cannot put quotes around sed_flag_i, or else it will not work on macOS
+  #   sed "${sed_flags_i[@]}" 's|foo|bar|' some_file.txt
   #
   #   # Not ok
-  #   sed -${sed_flag_i}n ...
+  #   sed "${sed_flags_i}" ...
+  #   # Not ok
+  #   sed -"${sed_flags_i[@]}" ...
+  #   # Not ok
+  #   sed "${sed_flags_i[@]}"n ...
   #   # This is ok
-  #   sed -n${sed_flag_i} ...
-  #   # Also ok
-  #   sed -${sed_flag_i} -n ...
+  #   sed "${sed_flags_i[@]}" -n ...
   #**
 
   # Handle macOS BSD version
   if [[ ${OSTYPE-} = darwin* ]]; then
-    sed_flag_i="i ''"
+    sed_flags_i=('-i' '')
   else
-    sed_flag_i='i'
+    sed_flags_i=('-i')
   fi
 
   #**

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -580,29 +580,29 @@ function load_vsi_compat()
   # The following variables will help cope with the difference in git versions as seamlessly as possible.
   #
   #**
-  # .. function:: git_bug_submodule_path_with_tab
+  # .. function:: git_bug_submodule_path_with_special_characters
   #
-  # There is a bug in git, fixed in git 1.8.3.3, that caused many ``git submodule`` operations not to work on a submodule at a path whose name contains a tab (and presumably other characters).
+  # There is a bug in git, fixed in git 1.8.3.3, that caused many ``git submodule`` operations not to work on a submodule at a path whose name contains a tab or " (double quote) (and presumably other characters).
   #
-  # :Return Value: * ``0`` - ``git`` does not support submodule paths containing a tab
+  # :Return Value: * ``0`` - ``git`` does not support submodule paths containing special characters
   #                * ``1`` - ``git`` works as expected
   #**
-  function git_bug_submodule_path_with_tab()
+  function git_bug_submodule_path_with_special_characters()
   {
-    if [ -z "${__git_bug_submodule_path_with_tab+set}" ]; then
+    if [ -z "${__git_bug_submodule_path_with_special_characters+set}" ]; then
       if [ "${OS-}" = "Windows_NT" ]; then
-        __git_bug_submodule_path_with_tab=0
+        __git_bug_submodule_path_with_special_characters=0
       else
         source "${VSI_COMMON_DIR}/linux/requirements.bsh"
         if meet_requirements "$(git_version)" ">=1.8.3.3"; then
-          __git_bug_submodule_path_with_tab=1
+          __git_bug_submodule_path_with_special_characters=1
         else
-          __git_bug_submodule_path_with_tab=0
+          __git_bug_submodule_path_with_special_characters=0
         fi
       fi
     fi
 
-    return "${__git_bug_submodule_path_with_tab}"
+    return "${__git_bug_submodule_path_with_special_characters}"
   }
 
   #**

--- a/linux/just_files/just_makeself_functions.bsh
+++ b/linux/just_files/just_makeself_functions.bsh
@@ -246,7 +246,7 @@ function makeself_defaultify()
     #         "${PROJECT_CWD}/build/makeself/makeself-header.sh" > "${PROJECT_CWD}/build/makeself/makeself-header_just.sh"
 
     #     # Add sourcing local.env to the header, to cover corner cases like needing to to change TMPDIR
-    #     sed -${sed_flag_i} '2r /dev/stdin' "${PROJECT_CWD}/build/makeself/makeself-header_just.sh" < \
+    #     sed "${sed_flags_i[@]}" '2r /dev/stdin' "${PROJECT_CWD}/build/makeself/makeself-header_just.sh" < \
     #       <(echo 'for check_dir in "\`dirname \$0\`" "\${PWD}"; do'
     #         echo '  if test -f "\${check_dir}/local.env"; then'
     #         echo '    set -a'

--- a/tests/int/test-compat.bsh
+++ b/tests/int/test-compat.bsh
@@ -16,6 +16,17 @@ function setup()
   export GIT_AUTHOR_EMAIL='foo.bar@example.com'
 }
 
+begin_test "Test sed_flag_i"
+(
+  setup_test
+
+  echo "foo" > "${TESTDIR}/file"
+  sed "${sed_flags_i[@]}" -e 's|foo|bar|' "${TESTDIR}/file"
+  [ "$(cat "${TESTDIR}/file")" = "bar" ]
+  [ "$(ls "${TESTDIR}" | grep "file")" = "file" ]
+)
+end_test
+
 command -v "${GIT-git}" &> /dev/null || skip_next_test
 git_feature_support_tls && tls=0 || tls=$?
 [ ${tls} -ge 2 ] && [ ${tls} -ne 125 ] || skip_next_test
@@ -37,13 +48,13 @@ function begin_submodule_path_test()
 }
 
 command -v "${GIT-git}" &> /dev/null || skip_next_test
-begin_submodule_path_test "non-ASCII submodule path"
+begin_submodule_path_test "Test difficult git submodule path"
 (
   setup_test
 
-  GIT_TEST_REPO="${TRASHDIR}/test"
-  SUBMODULE_REPO="${TRASHDIR}/difficult"
-  SUBMODULE_URL="${TRASHDIR}/git/difficult.git"
+  GIT_TEST_REPO="${TESTDIR}/test"
+  SUBMODULE_REPO="${TESTDIR}/difficult"
+  SUBMODULE_URL="${TESTDIR}/git/difficult.git"
   DIFFICULT_PATH=$'diff  i \t cult'
 
   # Sub module

--- a/tests/int/test-compat.bsh
+++ b/tests/int/test-compat.bsh
@@ -29,7 +29,7 @@ end_test
 
 function begin_submodule_path_test()
 {
-  if git_bug_submodule_path_with_tab; then
+  if git_bug_submodule_path_with_special_characters; then
     begin_required_fail_test "${@}"
   else
     begin_test "${@}"

--- a/tests/int/test-git_mirror.bsh
+++ b/tests/int/test-git_mirror.bsh
@@ -426,7 +426,7 @@ begin_archive_test "Archive"
     # The archives are only datetime stamped out to seconds
     # Rename file to just some point in the past
     ORIG_PREP_FILE=("${PREP_FILE[@]}")
-    PREP_FILE=("$(dirname ${PREP_FILE[0]})/transfer_2020_09_23_20_40_58.snar")
+    PREP_FILE=("$(dirname ${PREP_FILE[0]})/transfer_2020_09_23_20_40_58.tgz")
     mv "${ORIG_PREP_FILE[0]}" "${PREP_FILE[0]}"
     mv "${ORIG_PREP_FILE[0]%.tgz}.snar" "${PREP_FILE[0]%.tgz}.snar"
 
@@ -443,7 +443,6 @@ begin_archive_test "Archive"
     rm "${last_snar_file}" "${last_snar_file%.snar}.tgz" \
         "${INCREMENTAL_PREP_FILE}" "${PREP_FILE[0]%.tgz}.l1.snar"
 
-    sleep 2 # the archives are only datetime stamped out to seconds
     archive_mirrors "${ARCHIVE_DIR}"
 
     INCREMENTAL_PREP_FILE="$(shopt -s nullglob; echo "${ARCHIVE_DIR}"/transfer_*_transfer_*.tgz)"

--- a/tests/int/test-git_mirror.bsh
+++ b/tests/int/test-git_mirror.bsh
@@ -31,7 +31,7 @@ function setup()
   PRETEND_URL="${TRASHDIR}/pretend_repo" # bare repo
 
   # Test if git supports difficult submodule paths
-  if git_bug_submodule_path_with_tab; then
+  if git_bug_submodule_path_with_special_characters; then
     DIFFICULT_NAME='diff  i cult'
   else
     DIFFICULT_NAME=$'diff  i \t cult'

--- a/tests/int/test-just_git_airgap_repo.bsh
+++ b/tests/int/test-just_git_airgap_repo.bsh
@@ -273,7 +273,7 @@ begin_test "Check for unpushed tracked commits in submodules"
   BUILD_REPO="${TESTDIR}"/build_repo
   PRETEND_URL="${TESTDIR}/git/pretend_repo" # bare repo
   # Test if git supports difficult submodule paths
-  if git_bug_submodule_path_with_tab; then
+  if git_bug_submodule_path_with_special_characters; then
     DIFFICULT_PATH='ext/diff  i cult'
   else
     DIFFICULT_PATH=$'ext/diff  i \t cult'
@@ -811,7 +811,7 @@ begin_test "Make remote pushable"
   BUILD_REPO="${TESTDIR}"/build_repo
   PRETEND_URL="${TESTDIR}/git/pretend_repo" # bare repo
   # Test if git supports difficult submodule paths
-  if git_bug_submodule_path_with_tab; then
+  if git_bug_submodule_path_with_special_characters; then
     DIFFICULT_PATH='diff  i cult'
   else
     DIFFICULT_PATH=$'diff  i \t cult'

--- a/tests/int/test-just_git_airgap_repo.bsh
+++ b/tests/int/test-just_git_airgap_repo.bsh
@@ -149,7 +149,8 @@ begin_test "Part 4 - Pushing to mirror"
   pushd "${TRANSFER_DIR}" &> /dev/null
     source setup.env # Sets VSI_COMMON_DIR to "${TRANSFER_DIR}"/.vsi_common
     source "${VSI_COMMON_DIR}/linux/just_git_airgap_repo.bsh"
-    sed -${sed_flag_i} -e 's|^JUST_GIT_AIRGAP_MIRROR_URL=$|JUST_GIT_AIRGAP_MIRROR_URL="'"${AIRGAP_MIRROR_DIR}"'"|' repo_map.env
+    sed "${sed_flags_i[@]}" -e \
+        's|^JUST_GIT_AIRGAP_MIRROR_URL=$|JUST_GIT_AIRGAP_MIRROR_URL="'"${AIRGAP_MIRROR_DIR}"'"|' repo_map.env
     JUST_USER_CWD="${PWD}" relocate_git_defaultify git_import-repo
   popd &> /dev/null
 )
@@ -240,7 +241,8 @@ begin_test "Part 6 - Incremental update"
   (
     source setup.env # Sets VSI_COMMON_DIR to "${TRANSFER_DIR}"/.vsi_common
     source "${VSI_COMMON_DIR}/linux/just_git_airgap_repo.bsh"
-    sed -${sed_flag_i} -e 's|^JUST_GIT_AIRGAP_MIRROR_URL=$|JUST_GIT_AIRGAP_MIRROR_URL="'"${AIRGAP_MIRROR_DIR}"'"|' repo_map.env
+    sed "${sed_flags_i[@]}" -e \
+        's|^JUST_GIT_AIRGAP_MIRROR_URL=$|JUST_GIT_AIRGAP_MIRROR_URL="'"${AIRGAP_MIRROR_DIR}"'"|' repo_map.env
     JUST_USER_CWD="${PWD}" relocate_git_defaultify git_import-repo
   )
   popd &> /dev/null

--- a/tests/int/test-new_just.bsh
+++ b/tests/int/test-new_just.bsh
@@ -30,7 +30,7 @@ function setup()
   fi
 
   # Cache results
-  git_bug_submodule_path_with_tab || :
+  git_bug_submodule_path_with_special_characters || :
 }
 
 function teardown()
@@ -263,7 +263,7 @@ begin_test "New just instructions test (git)"
 (
   setup_test
 
-  if git_bug_submodule_path_with_tab; then
+  if git_bug_submodule_path_with_special_characters; then
     # git submodule add on windows won't handle "??? This works on cmd, but not bash.
     # MSYS2_ARG_CONV_EXCL=* did not fix it, therefore it is not a path mangling issue
     # Also an issue in older git for submodules
@@ -322,7 +322,7 @@ begin_test "New just docker test"
 (
   setup_test
 
-  if git_bug_submodule_path_with_tab; then
+  if git_bug_submodule_path_with_special_characters; then
     # Windows does not allow " in filenames, and old git doesn't allow it in
     # submodules
     tough_name=""

--- a/tests/test-compat.bsh
+++ b/tests/test-compat.bsh
@@ -15,12 +15,12 @@ begin_test "Sed flag"
   unset sed VSI_SED_COMPAT
   OSTYPE=darwin14 load_vsi_compat
   [ "${sed_flag_rE}" = "E" ]
-  [ "${sed_flag_i}" = "i ''" ]
+  assert_array_values sed_flags_i -i ''
   unset OSTYPE
 
   OS=Windows_NT load_vsi_compat
   [ "${sed_flag_rE}" = "r" ]
-  [ "${sed_flag_i}" = "i" ]
+  assert_array_values sed_flags_i -i
   unset OS
 
   function sed()
@@ -44,12 +44,12 @@ begin_test "Sed flag"
   VSI_SED_COMPAT=gnu
   load_vsi_compat
   [ "${sed_flag_rE}" = "r" ]
-  [ "${sed_flag_i}" = "i" ]
+  assert_array_values sed_flags_i -i
 
   VSI_SED_COMPAT=bsd
   load_vsi_compat
   [ "${sed_flag_rE}" = "E" ]
-  [ "${sed_flag_i}" = "i" ]
+  assert_array_values sed_flags_i -i
 )
 end_test
 


### PR DESCRIPTION
`sed_flag_i` wasn't working on macOS. We had to change it to an array. It is now called `sed_flags_i` to highlight that it must be used as an array