### PR TITLE
Create smaller incremental archives

### DIFF
--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -644,6 +644,41 @@ function load_vsi_compat()
 
     return "${__git_feature_support_tls}"
   }
+
+  #**
+  # Tar
+  # ===
+  #
+  # The following variables will help cope with the difference in tar versions as seamlessly as possible.
+  #
+  #**
+  # .. function:: tar_feature_incremental_backup
+  #
+  # BSD versions of ``tar`` do not support incremental backups.
+  #
+  # :Return Value: * ``0`` - ``tar`` supports incremental backups
+  #                * ``1`` - ``tar`` does not support incremental backups
+  #**
+  function tar_feature_incremental_backup()
+  {
+    if [ -z "${__tar_feature_incremental_backup+set}" ]; then
+      if [ "${OS-}" = "Windows_NT" ]; then
+        __tar_feature_incremental_backup=0
+      else
+        # Test if tar supports incremental backups
+        source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
+        local temp_file
+        make_temp_path temp_file
+        if ${TAR-tar} -cf /dev/null -g "${temp_file}" /dev/null &> /dev/null; then
+          __tar_feature_incremental_backup=0
+        else
+          __tar_feature_incremental_backup=1
+        fi
+      fi
+    fi
+
+    return "${__tar_feature_incremental_backup}"
+  }
 }
 
 # The purpose of this file is to set all these flag. Make it a function to help

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -219,7 +219,8 @@ function clone_submodules()
   # Update submodule urls to use GIT_MIRROR_PREP_DIR
   for submodule in ${submodule_names[@]+"${submodule_names[@]}"}; do
     # Calculate full submodule path wrt superproject (not just parent submodule)
-    full_relative_path="${base_submodule_path}${base_submodule_path:+/}$(${GIT} config -f .gitmodules ${submodule}.path)"
+    local sm_path="$(${GIT} config -f .gitmodules ${submodule}.path)"
+    full_relative_path="${base_submodule_path}${base_submodule_path:+/}${sm_path}"
 
     # Get the url of the submodule set by init above
     submodule_url="$(${GIT} config "${submodule}.url")"
@@ -247,8 +248,53 @@ function clone_submodules()
       ${GIT} clone --mirror "${submodule_url}" "${prepped_submodule_path}"
     fi
 
-    # Set the local non-bare repo's url to point to the prepped mirror
-    ${GIT} config "${submodule}.url" "${prepped_submodule_path}"
+    # Set the local non-bare repo's url to point to the prepped mirror (so that
+    # git submodule update pulls from the this local mirror instead of the real
+    # URL, as we've just done a mirror clone
+    if tar_feature_incremental_backup; then
+      # I can't find mention of submodules using hardlinks, but it looks like
+      # 'git submodule update' uses 'git clone' to update the submodule after it
+      # is init'd:
+      #   #. [cmd_update](https://github.com/git/git/blob/v2.16.0/git-submodule.sh#L511)
+      #   #. [update_clone](https://github.com/git/git/blob/v2.16.0/builtin/submodule--helper.c#L1220)
+      #   #. [update_clone_get_next_task](https://github.com/git/git/blob/v2.16.0/builtin/submodule--helper.c#L1118)
+      #   #. [prepare_to_clone_next_submodule](https://github.com/git/git/blob/v2.16.0/builtin/submodule--helper.c#L1008)
+      #   #. [module_clone](https://github.com/git/git/blob/v2.16.0/builtin/submodule--helper.c#L848)
+      #   #. [clone_submodule](https://github.com/git/git/blob/v2.16.0/builtin/submodule--helper.c#L721)
+      # which builds a 'git clone' command. From git clone's documentation:
+      # "When the repository to clone from is on a local machine...the files
+      # under .git/objects/ directory are hardlinked" by default.
+      # https://git-scm.com/docs/git-clone#Documentation/git-clone.txt--l
+      #
+      # A Hardlink affects the change time (ctime) of a file (see stat). Thus,
+      # the files in the objects directory will have their ctime updated. This
+      # causes tar to include the file in its incremental archive. Unfortunately,
+      # there isn't a tar flag to ignore ctime nor a --no-hardlinks flag that
+      # can be passed to git submodule update
+
+      # Fetch a single branch to a bare repo
+      local TEMP_DIR
+      make_temp_path TEMP_DIR -d
+      TEMP_DIR="${TEMP_DIR}"/"$(basename "${prepped_submodule_path}")"
+
+      local tracked_sha="$(${GIT} submodule status --cached "${sm_path}" | cut -c2- | awk '{print $1}')"
+      local containing_branch="$(cd "${prepped_submodule_path}" && \
+          ${GIT} branch --contains "${tracked_sha}" | cut -c3- | head -n1)" || :
+      # Optimization - instead of copying the entire mirror, just fetch the needed branch
+      if [ -n "${containing_branch:+set}" ]; then
+        mkdir -p "${TEMP_DIR}"
+        pushd "${TEMP_DIR}" &> /dev/null
+          ${GIT} init --bare
+          ${GIT} fetch "${prepped_submodule_path}" "${containing_branch}"
+        popd &> /dev/null
+      else
+        cp -a "${prepped_submodule_path}" "${TEMP_DIR}"
+      fi
+
+      ${GIT} config "${submodule}.url" "${TEMP_DIR}"
+    else
+      ${GIT} config "${submodule}.url" "${prepped_submodule_path}"
+    fi
   done
 
   # Checkout submodule
