### PR TITLE
docker_compose_override premkdir for bind-mount directories

### DIFF
--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -278,6 +278,12 @@ function generate_docker_compose_override()
 
     # Get internal volumes of service
     for volume in "${!DOCKER_VOLUME_SOURCES[@]}"; do
+
+      # If directory doesn't exist, attempt to make it as this user. Better than root
+      # When the argument is a docker volume, nothing should happen.
+      docker_premkdir "${DOCKER_VOLUME_SOURCES[$volume]}"
+
+      # Get internal volumes of service
       if is_internal_docker_volume "${DOCKER_VOLUME_SOURCES[$volume]}"; then
         if [ "${DOCKER_VOLUME_FORMATS[$volume]}" == "short" ]; then
           if is_readonly_docker_volume "${DOCKER_VOLUME_FLAGS[$volume]}"; then


### PR DESCRIPTION
`generate_docker_compose_override` ensure bind-mount directories defined by `DOCKER_VOLUME_SOURCES` are created via `docker_premkdir`