### PR TITLE
Update just_install_functions.bsh

### DIFF
--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -263,7 +263,7 @@ function conda-python-install()
       CONDA="${conda_dir}/_conda"
 
       # cleanup shortcuts
-      "${CONDA}" remove -y -p "${conda_dir}" console_shortcut powershell_shortcut
+      "${CONDA}" remove --offline -y -p "${conda_dir}" console_shortcut powershell_shortcut
 
     # linux & darwin
     else


### PR DESCRIPTION
`conda remove` apparently updates everything too, wasting time and differentiating from other OSes.

The simpler approach is to stop it from updating, so forcing it into offline mode is the first way I found that does this.