@@ -532,7 +578,13 @@ function git_mirror_repos()
   local TEMP_DIR
   make_temp_path TEMP_DIR -d
   # The local non-bare repo doesn't need to waste time copying LFS objects
-  GIT_LFS_SKIP_SMUDGE=1 ${GIT} clone "${GIT_MIRROR_PREP_DIR}/${MAIN_DIR}" "${TEMP_DIR}"
+  if tar_feature_incremental_backup; then
+    # Clone without hardlinks because they mess up the incremental archive
+    # (see clone_submodules)
+    GIT_LFS_SKIP_SMUDGE=1 ${GIT} clone --no-hardlinks "${GIT_MIRROR_PREP_DIR}/${MAIN_DIR}" "${TEMP_DIR}"
+  else
+    GIT_LFS_SKIP_SMUDGE=1 ${GIT} clone "${GIT_MIRROR_PREP_DIR}/${MAIN_DIR}" "${TEMP_DIR}"
+  fi
 
   pushd "${TEMP_DIR}" &> /dev/null
     # The local non-bare repo doesn't need to waste time copying LFS objects
@@ -566,12 +618,6 @@ function git_mirror_repos()
 function archive_mirrors()
 {
   local prep_dir="${1}"
-
-  # Test if tar supports incremental backups
-  local temp_file
-  make_temp_path temp_file
-  local TAR_INCREMENTAL=1
-  ${TAR} -cf /dev/null -g "${temp_file}" /dev/null &> /dev/null || TAR_INCREMENTAL=0
 
   pushd "${prep_dir}" &> /dev/null
     next_section "Creating tar file..."
@@ -621,7 +667,7 @@ function archive_mirrors()
     local existing_tar_files=($(ls "${CWD}"/{*.tgz,*.snar} 2>/dev/null || :))
     IFS="${OLD_IFS}"
     args+=("--exclude" "${CWD}/${tar_file}.tgz")
-    if [ "${TAR_INCREMENTAL}" = "1" ]; then
+    if tar_feature_incremental_backup; then
       args+=("--exclude" "${CWD}/${tar_file}.snar")
     fi
     local existing_tar_file
@@ -633,7 +679,7 @@ function archive_mirrors()
     local last_tar_file
     # https://stackoverflow.com/a/37993307
     touch "${tar_file}.tgz"
-    if [ "${TAR_INCREMENTAL}" = "1" ]; then
+    if tar_feature_incremental_backup; then
       # Get the last one, alphabetically speaking (.l1.snar comes before .snar)
       # per sort's man page:
       # The locale specified by the environment affects sort order. Set LC_ALL=C
@@ -646,7 +692,7 @@ function archive_mirrors()
       ${TAR} czf "${tar_file}.tgz" "${args[@]}" "${CWD}"
     fi
 
-    if [ "${TAR_INCREMENTAL}" = "1" ] && [ "${last_tar_file}" != "" ]; then
+    if tar_feature_incremental_backup && [ "${last_tar_file}" != "" ]; then
       next_section "Creating an incremental tar file too, based on ${last_tar_file}"
       args+=("--exclude" "${CWD}/${tar_file}_${last_tar_file}.tgz" \
              "--exclude" "${CWD}/${last_tar_file}.l1.snar")

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -287,6 +287,9 @@ function clone_submodules()
   next_section "Updating submodules for ${prefix-${displaypath-${GIT_MIRROR_MAIN_REPO}}}"
   # The local non-bare repo doesn't need to waste time copying LFS objects
   # Could also add --recommend-shallow (introduced in git 2.10.0)
+  # This flag gets translated to the --depth flag, which is ignored for local
+  # clones
+  # RE This optimization does not seem worth it for a local clone
   GIT_LFS_SKIP_SMUDGE=1 ${GIT} submodule update
   # Restore the origin urls after update, so that relative URLs work
   ${GIT} submodule sync
@@ -568,6 +571,7 @@ function git_mirror_repos()
   # Could also add --depth 1 --branch "${BRANCH}" --no-recursive
   # RE --depth is ignored for local clones...could add
   # --single-branch --branch "${BRNACH}" --no-recursive
+  # RE This optimization does not seem worth it for a local clone
   if tar_feature_incremental_backup; then
     # Clone without hardlinks because they mess up the incremental archive
     # (see clone_submodules)

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -272,24 +272,10 @@ function clone_submodules()
       # there isn't a tar flag to ignore ctime nor a --no-hardlinks flag that
       # can be passed to git submodule update
 
-      # Fetch a single branch to a bare repo
+      # Bare clone without hardlinks
       local TEMP_DIR
       make_temp_path TEMP_DIR -d
-      TEMP_DIR="${TEMP_DIR}"/"$(basename "${prepped_submodule_path}")"
-
-      local tracked_sha="$(${GIT} submodule status --cached "${sm_path}" | cut -c2- | awk '{print $1}')"
-      local containing_branch="$(cd "${prepped_submodule_path}" && \
-          ${GIT} branch --contains "${tracked_sha}" | cut -c3- | head -n1)" || :
-      # Optimization - instead of copying the entire mirror, just fetch the needed branch
-      if [ -n "${containing_branch:+set}" ]; then
-        mkdir -p "${TEMP_DIR}"
-        pushd "${TEMP_DIR}" &> /dev/null
-          ${GIT} init --bare
-          ${GIT} fetch "${prepped_submodule_path}" "${containing_branch}"
-        popd &> /dev/null
-      else
-        cp -a "${prepped_submodule_path}" "${TEMP_DIR}"
-      fi
+      ${GIT} clone --bare --no-hardlinks "${prepped_submodule_path}" "${TEMP_DIR}"
 
       ${GIT} config "${submodule}.url" "${TEMP_DIR}"
     else

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -286,6 +286,7 @@ function clone_submodules()
   # Checkout submodule
   next_section "Updating submodules for ${prefix-${displaypath-${GIT_MIRROR_MAIN_REPO}}}"
   # The local non-bare repo doesn't need to waste time copying LFS objects
+  # Could also add --recommend-shallow (introduced in git 2.10.0)
   GIT_LFS_SKIP_SMUDGE=1 ${GIT} submodule update
   # Restore the origin urls after update, so that relative URLs work
   ${GIT} submodule sync
@@ -564,6 +565,9 @@ function git_mirror_repos()
   local TEMP_DIR
   make_temp_path TEMP_DIR -d
   # The local non-bare repo doesn't need to waste time copying LFS objects
+  # Could also add --depth 1 --branch "${BRANCH}" --no-recursive
+  # RE --depth is ignored for local clones...could add
+  # --single-branch --branch "${BRNACH}" --no-recursive
   if tar_feature_incremental_backup; then
     # Clone without hardlinks because they mess up the incremental archive
     # (see clone_submodules)

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -272,10 +272,10 @@ function clone_submodules()
       # there isn't a tar flag to ignore ctime nor a --no-hardlinks flag that
       # can be passed to git submodule update
 
-      # Bare clone without hardlinks
       local TEMP_DIR
       make_temp_path TEMP_DIR -d
-      ${GIT} clone --bare --no-hardlinks "${prepped_submodule_path}" "${TEMP_DIR}"
+      TEMP_DIR="${TEMP_DIR}"/"$(basename "${prepped_submodule_path}")"
+      cp -a "${prepped_submodule_path}" "${TEMP_DIR}"
 
       ${GIT} config "${submodule}.url" "${TEMP_DIR}"
     else

--- a/tests/int/test-git_mirror.bsh
+++ b/tests/int/test-git_mirror.bsh
@@ -375,6 +375,24 @@ begin_test "Part 6 - Update a repo and the prepped mirror"
     # alternatively
     #[ "$(git show HEAD | git patch-id | awk '{print $1}')" = "bd6ba42dfd6bb1cacf02ec71f97292f25b58d0da" ]
   popd &> /dev/null
+
+
+  # Verify that if nothing changed, the next incremental mirror (if it exists)
+  # doesn't include any (all) of the git objects (there was a problem where
+  # these were always being included)
+
+  # Select the incremental backup if it exists (should be at most one)
+  PREP_FILE="$(shopt -s nullglob; echo "${PRETEND_URL}_prep"/transfer_*_transfer_*.tgz)"
+  if [ -n "${PREP_FILE:+set}" ]; then
+    pushd "${TRASHDIR}" &> /dev/null
+      LFS_DIR="${PRETEND_URL}_lfs/lfs/objects" GIT="${TRASHDIR}/git2" git_mirror_main "${PRETEND_URL}"
+      last_incremental_tar_file="$(LC_ALL=C ls "${PRETEND_URL}_prep"/transfer_*_transfer_*.tgz 2>/dev/null | \
+          tail -n1)"
+      # There should not be any files under the objects git directory; these
+      # look like objects/12/SHA
+      ! tar tf "${last_incremental_tar_file}" | grep -e "/objects/../.\+[^/]$"
+    popd &> /dev/null
+  fi
 )
 end_test
 

