### PR TITLE
just_install_functions::pipenv-install virtualenv version

### DIFF
--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -352,6 +352,8 @@ function conda-python-install()
 #             * [``--version {version}``] - Pipenv version for install (default=``${PIPENV_VERSION:-2020.8.13}``)
 #             * [``--python {PYTHON}``] - Python executable (default=(python3|python|python2))
 #             * [``--python-activate {script}``] - Optional python activation script, for example as created by :func:`conda-python-install`
+#             * [``--virtualenv-pyz {file}``] - Optional virtualenv zipapp file (default=``${VIRTUALENV_PYZ-}``)
+#             * [``--virtualenv-version {version}``] - Optional viertualenv version (default=``${VIRTUALENV_VERSION:-20.0.33}``)
 #
 # :Output: * pipenv_exe - Pipenv executable
 #          * pipenv_version - Pipenv version
@@ -366,12 +368,16 @@ function pipenv-install()
   local pipenv_ver="${PIPENV_VERSION:-2020.8.13}"  # pipenv version
   local PYTHON  # python executable
   local python_activate
+  local virtualenv_pyz="${VIRTUALENV_PYZ-}"
+  local virtualenv_ver="${VIRTUALENV_VERSION:-20.0.33}"
 
   parse_args pipenv_extra_args \
       --dir install_dir: \
       --version pipenv_ver: \
       --python PYTHON: \
       --python-activate python_activate: \
+      --virtualenv-pyz virtualenv_pyz: \
+      --virtualenv-version virtualenv_ver: \
       -- ${@+"${@}"}
 
   # check for pipenv directory
@@ -413,6 +419,8 @@ function pipenv-install()
     PIPENV_PYTHON="${PYTHON}"
     PIPENV_VERSION="${pipenv_ver}"
     PIPENV_VIRTUALENV="${pipenv_dir}"
+    VIRTUALENV_PYZ="${virtualenv_pyz}"
+    VIRTUALENV_VERSION="${virtualenv_ver}"
     install_pipenv
   )
 


### PR DESCRIPTION
Add virtualenv options to `just_install_functions::pipenv-install`, including the optional virtualenv version (currently pinned to 20.0.33) and a previously downloaded virtualenv zipapp.

Update docker_recipes.