--- a/tests/int/test-just_git_airgap_repo.bsh
+++ b/tests/int/test-just_git_airgap_repo.bsh
@@ -772,12 +772,12 @@ begin_test "git functionality"
     # NOTE remote_tracking_branch_deleted is a tracking branch, but the remote-
     # tracking branch has been deleted
     get_tracking_branches
-    # TODO use assert_array_eq
+    # REVIEW use assert_array_eq
     ans=("master" "tracking_branch_ahead" "tracking_branch_behind" "tracking_branch_equal" "tracking_branchpoint")
-    [ "$(declare -p just_git_tracking_branches | cut -d'=' | -f2-)" = "$(declare -p ans | cut -d'=' | -f2-)" ]
+    [ "$(declare -p just_git_tracking_branches | cut -d'=' -f2-)" = "$(declare -p ans | cut -d'=' -f2-)" ]
 
     ans=("origin/master" "origin/tracking_branch_ahead" "origin/master" "origin/tracking_branch_equal" "origin/master")
-    [ "$(declare -p just_git_remote_tracking_branches | cut -d'=' | -f2-)" = "$(declare -p ans | cut -d'=' | -f2-)" ]
+    [ "$(declare -p just_git_remote_tracking_branches | cut -d'=' -f2-)" = "$(declare -p ans | cut -d'=' -f2-)" ]
 
     # specify a branch that has a tracking branch
     output="$(get_tracking_branches origin tracking_branch_behind)"

--- a/tests/int/test-just_git_airgap_repo.bsh
+++ b/tests/int/test-just_git_airgap_repo.bsh
@@ -5,6 +5,7 @@ if [ -z ${VSI_COMMON_DIR+set} ]; then
 fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
+source "${VSI_COMMON_DIR}/tests/test_utils.bsh"
 command -v "${GIT-git}" &> /dev/null && source "${VSI_COMMON_DIR}/linux/just_git_airgap_repo.bsh"
 source "${VSI_COMMON_DIR}/linux/requirements.bsh"
 source "${VSI_COMMON_DIR}/linux/real_path"
@@ -772,12 +773,13 @@ begin_test "git functionality"
     # NOTE remote_tracking_branch_deleted is a tracking branch, but the remote-
     # tracking branch has been deleted
     get_tracking_branches
-    # REVIEW use assert_array_eq
-    ans=("master" "tracking_branch_ahead" "tracking_branch_behind" "tracking_branch_equal" "tracking_branchpoint")
-    [ "$(declare -p just_git_tracking_branches | cut -d'=' -f2-)" = "$(declare -p ans | cut -d'=' -f2-)" ]
+    ans=("master" "tracking_branch_ahead" "tracking_branch_behind" \
+        "tracking_branch_equal" "tracking_branchpoint")
+    assert_array_eq just_git_tracking_branches ans
 
-    ans=("origin/master" "origin/tracking_branch_ahead" "origin/master" "origin/tracking_branch_equal" "origin/master")
-    [ "$(declare -p just_git_remote_tracking_branches | cut -d'=' -f2-)" = "$(declare -p ans | cut -d'=' -f2-)" ]
+    ans=("origin/master" "origin/tracking_branch_ahead" "origin/master" \
+        "origin/tracking_branch_equal" "origin/master")
+    assert_array_eq just_git_remote_tracking_branches ans
 
     # specify a branch that has a tracking branch
     output="$(get_tracking_branches origin tracking_branch_behind)"
@@ -870,7 +872,7 @@ begin_test "Make remote pushable"
     [ "$(git config --get remote.origin.url)" = "http://git-server.org/company/arepo.git" ]
     [ "$(git config --get remote.origin.pushurl)" = "git@git-server.org:company/arepo.git" ]
     [ "$(git config --get remote.upstream.url)" = "https://git2-server.org/company/arepo1.git" ]
-    ! git config --get remote.upstream.pushurl
+    not git config --get remote.upstream.pushurl
     convert_git_remote_http_to_git upstream
     [ "$(git config --get remote.upstream.url)" = "https://git2-server.org/company/arepo1.git" ]
     [ "$(git config --get remote.upstream.pushurl)" = "git@git2-server.org:company/arepo1.git" ]

--- a/tests/test-compat.bsh
+++ b/tests/test-compat.bsh
@@ -390,3 +390,16 @@ begin_required_fail_test "Fail bash case modification"
   echo "${x_16^^}"
 )
 end_test
+
+begin_test "Tar flags"
+(
+  setup_test
+
+  touch "${TESTDIR}/file"
+  if tar_feature_incremental_backup; then
+    ${TAR-tar} -cf /dev/null -g "${TESTDIR}/file" /dev/null &> /dev/null
+  else
+    not ${TAR-tar} -cf /dev/null -g "${TESTDIR}/file" /dev/null &> /dev/null
+  fi
+)
+end_test


### PR DESCRIPTION
The incremental archive was way too big; it was including all of git's object files. These were being included because a local `git clone` uses hardlinks (by default) which affect the ctime of the files. That causes tar to treat them as changed and include them in the incremental archive.