### PR TITLE
Andy 20201105

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,9 +44,10 @@ install:
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U --config <(echo) /tmp/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   # Update the db and mirrors
   - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
-  # Update the db again, since we just got new mirrors, and then install pacman
+  # Hack for https://github.com/msys2/MSYS2-packages/issues/2300
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U https://repo.msys2.org/msys/x86_64/zstd-1.4.7-1-x86_64.pkg.tar.xz"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U https://repo.msys2.org/msys/x86_64/pacman-5.2.2-5-x86_64.pkg.tar.xz"
+  # Update the db again, since we just got new mirrors, and then update pacman (again)
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sydd pacman"
 
   # This is too late to install rank mirrors to make it worth it

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,6 +45,8 @@ install:
   # Update the db and mirrors
   - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   # Update the db again, since we just got new mirrors, and then install pacman
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U https://repo.msys2.org/msys/x86_64/zstd-1.4.7-1-x86_64.pkg.tar.xz"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U https://repo.msys2.org/msys/x86_64/pacman-5.2.2-5-x86_64.pkg.tar.xz"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sydd pacman"
 
   # This is too late to install rank mirrors to make it worth it

--- a/docs/linux/index.rst
+++ b/docs/linux/index.rst
@@ -11,7 +11,7 @@ Linux Utilities
    *.auto
    python_scripts/modules
 
-A set of useful linux scripts that should on any modern Linux machine. For the most part, these are bash scripts that are either pure bash, or rely on core Linux utils. These scripts are tests against a variety of Linuxes, macOS, and Windows using msys2/mingw64 (such as Git for Windows). And scripts that require something beyond cord utils should have these requirements called in their documentation.
+A set of useful linux scripts that should be on any modern Linux machine. For the most part, these are bash scripts that are either pure bash or rely on core Linux utils. These scripts are tested against a variety of Linuxes, macOS, and Windows using msys2/mingw64 (such as Git for Windows). And scripts that require something beyond these core and common utils should have these requirements called in their documentation.
 
 Used core utils include:
 

--- a/docs/linux/index.rst
+++ b/docs/linux/index.rst
@@ -10,3 +10,50 @@ Linux Utilities
 
    *.auto
    python_scripts/modules
+
+A set of useful linux scripts that should on any modern Linux machine. For the most part, these are bash scripts that are either pure bash, or rely on core Linux utils. These scripts are tests against a variety of Linuxes, macOS, and Windows using msys2/mingw64 (such as Git for Windows). And scripts that require something beyond cord utils should have these requirements called in their documentation.
+
+Used core utils include:
+
+* ``basename``
+* ``cat``
+* ``cp``
+* ``cut``
+* ``date``
+* ``df``
+* ``dirname``
+* ``env``
+* ``false``
+* ``fold``
+* ``head``
+* ``id``
+* ``ln``
+* ``ls``
+* ``mkdir``
+* ``mktemp``
+* ``mkfifo``
+* ``pwd``
+* ``rm``
+* ``sort``
+* ``tail``
+* ``test``
+* ``tr``
+* ``true``
+* ``touch``
+* ``xargs``
+
+In addition to other commonly included tools:
+
+* ``awk``
+* ``column`` (if available)
+* ``getent`` (Linux only)
+* ``grep``
+* ``mount``
+* ``pgrep`` (if available)
+* ``ps``
+* ``sed``
+* ``tput`` (This should be moved to docs for specific function, not in this list)
+
+.. note::
+
+   Busybox based operating systems have a version of ``awk`` and ``sed`` that is not fully compatible. In a few cases, the GNU version is needed over the Busybox version. The BSD version will also work.

--- a/linux/aliases.bsh
+++ b/linux/aliases.bsh
@@ -15,7 +15,7 @@ fi
 #
 # .. file:: aliases.bsh
 #
-# Because bash script do not use ``alias`` by default, common external programs are soft-coded using an all caps variable name (e.g. ``tar`` is called using ``"${TAR}"``. Simply source :file:`aliases.bsh` and use the variables, instead of hard-coding "tar" everywhere, use the variable ``TAR"`` so that when the need comes, it is easier to switch which executable gets called. When an alias variable is used, it should always be surrounded by quotes, e.g. ``"${TAR}"``.
+# Because bash scripts do not use ``alias`` by default, common external programs are soft-coded using an all-caps variable name (e.g. ``tar`` is called using ``"${TAR}"``. Simply source :file:`aliases.bsh` and use the variables. For example, instead of hard-coding "tar" everywhere, use the variable ``TAR`` so that when the need comes, it is easier to switch which executable gets called. When an alias variable is used, this variable should be surrounded by quotes, e.g. ``"${TAR}"``.
 #
 # Variables should default to the common executable name, and allow the user to override them.
 #
@@ -28,7 +28,7 @@ fi
 #
 # .. note::
 #
-#    ``SSH="ssh -v"`` will look for an executable called ``ssh -v``, and will not run ``ssh`` with the ``-v`` flag
+#    ``SSH="ssh -v"`` will look for an executable called ``ssh -v``, instead of running  ``ssh`` with the ``-v`` flag, as desired.
 #
 # .. var:: GIT
 #

--- a/linux/aliases.bsh
+++ b/linux/aliases.bsh
@@ -1,0 +1,108 @@
+#!/usr/bin/env false bash
+
+if [[ $- != *i* ]]; then
+  source_once &> /dev/null && return 0
+fi
+
+#*# linux/aliases
+
+#**
+# ==================
+# Executable Aliases
+# ==================
+#
+# .. default-domain:: bash
+#
+# .. file:: aliases.bsh
+#
+# Since bash script do not use ``alias`` by default, common external programs are soft coded using an all caps variable name (e.g. ``tar`` is called using ``"${TAR}"``. Simply source :file:`aliases.bsh` and use the variables.
+#
+# Variables should default to the common executable name, and allow the user to override them.
+#
+# For example, :var:`SSH` defaults to ``ssh``. There are a number of ways to override this:
+#
+# * ``SSH=ssh2`` - Finds the command on the path called ``ssh2``
+# * ``SSH=/usr/local/bin/ssh`` - Uses a full path
+# * ``function ssh3(){ SSH_FLAG=3 ssh -v ${@+"${@}"}; }; export -f ssh3; SSH=ssh3`` - Use an exported function
+# * ``echo '#!/usr/bin/env bash' > ~/foo; echo 'ssh -v ${@}' >> ~/foo; SSH=~/foo``
+#
+# .. note::
+#
+#    ``SSH="ssh -v"`` will look for an executable called ``ssh -v``, not run ``ssh`` with the ``-v`` flag
+#
+# .. var:: GIT
+#
+# Name/path of git executable
+#
+# Instead of hard-coding "git" everywhere, use the variable :var:`GIT` so that when the need comes, it is easier to switch which executable gets called. Default is ``git``. Set to empty string to have any calls to git skipped.
+#
+# .. note::
+#
+#   When using the GIT env variable in this file, do not surround it with quotes as you normally would. Although this prevents using a path to ``git`` with a space in it, in exchange, it may be possible (eventually) to enable a dry-run-ish capability if GIT is set to ``echo git``. However, this feature does not currently work and even in the future may not work very well because this script is constantly cloning and cd'ing to new repos.
+#**
+
+: ${GIT=git}
+
+#**
+# .. var:: TAR
+#
+# Name/path of tar executable
+#
+# Instead of hard-coding "tar" everywhere, use the variable :var:`TAR` so that when the need comes, it is easier to switch which executable gets called. Default is ``tar``.
+#
+# .. note::
+#
+#   When using the TAR env variable in this file, do not surround it with quotes as you normally would. Although this prevents using a path to ``tar`` with a space in it, in exchange, it may be possible (eventually) to enable a dry-run-ish capability if TAR is set to 'echo tar'.
+#**
+
+: ${TAR=tar}
+
+#**
+# .. var:: DOCKER
+#
+# Name/path of docker executable
+#
+# Instead of hard-coding "docker" everywhere, use the variable :var:`DOCKER` so that when the need comes, it is easier to switch which executable gets called.
+#**
+
+: ${DOCKER=docker}
+
+#**
+# .. var:: DOCKER_COMPOSE
+#
+# Name/path of docker-compose executable
+#
+# Instead of hard-coding "docker-compose" everywhere, use the variable :var:`DOCKER_COMPOSE` so that when the need comes, it is easier to switch which executable gets called
+#**
+
+: ${DOCKER_COMPOSE=docker-compose}
+
+#**
+# .. var:: SINGULARITY
+#
+# Name/path of singularity executable
+#
+# Instead of hard-coding "singularity" everywhere, use the variable :var:`SINGULARITY` so that when the need comes, it is easier to switch which executable gets called.
+#**
+
+: ${SINGULARITY=singularity}
+
+#**
+# .. var:: NVIDIA_SMI
+#
+# Name/path of nvidia-smi executable
+#
+# Instead of hard-coding "nvidia-smi" everywhere, use the variable :var:`NVIDIA_SMI` so that when the need comes, it is easier to switch which executable gets called.
+#**
+
+: ${NVIDIA_SMI=nvidia-smi}
+
+#**
+# .. var:: SSH
+#
+# Name/path of ssh executable
+#
+# Instead of hard-coding "ssh" everywhere, use the variable :var:`SSH` so that when the need comes, it is easier to switch which executable gets called.
+#**
+
+: ${SSH=ssh}

--- a/linux/aliases.bsh
+++ b/linux/aliases.bsh
@@ -15,7 +15,7 @@ fi
 #
 # .. file:: aliases.bsh
 #
-# Since bash script do not use ``alias`` by default, common external programs are soft coded using an all caps variable name (e.g. ``tar`` is called using ``"${TAR}"``. Simply source :file:`aliases.bsh` and use the variables.
+# Because bash script do not use ``alias`` by default, common external programs are soft-coded using an all caps variable name (e.g. ``tar`` is called using ``"${TAR}"``. Simply source :file:`aliases.bsh` and use the variables, instead of hard-coding "tar" everywhere, use the variable ``TAR"`` so that when the need comes, it is easier to switch which executable gets called. When an alias variable is used, it should always be surrounded by quotes, e.g. ``"${TAR}"``.
 #
 # Variables should default to the common executable name, and allow the user to override them.
 #
@@ -24,21 +24,17 @@ fi
 # * ``SSH=ssh2`` - Finds the command on the path called ``ssh2``
 # * ``SSH=/usr/local/bin/ssh`` - Uses a full path
 # * ``function ssh3(){ SSH_FLAG=3 ssh -v ${@+"${@}"}; }; export -f ssh3; SSH=ssh3`` - Use an exported function
-# * ``echo '#!/usr/bin/env bash' > ~/foo; echo 'ssh -v ${@}' >> ~/foo; SSH=~/foo``
+# * ``echo '#!/usr/bin/env bash' > ~/foo; echo 'ssh -v ${@}' >> ~/foo; chmod 755 ~/foo; SSH=~/foo``
 #
 # .. note::
 #
-#    ``SSH="ssh -v"`` will look for an executable called ``ssh -v``, not run ``ssh`` with the ``-v`` flag
+#    ``SSH="ssh -v"`` will look for an executable called ``ssh -v``, and will not run ``ssh`` with the ``-v`` flag
 #
 # .. var:: GIT
 #
 # Name/path of git executable
 #
-# Instead of hard-coding "git" everywhere, use the variable :var:`GIT` so that when the need comes, it is easier to switch which executable gets called. Default is ``git``. Set to empty string to have any calls to git skipped.
-#
-# .. note::
-#
-#   When using the GIT env variable in this file, do not surround it with quotes as you normally would. Although this prevents using a path to ``git`` with a space in it, in exchange, it may be possible (eventually) to enable a dry-run-ish capability if GIT is set to ``echo git``. However, this feature does not currently work and even in the future may not work very well because this script is constantly cloning and cd'ing to new repos.
+# :Default: ``git``
 #**
 
 : ${GIT=git}
@@ -48,11 +44,7 @@ fi
 #
 # Name/path of tar executable
 #
-# Instead of hard-coding "tar" everywhere, use the variable :var:`TAR` so that when the need comes, it is easier to switch which executable gets called. Default is ``tar``.
-#
-# .. note::
-#
-#   When using the TAR env variable in this file, do not surround it with quotes as you normally would. Although this prevents using a path to ``tar`` with a space in it, in exchange, it may be possible (eventually) to enable a dry-run-ish capability if TAR is set to 'echo tar'.
+# :Default: ``tar``
 #**
 
 : ${TAR=tar}
@@ -62,7 +54,7 @@ fi
 #
 # Name/path of docker executable
 #
-# Instead of hard-coding "docker" everywhere, use the variable :var:`DOCKER` so that when the need comes, it is easier to switch which executable gets called.
+# :Default: ``docker``
 #**
 
 : ${DOCKER=docker}
@@ -72,7 +64,7 @@ fi
 #
 # Name/path of docker-compose executable
 #
-# Instead of hard-coding "docker-compose" everywhere, use the variable :var:`DOCKER_COMPOSE` so that when the need comes, it is easier to switch which executable gets called
+# :Default: ``docker-compose``
 #**
 
 : ${DOCKER_COMPOSE=docker-compose}
@@ -82,7 +74,7 @@ fi
 #
 # Name/path of singularity executable
 #
-# Instead of hard-coding "singularity" everywhere, use the variable :var:`SINGULARITY` so that when the need comes, it is easier to switch which executable gets called.
+# :Default: ``singularity``
 #**
 
 : ${SINGULARITY=singularity}
@@ -92,7 +84,7 @@ fi
 #
 # Name/path of nvidia-smi executable
 #
-# Instead of hard-coding "nvidia-smi" everywhere, use the variable :var:`NVIDIA_SMI` so that when the need comes, it is easier to switch which executable gets called.
+# :Default: ``nvidia-smi``
 #**
 
 : ${NVIDIA_SMI=nvidia-smi}
@@ -102,7 +94,7 @@ fi
 #
 # Name/path of ssh executable
 #
-# Instead of hard-coding "ssh" everywhere, use the variable :var:`SSH` so that when the need comes, it is easier to switch which executable gets called.
+# :Default: ``ssh``
 #**
 
 : ${SSH=ssh}

--- a/linux/common_source.sh
+++ b/linux/common_source.sh
@@ -451,6 +451,7 @@ if [ "${VSI_DISTRO}" = "centos" ] || \
 fi
 
 # Turn debian codenames to numbers
+# https://wiki.debian.org/DebianReleases
 if [ "${VSI_DISTRO_CORE-}" = "debian" ]; then
   # Remove the /sid for some debian derivatives
   VSI_DISTRO_VERSION_CORE="${VSI_DISTRO_VERSION_CORE%/sid}"
@@ -463,11 +464,13 @@ if [ "${VSI_DISTRO_CORE-}" = "debian" ]; then
     buster)   VSI_DISTRO_VERSION_CORE=10 ;; # EOL 2022
     bullseye) VSI_DISTRO_VERSION_CORE=11 ;; # Release ?
     bookworm) VSI_DISTRO_VERSION_CORE=12 ;; # Release ?
+    trixie)   VSI_DISTRO_VERSION_CORE=13 ;; # Release ?
   esac
 fi
 
 # Fix the case when OSes like mint are like ubuntu but use the codename
 # https://wiki.ubuntu.com/Releases
+# https://launchpad.net/ubuntu/
 if [ "${VSI_DISTRO_LIKE-}" = "ubuntu" ]; then
   case "${VSI_DISTRO_VERSION_LIKE-}" in
     precise) VSI_DISTRO_VERSION_LIKE=12.04 ;; # EOL Apr 28, 2017
@@ -484,7 +487,8 @@ if [ "${VSI_DISTRO_LIKE-}" = "ubuntu" ]; then
     disco)   VSI_DISTRO_VERSION_LIKE=19.04 ;; # EOL Jan 23, 2020
     eoan)    VSI_DISTRO_VERSION_LIKE=19.10 ;; # EOL Jul 17, 2020
     focal)   VSI_DISTRO_VERSION_LIKE=20.04 ;; # EOL Apr 2030
-    groovy)  VSI_DISTRO_VERSION_LIKE=20.10 ;; # Release October 22, 2020 : EOL Jul 2021
+    groovy)  VSI_DISTRO_VERSION_LIKE=20.10 ;; # EOL Jul 2021
+    hirsute) VSI_DISTRO_VERSION_LIKE=21.04 ;; # Release April 22, 2021 : EOL ~Jan 2022
   esac
 fi
 

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -4,6 +4,8 @@ if [[ $- != *i* ]]; then
   source_once &> /dev/null && return 0
 fi
 
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
+
 # compat should avoid sourcing other files because it is used everywhere and we'd
 # like to avoid any potential circular source or time delays, without "having" to
 # use circular source or source once.
@@ -798,14 +800,14 @@ function load_vsi_compat()
       # GIT_DIR= ignores being in vsi_common/tests, which will break if the supermodule is not mounted in
 
       # Cannot be uncommented until https://github.com/chromium/badssl.com/issues/332
-      # if [[ $(GIT_DIR= ${GIT-git} ls-remote -h https://tls-v1-3.badssl.com:1013/ 2>&1 > /dev/null) =~ repository.*\ not\ found ]; then
+      # if [[ $(GIT_DIR= "${GIT}" ls-remote -h https://tls-v1-3.badssl.com:1013/ 2>&1 > /dev/null) =~ repository.*\ not\ found ]; then
       #   __git_feature_support_tls=3
       # elif ...
-      if [[ $(GIT_DIR= ${GIT-git} ls-remote -h https://tls-v1-2.badssl.com:1012/ 2>&1 > /dev/null) =~ repository.*\ not\ found ]]; then
+      if [[ $(GIT_DIR= "${GIT}" ls-remote -h https://tls-v1-2.badssl.com:1012/ 2>&1 > /dev/null) =~ repository.*\ not\ found ]]; then
         __git_feature_support_tls=2
-      elif [[ $(GIT_DIR= ${GIT-git} ls-remote -h https://tls-v1-1.badssl.com:1011/ 2>&1 > /dev/null) =~ repository.*\ not\ found ]]; then
+      elif [[ $(GIT_DIR= "${GIT}" ls-remote -h https://tls-v1-1.badssl.com:1011/ 2>&1 > /dev/null) =~ repository.*\ not\ found ]]; then
         __git_feature_support_tls=1
-      elif [[ $(GIT_DIR= ${GIT-git} ls-remote -h https://tls-v1-0.badssl.com:1010/ 2>&1 > /dev/null) =~ repository.*\ not\ found ]]; then
+      elif [[ $(GIT_DIR= "${GIT}" ls-remote -h https://tls-v1-0.badssl.com:1010/ 2>&1 > /dev/null) =~ repository.*\ not\ found ]]; then
         __git_feature_support_tls=0
       fi
     fi
@@ -846,7 +848,7 @@ function load_vsi_compat()
   function git_feature_cli_config_option()
   {
     if [ -z "${__git_feature_cli_config_option+set}" ]; then
-      if ${GIT-git} -c foo=bar version &> /dev/null; then
+      if "${GIT}" -c foo=bar version &> /dev/null; then
         __git_feature_cli_config_option=0
       else
         __git_feature_cli_config_option=1

--- a/linux/compat_singularity.bsh
+++ b/linux/compat_singularity.bsh
@@ -5,6 +5,7 @@ if [[ $- != *i* ]]; then
 fi
 
 source "${VSI_COMMON_DIR}/linux/requirements.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 
 #*# linux/compat_singularity.bsh
 
@@ -23,7 +24,7 @@ source "${VSI_COMMON_DIR}/linux/requirements.bsh"
 function _compat_singularity_get_version()
 {
   if [ -z "${_compat_singularity_version+set}" ]; then
-    _compat_singularity_version="$("${SINGULARITY-singularity}" --version)"
+    _compat_singularity_version="$("${SINGULARITY}" --version)"
     _compat_singularity_version="${_compat_singularity_version##* }"
     _compat_singularity_version="${_compat_singularity_version%%-*}"
   fi

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -9,6 +9,7 @@ if [ -z ${VSI_COMMON_DIR+set} ]; then
 fi
 
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 
 #*# linux/cuda_info
 
@@ -59,7 +60,7 @@ function discover_cuda_versions()
     CUDA_VERSIONS+=($("${version}" --version | \awk 'END{print substr($6, 2)}'))
   done 2>/dev/null
 
-  if [ "${#CUDA_VERSIONS[@]}" = "0" ] && command -v "${NVIDIA_SMI-nvidia-smi}" &> /dev/null; then
+  if [ "${#CUDA_VERSIONS[@]}" = "0" ] && command -v "${NVIDIA_SMI}" &> /dev/null; then
     echo "No CUDA found: Determining max supported CUDA instead" >&2
     CUDA_VERSIONS=("$(nvidia-smi | sed -n${sed_flag_rE} '/CUDA Version:/{s|.*CUDA Version: *([0-9.]*).*|\1|;p;q;}')")
   fi

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -10,6 +10,7 @@ fi
 
 source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 source "${VSI_COMMON_DIR}/linux/findin"
 source "${VSI_COMMON_DIR}/linux/requirements.bsh"
 
@@ -46,34 +47,6 @@ GIT_MIRROR_SOURCE="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"/"$(basename "${B
 # 6. ``git_mirror push ./info.env ./transfer_extracted_dir/`` - Push the mirrored repository and all submodules to a new git server as defined by info.env
 # #. ``git_mirror clone ./info.env ./my_project_dir/`` - Clone recursively from the new mirror
 #**
-
-#**
-# .. var:: GIT
-#
-# Name/path of git executable
-#
-# Instead of hard-coding "git" everywhere, use the variable :var:`GIT` so that when the need comes, it is easier to switch which executable gets called. Default is ``git``.
-#
-# .. note::
-#
-#   When using the GIT env variable in this file, do not surround it with quotes as you normally would. Although this prevents using a path to ``git`` with a space in it, in exchange, it may be possible (eventually) to enable a dry-run-ish capability if GIT is set to 'echo git'. However, this feature does not currently work and even in the future may not work very well because this script is constantly cloning and cd'ing to new repos.
-#**
-
-: ${GIT=git}
-
-#**
-# .. var:: TAR
-#
-# Name/path of tar executable
-#
-# Instead of hard-coding "tar" everywhere, use the variable :var:`TAR` so that when the need comes, it is easier to switch which executable gets called. Default is ``tar``.
-#
-# .. note::
-#
-#   When using the TAR env variable in this file, do not surround it with quotes as you normally would. Although this prevents using a path to ``tar`` with a space in it, in exchange, it may be possible (eventually) to enable a dry-run-ish capability if TAR is set to 'echo tar'.
-#**
-
-: ${TAR=tar}
 
 #**
 # .. function:: next_section
@@ -136,7 +109,7 @@ GIT_VERSION="$(git_version)"
 if meet_requirements "${GIT_VERSION}" ">=2.6"; then
   function get_config_submodule_names()
   {
-    ${GIT} config --name-only --get-regexp '^submodule\..*\.url$' | sed 's|.url$||'
+    "${GIT}" config --name-only --get-regexp '^submodule\..*\.url$' | sed 's|.url$||'
   }
 else
   function get_config_submodule_names()
@@ -148,7 +121,7 @@ else
       # Get first newline terminated line of that record, it's the name
       IFS= read -r -d $'\n' record <<< "${record}"
       names+=("${record}")
-    done < <(${GIT} config -z --get-regexp '^submodule\..*\.url$')
+    done < <("${GIT}" config -z --get-regexp '^submodule\..*\.url$')
 
     for line in ${names[@]+"${names[@]}"}; do
       echo "${line%.url}"
@@ -170,7 +143,7 @@ fi
 function git_mirror_has_lfs()
 {
   if [ -z "${__git_mirror_has_lfs:+set}" ]; then
-    if ! ${GIT} lfs &> /dev/null; then
+    if ! "${GIT}" lfs &> /dev/null; then
       __git_mirror_has_lfs=1 # Does not have lfs
     else
       __git_mirror_has_lfs=0 # Does have lfs
@@ -197,12 +170,12 @@ function git_mirror_has_lfs()
 function clone_submodules()
 {
   # Init (any) submodules non-recursively
-  ${GIT} submodule init
+  "${GIT}" submodule init
 
   # Submodule names can't contain newlines
   local IFS=$'\n'
   # This does not work for init-only modules
-  #   submodule_names=($(${GIT} submodule foreach --quiet 'echo "${name}"'))
+  #   submodule_names=($("${GIT}" submodule foreach --quiet 'echo "${name}"'))
   # This does
   local submodule_names=($(get_config_submodule_names))
 
@@ -219,11 +192,11 @@ function clone_submodules()
   # Update submodule urls to use GIT_MIRROR_PREP_DIR
   for submodule in ${submodule_names[@]+"${submodule_names[@]}"}; do
     # Calculate full submodule path wrt superproject (not just parent submodule)
-    local sm_path="$(${GIT} config -f .gitmodules ${submodule}.path)"
+    local sm_path="$("${GIT}" config -f .gitmodules ${submodule}.path)"
     full_relative_path="${base_submodule_path}${base_submodule_path:+/}${sm_path}"
 
     # Get the url of the submodule set by init above
-    submodule_url="$(${GIT} config "${submodule}.url")"
+    submodule_url="$("${GIT}" config "${submodule}.url")"
 
     # Search for existing prepped mirror
     # https://stackoverflow.com/a/52657447/4166604
@@ -234,18 +207,18 @@ function clone_submodules()
       # cd into the prepped mirror
       pushd "${prepped_submodule_path}" &> /dev/null
         # Re-establish url in case it changed
-        ${GIT} remote set-url origin "${submodule_url}"
+        "${GIT}" remote set-url origin "${submodule_url}"
         # Fetch the latest changes
         if meet_requirements "${GIT_VERSION}" ">=2.17"; then
-          ${GIT} fetch -pP origin
+          "${GIT}" fetch -pP origin
         else
-          ${GIT} fetch -p origin
+          "${GIT}" fetch -p origin
         fi
       popd &> /dev/null
     else
       prepped_submodule_path="$(mktemp_compat "${GIT_MIRROR_PREP_DIR}")/${full_relative_path}"
       next_section "Cloning a fresh copy of ${full_relative_path}"
-      ${GIT} clone --mirror "${submodule_url}" "${prepped_submodule_path}"
+      "${GIT}" clone --mirror "${submodule_url}" "${prepped_submodule_path}"
     fi
 
     # Set the local non-bare repo's url to point to the prepped mirror (so that
@@ -277,9 +250,9 @@ function clone_submodules()
       TEMP_DIR="${TEMP_DIR}"/"$(basename "${prepped_submodule_path}")"
       cp -a "${prepped_submodule_path}" "${TEMP_DIR}"
 
-      ${GIT} config "${submodule}.url" "${TEMP_DIR}"
+      "${GIT}" config "${submodule}.url" "${TEMP_DIR}"
     else
-      ${GIT} config "${submodule}.url" "${prepped_submodule_path}"
+      "${GIT}" config "${submodule}.url" "${prepped_submodule_path}"
     fi
   done
 
@@ -290,9 +263,9 @@ function clone_submodules()
   # This flag gets translated to the --depth flag, which is ignored for local
   # clones
   # RE This optimization does not seem worth it for a local clone
-  GIT_LFS_SKIP_SMUDGE=1 ${GIT} submodule update
+  GIT_LFS_SKIP_SMUDGE=1 "${GIT}" submodule update
   # Restore the origin urls after update, so that relative URLs work
-  ${GIT} submodule sync
+  "${GIT}" submodule sync
 
   if git_mirror_has_lfs; then
     next_section "Fetching lfs objects for ${prefix-${displaypath-${GIT_MIRROR_MAIN_REPO}}}"
@@ -303,7 +276,7 @@ function clone_submodules()
       prepped_submodule_path="$(dirname "$(shopt -s nullglob; echo "${GIT_MIRROR_PREP_DIR}"/*/"${base_submodule_path}/config")")"
     fi
 
-    local lfs_dir="$(${GIT} rev-parse --git-dir)/lfs"
+    local lfs_dir="$("${GIT}" rev-parse --git-dir)/lfs"
     # Incase it it doesn't exist
     mkdir -p "${lfs_dir}" "${prepped_submodule_path}/lfs/"
 
@@ -322,7 +295,7 @@ function clone_submodules()
       ln -s "${prepped_submodule_path}/lfs" "${lfs_dir}"
     fi
 
-    ${GIT} lfs fetch --all
+    "${GIT}" lfs fetch --all
 
     if [[ ${OS-} = "Windows_NT" && -n $(ls -A "${lfs_dir}") ]]; then
       cp -a "${lfs_dir}"/* "${prepped_submodule_path}/lfs/"
@@ -348,7 +321,7 @@ function clone_submodules()
   # get_config_submodule_names (which uses git config and works with init-only
   # submodules) and, here, with git submodule foreach (which does not).
   # NOTE We could make a similar change in update_submodules
-  GIT_MIRROR_PREP_DIR="${GIT_MIRROR_PREP_DIR}" base_submodule_path="${base_submodule_path}" ${GIT} submodule foreach --quiet "export prefix displaypath; bash -euc 'unset GIT_DIR; source \"${GIT_MIRROR_SOURCE[0]}\"; clone_submodules'"
+  GIT_MIRROR_PREP_DIR="${GIT_MIRROR_PREP_DIR}" base_submodule_path="${base_submodule_path}" "${GIT}" submodule foreach --quiet "export prefix displaypath; bash -euc 'unset GIT_DIR; source \"${GIT_MIRROR_SOURCE[0]}\"; clone_submodules'"
   # The "unset GIT_DIR" is needed because somewhere between git 2.17 and 2.21,
   # git-submodule-foreach started setting the GIT_DIR; however, the logic here
   # is constantly switching directories into different repositories &
@@ -385,22 +358,22 @@ function update_submodules()
 
   # This is only done once when initially cloning the repo, so should not need
   # a sync
-  ${GIT} submodule init
+  "${GIT}" submodule init
   local IFS=$'\n'
   local submodule_names=($(get_config_submodule_names))
 
   for submodule_name in ${submodule_names[@]+"${submodule_names[@]}"}; do
-    full_relative_path="${base_submodule_path}${base_submodule_path:+/}$(${GIT} config -f .gitmodules ${submodule_name}.path)"
-    ${GIT} config "${submodule_name}.url" "$(_git_mirror_get_url "${full_relative_path}")"
+    full_relative_path="${base_submodule_path}${base_submodule_path:+/}$("${GIT}" config -f .gitmodules ${submodule_name}.path)"
+    "${GIT}" config "${submodule_name}.url" "$(_git_mirror_get_url "${full_relative_path}")"
   done
   next_section "Updating ${current_repo}'s submodules"
-  ${GIT} submodule update
+  "${GIT}" submodule update
 
   # And the recursion goes on... foreach runs in sh, so I'm forcing bash. I need
   # to pass the prefix/displaypath variables from git into the called function,
   # so export them.
   base_submodule_path="${base_submodule_path-}" \
-      ${GIT} submodule foreach --quiet "export prefix displaypath; bash -euc \
+      "${GIT}" submodule foreach --quiet "export prefix displaypath; bash -euc \
           'unset GIT_DIR; source \"${GIT_MIRROR_SOURCE[0]}\"; update_submodules \"${1}\"'"
 }
 
@@ -515,7 +488,7 @@ function git_mirror_repos()
     # Don't need nullglob here because the directory exists
     pushd "$(dirname "${1}/"*"/config")" &> /dev/null
       GIT_MIRROR_PREP_DIR="${GIT_MIRROR_PREP_DIR:-"$(dirname "${PWD}")"}"
-      GIT_MIRROR_MAIN_REPO="$(${GIT} config --get remote.origin.url)"
+      GIT_MIRROR_MAIN_REPO="$("${GIT}" config --get remote.origin.url)"
     popd &> /dev/null
   else
     GIT_MIRROR_MAIN_REPO="${1}"
@@ -550,16 +523,16 @@ function git_mirror_repos()
   mkdir -p "${GIT_MIRROR_PREP_DIR}"
   if [ ! -e "${GIT_MIRROR_PREP_DIR}/${MAIN_DIR}" ]; then
     next_section "Cloning super project ${GIT_MIRROR_MAIN_REPO}..."
-    ${GIT} clone --mirror "${GIT_MIRROR_MAIN_REPO}" "${GIT_MIRROR_PREP_DIR}/${MAIN_DIR}"
+    "${GIT}" clone --mirror "${GIT_MIRROR_MAIN_REPO}" "${GIT_MIRROR_PREP_DIR}/${MAIN_DIR}"
   else
     next_section "Fetching for super project ${GIT_MIRROR_MAIN_REPO} using last run..."
     pushd "${GIT_MIRROR_PREP_DIR}/${MAIN_DIR}" &> /dev/null
       # Re-establish url in case it changed
-      ${GIT} remote set-url origin "${GIT_MIRROR_MAIN_REPO}"
+      "${GIT}" remote set-url origin "${GIT_MIRROR_MAIN_REPO}"
       if meet_requirements "${GIT_VERSION}" ">=2.17"; then
-        ${GIT} fetch -pP origin
+        "${GIT}" fetch -pP origin
       else
-        ${GIT} fetch -p origin
+        "${GIT}" fetch -p origin
       fi
     popd &> /dev/null
   fi
@@ -575,17 +548,17 @@ function git_mirror_repos()
   if tar_feature_incremental_backup; then
     # Clone without hardlinks because they mess up the incremental archive
     # (see clone_submodules)
-    GIT_LFS_SKIP_SMUDGE=1 ${GIT} clone --no-hardlinks "${GIT_MIRROR_PREP_DIR}/${MAIN_DIR}" "${TEMP_DIR}"
+    GIT_LFS_SKIP_SMUDGE=1 "${GIT}" clone --no-hardlinks "${GIT_MIRROR_PREP_DIR}/${MAIN_DIR}" "${TEMP_DIR}"
   else
-    GIT_LFS_SKIP_SMUDGE=1 ${GIT} clone "${GIT_MIRROR_PREP_DIR}/${MAIN_DIR}" "${TEMP_DIR}"
+    GIT_LFS_SKIP_SMUDGE=1 "${GIT}" clone "${GIT_MIRROR_PREP_DIR}/${MAIN_DIR}" "${TEMP_DIR}"
   fi
 
   pushd "${TEMP_DIR}" &> /dev/null
     # The local non-bare repo doesn't need to waste time copying LFS objects
-    GIT_LFS_SKIP_SMUDGE=1 ${GIT} checkout "${BRANCH}"
+    GIT_LFS_SKIP_SMUDGE=1 "${GIT}" checkout "${BRANCH}"
 
     # Restore origin to not point to mirror, so relative submodules work right
-    ${GIT} remote set-url origin "${GIT_MIRROR_MAIN_REPO}"
+    "${GIT}" remote set-url origin "${GIT_MIRROR_MAIN_REPO}"
 
     # This effectively does git submodule update --recursive --init,
     # but plumbs the submodules to use the "${GIT_MIRROR_PREP_DIR}" instead
@@ -773,7 +746,7 @@ function git_clone_main()
   mkdir -p "${2-.}"
   pushd "${2-.}" &> /dev/null
     if [ ! -d ./.git ]; then
-      ${GIT} clone "$(_git_mirror_get_url .)" .
+      "${GIT}" clone "$(_git_mirror_get_url .)" .
     fi
     update_submodules "${1}"
   popd &> /dev/null
@@ -843,14 +816,14 @@ function git_push_main()
           #
           # Push to the mirror (git push --mirror will remove deleted refs)
           # Spaces are not allowed in a refname
-          ${GIT} for-each-ref --format='%(refname)' | grep -v -e '^refs/remotes' -e '^refs/stash' | \
-              xargs ${GIT} push "${repo_urls[$index]}"
+          "${GIT}" for-each-ref --format='%(refname)' | grep -v -e '^refs/remotes' -e '^refs/stash' | \
+              xargs "${GIT}" push "${repo_urls[$index]}"
 
           if git_mirror_has_lfs; then
             next_section "Pushing lfs objects for ${repo_path}"
-            ${GIT} remote add mirror "${repo_urls[$index]}" 2>/dev/null || ${GIT} remote set-url mirror "${repo_urls[$index]}"
+            "${GIT}" remote add mirror "${repo_urls[$index]}" 2>/dev/null || "${GIT}" remote set-url mirror "${repo_urls[$index]}"
             # Does not work on file systems, only with real lfs servers, unless you set up lfs-filestore
-            ${GIT} lfs push mirror --all || :
+            "${GIT}" lfs push mirror --all || :
           fi
         popd &> /dev/null
       else

--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -11,6 +11,7 @@ fi
 source "${VSI_COMMON_DIR}/linux/mount_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/set_flags.bsh"
 source "${VSI_COMMON_DIR}/linux/elements.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 source "${VSI_COMMON_DIR}/linux/just_files/container_functions.bsh"
 
 source "${VSI_COMMON_DIR}/linux/circular_source.bsh"

--- a/linux/just_files/docker_functions.bsh
+++ b/linux/just_files/docker_functions.bsh
@@ -12,6 +12,7 @@ source "${VSI_COMMON_DIR}/linux/mount_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/just_files/docker_compose_override"
 source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 
 #*# just/plugins/docker/docker_functions
 
@@ -26,33 +27,6 @@ source "${VSI_COMMON_DIR}/linux/compat.bsh"
 #
 # Set of functions to make using dockers easier
 #
-# .. envvar:: DOCKER
-#
-# Name/path of docker executable
-#
-# Instead of hard-coding "docker" everywhere, use the variable :envvar:`DOCKER` so that
-# when the need comes, it is easier to switch which executable gets called.
-#**
-
-: ${DOCKER=docker}
-
-#**
-# .. envvar:: NVIDIA_DOCKER
-#
-# Name/path of nvidia-docker executable
-#
-# Instead of hard-coding "nvidia-docker" everywhere, use the variable
-# :envvar:`NVIDIA_DOCKER` so that when the need comes, it is easier to switch which
-# executable gets called. Default to :envvar:`DOCKER` if nvidia-docker executable is not
-# in the path (hash-able)
-#**
-
-: ${NVIDIA_DOCKER=nvidia-docker}
-if ! hash ${NVIDIA_DOCKER} 2> /dev/null; then
-  NVIDIA_DOCKER=${DOCKER}
-fi
-
-#**
 # .. var:: DOCKER_VOLUME_PATTERN
 #
 # Regex pattern for matching docker volume short form
@@ -464,22 +438,6 @@ function parse-docker()
 }
 
 #**
-# .. function:: Exec-Nvidia-Docker
-#
-# Version of Docker for Nvidia and ``exec``'s
-#**
-
-function Exec-Nvidia-docker(){ DOCKER_EXEC=1 Nvidia-Docker "${@}";}
-
-#**
-# .. function:: Nvidia-Docker
-#
-# Version of Docker for Nvidia
-#**
-
-function Nvidia-docker(){ DOCKER="${NVIDIA_DOCKER}" Docker "${@}";}
-
-#**
 # .. function:: Exec-Docker
 #
 # Version of Docker that ``exec``'s the command rather than call
@@ -524,7 +482,7 @@ function Docker()
 function _Docker()
 {
   local docker_extra_command_args=()
-  local cmd=(${DRYRUN} ${DOCKER})
+  local cmd=(${DRYRUN} "${DOCKER}")
   local extra_args_var
 
   if [ "${docker_command}" = "run" ] && [ "${DOCKER_AUTOREMOVE-1}" == "1" ]; then
@@ -554,18 +512,6 @@ function _Docker()
 ######################
 ### docker-compose ###
 ######################
-
-#**
-# .. envvar:: DOCKER_COMPOSE
-#
-# Name/path of docker-compose executable
-#
-# Instead of hard-coding "docker-compose" everywhere, use the variable
-# :envvar:`DOCKER_COMPOSE` so that when the need comes, it is easier to switch which
-# executable gets called
-#**
-
-: ${DOCKER_COMPOSE=docker-compose}
 
 #**
 # .. function:: docker-compose-volumes-old
@@ -1137,7 +1083,7 @@ function Docker-compose()
 function _Docker-compose()
 {
   local docker_compose_extra_command_args=()
-  local cmd=(${DRYRUN} ${DOCKER_COMPOSE})
+  local cmd=(${DRYRUN} "${DOCKER_COMPOSE}")
   local extra_args_var
 
   if [ "${docker_compose_command}" = "run" ] && [ "${DOCKER_COMPOSE_AUTOREMOVE-1}" == "1" ]; then
@@ -1353,8 +1299,8 @@ function Just-docker-compose()
 
 function docker_service_running()
 {
-  ${DOCKER} inspect -f '{{.State.Status}}' \
-            $(${DOCKER_COMPOSE} ps -q ${@+"${@}"}) 2>/dev/null
+  "${DOCKER}" inspect -f '{{.State.Status}}' \
+              $("${DOCKER_COMPOSE}" ps -q ${@+"${@}"}) 2>/dev/null
 }
 
 #**

--- a/linux/just_files/just_env
+++ b/linux/just_files/just_env
@@ -5,6 +5,8 @@ if [ -z ${VSI_COMMON_DIR+set} ]; then
 fi
 
 # Source the environment
+# This disables the smart mechanism in env.bsh that prevents multiple sourcing of env.bsh
+unset unsetup_vsi_common
 source "${VSI_COMMON_DIR}/env.bsh"
 source "${VSI_COMMON_DIR}/linux/just_files/just_functions.bsh"
 
@@ -39,13 +41,13 @@ source "${VSI_COMMON_DIR}/linux/just_files/just_functions.bsh"
 #   :envvar:`VSI_PATH_ESC`
 #**
 
-if [[ ${OS-} == Windows_NT && ! ${OSTYPE-} == cygwin* ]]; then
+if [ "${OS-}" = "Windows_NT" ] && [[ ! ${OSTYPE-} == cygwin* ]]; then
   export JUST_PATH_ESC='/'
 else
   export JUST_PATH_ESC=''
 fi
 source_environment_files "${1}"
 
-if [[ ${OS-} == Windows_NT ]]; then
+if [ "${OS-}" = "Windows_NT" ]; then
   auto_path_escape
 fi

--- a/linux/just_files/just_git_functions.bsh
+++ b/linux/just_files/just_git_functions.bsh
@@ -7,6 +7,7 @@ fi
 source "${VSI_COMMON_DIR}/linux/ask_question"
 source "${VSI_COMMON_DIR}/linux/colors.bsh"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 source "${VSI_COMMON_DIR}/linux/set_flags.bsh"
 
 #*# just/plugins/just_git_functions
@@ -25,21 +26,6 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 #
 # git plugin for just
 #**
-
-#**
-# .. var:: GIT
-#
-# Name/path of git executable
-#
-# Instead of hard-coding "git" everywhere, use the variable :var:`GIT` so that when the need comes, it is easier to switch which executable gets called. Set to empty string to have any calls to git skipped.
-#
-# All :func:`git_defaultify` targets will be skipped if the value of :var:`GIT` is not found or empty.
-#
-# .. note::
-#   When using the GIT env variable in this file, do not surround it with quotes as you normally would. Although this prevents using a path to ``git`` with a space in it, in exchange, it is possible to enable a dry-run-ish capability if GIT is set to 'echo git'.
-#**
-
-: ${GIT=git}
 
 #**
 # .. function:: submodule-helper-list
@@ -62,7 +48,7 @@ function submodule-helper-list()
 {
   # Get submodule data
   local IFS=$'\n'
-  local submodule_data=($(${GIT} config -l -f .gitmodules | \
+  local submodule_data=($("${GIT}" config -l -f .gitmodules | \
       sed -n${sed_flag_rE} 's|^submodule.(.*).path=(.*)|\1'$'\\\n''\2|p'))
   # Parse submodule data
   # Git submodules can't have newlines in the "name" nor (realistically) "path",
@@ -152,18 +138,18 @@ function _checkout_git_submodule()
 {
   popd > /dev/null
 
-  if ! ${GIT} -c foo=bar version &> /dev/null || \
+  if ! "${GIT}" -c foo=bar version &> /dev/null || \
      ! git_feature_submodule_update_with_custom_command; then
     # This is older than 1.8 so it doesn't support -c OR submodule.${1}.update
     echo "${YELLOW}Warning:${NC} your version of git is too old. Doing normal submodule update" >&2
 
-    local tracked_sha="$(${GIT} submodule status --cached "${2}" | cut -c2- | awk '{print $1}')"
+    local tracked_sha="$("${GIT}" submodule status --cached "${2}" | cut -c2- | awk '{print $1}')"
     if ! _is_tip_reachable "${2}" "${tracked_sha}"; then
       pushd "${2}" &> /dev/null
-        ${GIT} fetch "${JUST_GIT_UPSTREAM-just_upstream}"
+        "${GIT}" fetch "${JUST_GIT_UPSTREAM-just_upstream}"
       popd &> /dev/null
     fi
-    if ${GIT} submodule update "${2}"; then
+    if "${GIT}" submodule update "${2}"; then
       if [ -f "${2}/.gitmodules" ]; then
         pushd "${2}" &> /dev/null
         show_summary_message=0 safe_git_submodule_update
@@ -175,7 +161,7 @@ function _checkout_git_submodule()
       echo
     fi
   else
-    if PATH="${VSI_COMMON_DIR}/linux:${PATH}" ${GIT} -c "submodule.${1}.update"='!bash git_safe_update' submodule update --no-fetch "${2}"; then
+    if PATH="${VSI_COMMON_DIR}/linux:${PATH}" "${GIT}" -c "submodule.${1}.update"='!bash git_safe_update' submodule update --no-fetch "${2}"; then
       if [ -f "${2}/.gitmodules" ]; then
         pushd "${2}" &> /dev/null
         show_summary_message=0 safe_git_submodule_update
@@ -245,10 +231,10 @@ function safe_git_submodule_update()
       name="${submodule_names[$i]}"
       sm_path="${submodule_paths[$i]}"
 
-      if ! ${GIT} config submodule."$name".url > /dev/null; then
-        if [ "$(${GIT} ls-tree HEAD:"$(dirname "${sm_path}")"/ "$(basename "${sm_path}")" | awk '{print $2}')" == "commit" ]; then
+      if ! "${GIT}" config submodule."$name".url > /dev/null; then
+        if [ "$("${GIT}" ls-tree HEAD:"$(dirname "${sm_path}")"/ "$(basename "${sm_path}")" | awk '{print $2}')" == "commit" ]; then
           echo "Uninitialized submodule '${name}'...Initializing"
-          ${GIT} submodule init $sm_path
+          "${GIT}" submodule init $sm_path
         else
           # There are cases where novices remove a submodule and forget to
           # remove it from the .gitmodules files. In this case, it will show up
@@ -259,17 +245,17 @@ function safe_git_submodule_update()
           continue
         fi
       fi
-      current_submodule_url="$(${GIT} config submodule."${name}".url)"
+      current_submodule_url="$("${GIT}" config submodule."${name}".url)"
       # Initialize (and update) the submodule if it is not already
       if [ -z "${current_submodule_url}" ] || \
         ([ ! -d "$sm_path"/.git ] && [ ! -f "$sm_path"/.git ]); then
-        if ! [ "$(${GIT} config -f .gitmodules "submodule.${name}.update")" == "none" ]; then
+        if ! [ "$("${GIT}" config -f .gitmodules "submodule.${name}.update")" == "none" ]; then
           echo "Submodule '${name}' is not checked out! Initializing and updating..."
-          ${GIT} submodule update --init "${sm_path}"
+          "${GIT}" submodule update --init "${sm_path}"
           pushd "${sm_path}" &> /dev/null
           # Go ahead and setup this remote
-           ${GIT} config remote."${JUST_GIT_UPSTREAM-just_upstream}".url \
-              "$(${GIT} config remote.origin.url)"
+           "${GIT}" config remote."${JUST_GIT_UPSTREAM-just_upstream}".url \
+              "$("${GIT}" config remote.origin.url)"
           popd &> /dev/null
         fi
         continue
@@ -286,16 +272,16 @@ function safe_git_submodule_update()
       # .gitmodules file and the default remote of the current branch, if set;
       # otherwise origin.
       pushd "${sm_path}" > /dev/null
-        local current_branch="$(${GIT} rev-parse --abbrev-ref HEAD)"
-        local default_remote="$(${GIT} config branch."${current_branch}".remote || echo origin)"
-        current_remote_url="$(${GIT} config remote."${default_remote}".url)"
-        current_just_upstream_url="$(${GIT} config remote."${JUST_GIT_UPSTREAM-just_upstream}".url || :)"
+        local current_branch="$("${GIT}" rev-parse --abbrev-ref HEAD)"
+        local default_remote="$("${GIT}" config branch."${current_branch}".remote || echo origin)"
+        current_remote_url="$("${GIT}" config remote."${default_remote}".url)"
+        current_just_upstream_url="$("${GIT}" config remote."${JUST_GIT_UPSTREAM-just_upstream}".url || :)"
       popd > /dev/null
 
       # sync with the .gitmodules file
-      ${GIT} submodule sync --quiet "${sm_path}"
+      "${GIT}" submodule sync --quiet "${sm_path}"
       # Get the updated URL
-      updated_submodule_url="$(${GIT} config submodule."$name".url)"
+      updated_submodule_url="$("${GIT}" config submodule."$name".url)"
 
       # Arguably, if the submodule's URL changed in the .gitmodules file, we
       # should leave these changes to the remote, but we cannot differentiate
@@ -315,24 +301,24 @@ function safe_git_submodule_update()
       # git submodule sync dies if there are multiple URLs (e.g.,
       # git config --get-all submodule.<name>.url or
       # git config --get-all remote.origin.url)
-      ${GIT} config submodule."$name".url "${current_submodule_url}"
+      "${GIT}" config submodule."$name".url "${current_submodule_url}"
       # Reset the default remote
       pushd "${sm_path}" > /dev/null
-        ${GIT} remote set-url "${default_remote}" "${current_remote_url}"
+        "${GIT}" remote set-url "${default_remote}" "${current_remote_url}"
       popd > /dev/null
 
       pushd "${sm_path}" > /dev/null
         # This is my equivalent to "git submodule sync". It uses a specific remote
         # that it not one of the defaults to handle issue #186
-        ${GIT} remote add "${JUST_GIT_UPSTREAM-just_upstream}" "${updated_submodule_url}" &> /dev/null || \
-          ${GIT} remote set-url "${JUST_GIT_UPSTREAM-just_upstream}" "${updated_submodule_url}"
+        "${GIT}" remote add "${JUST_GIT_UPSTREAM-just_upstream}" "${updated_submodule_url}" &> /dev/null || \
+          "${GIT}" remote set-url "${JUST_GIT_UPSTREAM-just_upstream}" "${updated_submodule_url}"
 
-        if ! ${GIT} diff --no-ext-diff --quiet; then
+        if ! "${GIT}" diff --no-ext-diff --quiet; then
           echo "Uncommited tracked files in '${sm_path}'"
           _checkout_git_submodule "${name}" "${sm_path}" "You need to add or discard changes in submodule '${name}'"
           continue
         fi
-        if ! ${GIT} diff --no-ext-diff --cached --quiet; then
+        if ! "${GIT}" diff --no-ext-diff --cached --quiet; then
           echo "Staged tracked files in '${sm_path}'"
           echo "You need to commit/reset files in submodule '${name}'"
           # REVIEW Seems like we should be able to try _checkout_git_submodule;
@@ -342,8 +328,8 @@ function safe_git_submodule_update()
           continue
         fi
         # Removed the -- to be compatible with slightly older git versions. Should work on newer
-        # if ${GIT} ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch -- ':/*' >/dev/null 2>/dev/null; then
-        if ${GIT} ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch ':/*' >/dev/null 2>/dev/null; then
+        # if "${GIT}" ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch -- ':/*' >/dev/null 2>/dev/null; then
+        if "${GIT}" ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch ':/*' >/dev/null 2>/dev/null; then
           echo "Untracked files in '${sm_path}'"
           _checkout_git_submodule "${name}" "${sm_path}" \
             "You need to resolve any conflicts in submodule '${name}'"
@@ -357,7 +343,7 @@ function safe_git_submodule_update()
   if [ "${show_summary_message-0}" == "1" ]; then
     local IFS=$'\n'
     local message_printed=0
-    for i in $(${GIT} submodule status --recursive | \grep ^+ || :); do
+    for i in $("${GIT}" submodule status --recursive | \grep ^+ || :); do
       i="${i% *}"
       i="${i#* }"
       echo
@@ -406,12 +392,12 @@ function safe_git_submodule_update()
 git_reattach_heads()
 {
   # git submodule foreach must be run from the top-level working tree in git 1.8
-  pushd "$(${GIT} rev-parse --show-cdup)" &> /dev/null
+  pushd "$("${GIT}" rev-parse --show-cdup)" &> /dev/null
     local submodule_paths
     if [ $# -eq 0 ]; then
       local OLD_IFS="${IFS}"
       IFS=$'\n'
-      submodule_paths=($(${GIT} submodule foreach --quiet --recursive 'echo "${prefix-${displaypath}}"'))
+      submodule_paths=($("${GIT}" submodule foreach --quiet --recursive 'echo "${prefix-${displaypath}}"'))
       IFS="${OLD_IFS}"
     else
       submodule_paths=("${@}")
@@ -421,11 +407,11 @@ git_reattach_heads()
     for submodule_path in "${submodule_paths[@]}"; do
       pushd "${submodule_path}" &>/dev/null
         # If detached, get SHA & first branch name, and then reattach
-        if [ "$(${GIT} rev-parse --abbrev-ref --symbolic-full-name HEAD)" = "HEAD" ]; then
-          local current_sha="$(${GIT} rev-parse HEAD)"
-          local branch_name="$(${GIT} show-ref --heads | sed -n${sed_flag_rE} "/^${current_sha} .*/{ s|.*/(.*)|\1|; p; q;}")"
+        if [ "$("${GIT}" rev-parse --abbrev-ref --symbolic-full-name HEAD)" = "HEAD" ]; then
+          local current_sha="$("${GIT}" rev-parse HEAD)"
+          local branch_name="$("${GIT}" show-ref --heads | sed -n${sed_flag_rE} "/^${current_sha} .*/{ s|.*/(.*)|\1|; p; q;}")"
           if [ "${branch_name}" != "" ]; then
-            ${GIT} checkout "${branch_name}"
+            "${GIT}" checkout "${branch_name}"
           fi
         fi
       popd &>/dev/null
@@ -465,7 +451,7 @@ function git_defaultify()
                           # tracking branch.
       extra_args=$#
 
-      if ! command -v ${GIT} >& /dev/null; then
+      if ! command -v "${GIT}" >& /dev/null; then
         echo "Git not found, skipping submodule sync" >&2
         return 0
       fi
@@ -496,7 +482,7 @@ function git_defaultify()
                                   # mounting into a docker. Resets modules \
                                   # relative to the $(pwd), so you should \
                                   # be in the main repo's base directory.
-      if ! command -v ${GIT} >& /dev/null; then
+      if ! command -v "${GIT}" >& /dev/null; then
         echo "Git not found, skipping submodule conversion" >&2
         return 0
       fi
@@ -513,7 +499,7 @@ function git_defaultify()
         exit 1
       fi
 
-      ${GIT} submodule foreach --recursive bash -c '
+      "${GIT}" submodule foreach --recursive bash -c '
       if [ -f .git ]; then
         submodule_path=$(cut -d" " -f2- .git)
         echo "gitdir: $('"${code}"')" > .git

--- a/linux/just_files/singularity_functions.bsh
+++ b/linux/just_files/singularity_functions.bsh
@@ -27,15 +27,6 @@ source "${VSI_COMMON_DIR}/linux/compat_singularity.bsh"
 #
 # Set of functions to make using singularity easier
 #
-# .. envvar:: SINGULARITY
-#
-# Name/path of singularity executable
-#
-# Instead of hard-coding "singularity" everywhere, use the variable :envvar:`SINGULARITY` so that when the need comes, it is easier to switch which executable gets called.
-#**
-: ${SINGULARITY=singularity}
-
-#**
 # .. var:: SINGULARITY_INSTANCE_NAME_REGEX
 #
 # Regex to validate singularity instance names against
@@ -74,7 +65,7 @@ function Singularity()
 function _Singularity()
 {
   local singularity_extra_command_args=()
-  local cmd=(${DRYRUN-} ${SINGULARITY})
+  local cmd=(${DRYRUN-} "${SINGULARITY}")
   local extra_args_var
 
   compose_arguments "SINGULARITY_EXTRA_ARGS" "SINGULARITY_EXTRA_$(uppercase "${subcommand-none}")_ARGS"

--- a/linux/just_git_airgap_repo.bsh
+++ b/linux/just_git_airgap_repo.bsh
@@ -17,6 +17,7 @@ source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/findin"
 source "${VSI_COMMON_DIR}/linux/command_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/string_tools.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 
 #*# just/plugins/just_git_airgap_repo
 
@@ -119,22 +120,6 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 #**
 
 #**
-# .. envvar:: GIT
-#
-# Name/path of git executable
-#
-# Instead of hard-coding "git" everywhere, use the variable :envvar:`GIT` so that when the need comes, it is easier to switch which executable gets called. Set to empty string to have any calls to git skipped.
-#
-# All :func:`relocate_git_defaultify` targets will be skipped if the value of :envvar:`GIT` is not found or empty.
-#
-# .. note::
-#
-#   When using the GIT env variable in this file, do not surround it with quotes as you normally would. Although this prevents using a path to ``git`` with a space in it, in exchange, it may be possible (eventually) to enable a dry-run-ish capability if GIT is set to ``echo git``.
-#**
-
-: ${GIT=git}
-
-#**
 # .. function:: log_unpushed_commits
 #
 # List all unpushed commits to stdout
@@ -164,7 +149,7 @@ function log_unpushed_commits()
     branch=("${2}")
   fi
 
-  local commits="$(${GIT} log --decorate --graph --format=short --color=always \
+  local commits="$("${GIT}" log --decorate --graph --format=short --color=always \
       "${branch[@]}" --not --remotes="${remote_name}")"
 
   _log_commits_helper "unpushed" "${commits}"
@@ -228,7 +213,7 @@ function get_tracking_branches()
   if [ $# -lt 2 ]; then
     local OLD_IFS="${IFS}"
     IFS=$'\n'
-    branches=($(${GIT} for-each-ref --format='%(refname:short)' refs/heads))
+    branches=($("${GIT}" for-each-ref --format='%(refname:short)' refs/heads))
     IFS="${OLD_IFS}"
   else
     branches=("${2}")
@@ -243,7 +228,7 @@ function get_tracking_branches()
     # git rev-parse will error if the branch doesn't exist or has been pruned;
     # although unfortunately, it is same error code in both cases. The stderr
     # could be parsed to differentiate...
-    remote_branch="$(${GIT} rev-parse --abbrev-ref "${branch}"@{upstream} 2> /dev/null)" || remote_branch_rv=$?
+    remote_branch="$("${GIT}" rev-parse --abbrev-ref "${branch}"@{upstream} 2> /dev/null)" || remote_branch_rv=$?
     if [ "${remote_branch_rv}" -ne 0 ]; then
       continue
     fi
@@ -326,7 +311,7 @@ function log_outgoing_commits()
   local tracking_branch
   local commits=()
   for tracking_branch in ${tracking_branches+"${tracking_branches[@]}"}; do
-    commits+=("$(${GIT} log --decorate --graph --format=short --color=always \
+    commits+=("$("${GIT}" log --decorate --graph --format=short --color=always \
         "${tracking_branch}"@{upstream}.."${tracking_branch}")")
   done
   local OLD_IFS="${IFS}"
@@ -356,12 +341,12 @@ function convert_git_remote_http_to_git()
   local remote_name="${1-origin}"
 
   # Don't do anything if a pushurl is already configured
-  if ${GIT} config --get remote."${remote_name}".pushurl &> /dev/null; then
+  if "${GIT}" config --get remote."${remote_name}".pushurl &> /dev/null; then
     echo "Skipping: pushurl already configured"
     return
   fi
 
-  local remote_url="$(${GIT} config --get remote."${remote_name}".url)"
+  local remote_url="$("${GIT}" config --get remote."${remote_name}".url)"
 
   local remote_git_url_rv=0
   local remote_git_url
@@ -371,10 +356,10 @@ function convert_git_remote_http_to_git()
     # NOTE since git 1.8, a remote (e.g., origin) can have multiple associated
     # pushurls (see .git/config:remote)
     # RE providing the old url (remote_url) will update the correct url
-    #${GIT} remote set-url "${remote_name}" --push "${remote_git_url}" "${remote_url}"
+    #"${GIT}" remote set-url "${remote_name}" --push "${remote_git_url}" "${remote_url}"
     # RE If a pushurl is configured, this function returns early; therefore,
     # assume a pushurl is not configured
-    ${GIT} remote set-url "${remote_name}" --push "${remote_git_url}"
+    "${GIT}" remote set-url "${remote_name}" --push "${remote_git_url}"
   else # See if URL is already in the expected format
     # This is very simple; basically undo the simple transform done here.
     # Perhaps one day we will have a git remote url parser in parser.bsh
@@ -424,16 +409,16 @@ function _http_to_git_protocol()
 
 function is_submodule()
 {
-  local toplevel="$(${GIT} rev-parse --show-toplevel 2> /dev/null)"
+  local toplevel="$("${GIT}" rev-parse --show-toplevel 2> /dev/null)"
   # Strip trailing / (this may be guaranteed by --show-toplevel)
   toplevel="${toplevel%/}"
   local sm_basename="$(basename "${toplevel}")"
   local is_submod=1
   pushd "${toplevel}/../" &> /dev/null
     # Are we still in a git repo
-    local superlevel="$(${GIT} rev-parse --show-toplevel 2> /dev/null)"
+    local superlevel="$("${GIT}" rev-parse --show-toplevel 2> /dev/null)"
     if [ -n "${superlevel:+set}" ]; then
-      local prefix="$(${GIT} rev-parse --show-prefix)"
+      local prefix="$("${GIT}" rev-parse --show-prefix)"
       # Guarantee a trailing / or empty string (this may be guaranteed by
       # --show-prefix)
       prefix="${prefix:+"${prefix%/}/"}"
@@ -444,7 +429,7 @@ function is_submodule()
         #
         # Strip trailing / (this may be guaranteed by sm_path)
         # real_path may be necessary to ensure the grep succeeds
-        if ${GIT} submodule foreach 'echo "${sm_path%/}"' | \
+        if "${GIT}" submodule foreach 'echo "${sm_path%/}"' | \
             grep "${prefix}${sm_basename}" &> /dev/null; then
           is_submod=0
         fi
@@ -492,7 +477,7 @@ function is_submodule()
 
 function git_project_root_dir()
 {
-  local toplevel="$(${GIT} rev-parse --show-toplevel 2> /dev/null)"
+  local toplevel="$("${GIT}" rev-parse --show-toplevel 2> /dev/null)"
   if is_submodule; then
     pushd "${toplevel}/../" &> /dev/null
       git_project_root_dir
@@ -513,15 +498,15 @@ function git_project_root_dir()
 function git_project_git_dir()
 {
   # In a bare repository or a .git directory
-  if [ "$(${GIT} rev-parse --is-inside-git-dir)" == "true" ]; then
-    local dir="$(${GIT} rev-parse --git-dir)"
+  if [ "$("${GIT}" rev-parse --is-inside-git-dir)" == "true" ]; then
+    local dir="$("${GIT}" rev-parse --git-dir)"
     if [ "${dir}" == "." ]; then
       echo "${PWD}"
     else
       echo "${dir}"
     fi
   # In a work tree
-  elif [ "$(${GIT} rev-parse --is-inside-work-tree)" ]; then
+  elif [ "$("${GIT}" rev-parse --is-inside-work-tree)" ]; then
     local project_dir="$(git_project_root_dir)"
     pushd "${project_dir}" &> /dev/null
       if [ -f .git ]; then
@@ -576,10 +561,10 @@ function submodule_summary()
 
   local sm_key
   for sm_key in ${submodule_keys[@]+"${submodule_keys[@]}"}; do
-    local sm_path="$(${GIT} config --file .gitmodules --get submodule."${sm_key}".path)"
+    local sm_path="$("${GIT}" config --file .gitmodules --get submodule."${sm_key}".path)"
 
     # Cf. git submodule summary - doesn't show modified/staged content
-    ${GIT} diff --submodule=log "${sm_path}"
+    "${GIT}" diff --submodule=log "${sm_path}"
 
     if [ -n "${RECURSIVE:+set}" ]; then
       pushd "${sm_path}" &>/dev/null
@@ -625,9 +610,9 @@ function get_submodule_displaypaths()
   fi
 
   # Relative path from the CWD to the root of the current repository
-  local up_path="$(${GIT} rev-parse --show-cdup)"
+  local up_path="$("${GIT}" rev-parse --show-cdup)"
   # Relative path from the root of the current repository to the CWD
-  local relative_cwd="$(${GIT} rev-parse --show-prefix)"
+  local relative_cwd="$("${GIT}" rev-parse --show-prefix)"
   # Guarantee a trailing / or empty string (this may be guaranteed by
   # --show-cdup)
   up_path="${up_path:+"${up_path%/}"/}"
@@ -637,7 +622,7 @@ function get_submodule_displaypaths()
   pushd "${up_path}" &> /dev/null
     # In git 1.8.3, git submodule must be run in the toplevel of the working tree
     # git 1.8.3 does not support git -C
-    ${GIT} submodule foreach '[ -n "${prefix+set}" ]' &> /dev/null || submodule_foreach_rv=$?
+    "${GIT}" submodule foreach '[ -n "${prefix+set}" ]' &> /dev/null || submodule_foreach_rv=$?
   popd &> /dev/null
 
   local OLD_IFS="${IFS}"
@@ -649,7 +634,7 @@ function get_submodule_displaypaths()
       # In git 1.8.3, git submodule must be run in the toplevel of the working tree
       # git 1.8.3 does not support git -C
       submodule_paths=($(up_path="${up_path}" relative_cwd="${relative_cwd}" \
-          ${GIT} submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} \
+          "${GIT}" submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} \
               'export prefix
                bash -c '\''faux_displaypath="${up_path}${prefix}"; \
                            echo "${faux_displaypath/"${up_path}${relative_cwd}"/}"'\'))
@@ -659,7 +644,7 @@ function get_submodule_displaypaths()
     # iterates through the submodules using ``git submodule--helper list``,
     # which queries info from .git/index; see
     # https://github.com/git/git/blob/v2.16.0/git-submodule.sh#L304
-    submodule_paths=($(${GIT} submodule foreach --quiet \
+    submodule_paths=($("${GIT}" submodule foreach --quiet \
         ${recursive_flag[@]+"${recursive_flag[@]}"} 'echo "${displaypath}"'))
   fi
   IFS="${OLD_IFS}"
@@ -731,12 +716,12 @@ function get_submodule_urls()
   fi
 
   # git submodule foreach must be run from the top-level working tree in git 1.8
-  pushd "$(${GIT} rev-parse --show-cdup)" &> /dev/null
+  pushd "$("${GIT}" rev-parse --show-cdup)" &> /dev/null
     # Query the URL from the submodule's repository configuration
     # (e.g., .git/modules/docker/recipes/config)
     # REVIEW Should i unset GIT_DIR?
-    ${GIT} submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} \
-        "export GIT; bash -euc 'echo \"\$(${GIT} config --get remote."${remote_name}".url)\"'"
+    "${GIT}" submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} \
+        "export GIT; bash -euc 'echo \"\$("${GIT}" config --get remote."${remote_name}".url)\"'"
   popd &> /dev/null
   #
   # Alternatively, the repository's configuration can be queried for the
@@ -801,8 +786,8 @@ function get_submodule_names()
   fi
 
   # git submodule foreach must be run from the top-level working tree in git 1.8
-  pushd "$(${GIT} rev-parse --show-cdup)" &> /dev/null
-    ${GIT} submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} 'echo "${name}"'
+  pushd "$("${GIT}" rev-parse --show-cdup)" &> /dev/null
+    "${GIT}" submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} 'echo "${name}"'
   popd &> /dev/null
   #
   # Alternatively, the names of a repository's submodules can be queried with
@@ -850,8 +835,8 @@ function get_submodule_toplevels()
   fi
 
   # git submodule foreach must be run from the top-level working tree in git 1.8
-  pushd "$(${GIT} rev-parse --show-cdup)" &> /dev/null
-    ${GIT} submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} 'echo "${toplevel}"'
+  pushd "$("${GIT}" rev-parse --show-cdup)" &> /dev/null
+    "${GIT}" submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} 'echo "${toplevel}"'
   popd &> /dev/null
 }
 
@@ -999,7 +984,7 @@ function orphan_commit_repo_map
   local orphan_branch="${2-__just_git_mirror_info_file}"
 
   local remote_local_url="$(git_project_git_dir)" # Alternatively, PWD
-  local refs_mapping="$(${GIT} for-each-ref --format='%(refname) %(objectname)' refs/heads)"
+  local refs_mapping="$("${GIT}" for-each-ref --format='%(refname) %(objectname)' refs/heads)"
 
   # Create an automatically deleting temporary directory
   local temp_repo
@@ -1009,28 +994,28 @@ function orphan_commit_repo_map
     local main_url="$(source /dev/stdin <<< "${repo_map}"; _git_mirror_get_url .)"
     # Clone the orphan branch from the mirror (if it exists)
     # Alternatively, https://stackoverflow.com/a/7349740
-    if ${GIT} clone --single-branch --branch "${orphan_branch}" "${main_url}" . &> /dev/null; then
-      ${GIT} remote set-url origin "${remote_local_url}"
-      ${GIT} checkout "${orphan_branch}" &> /dev/null
+    if "${GIT}" clone --single-branch --branch "${orphan_branch}" "${main_url}" . &> /dev/null; then
+      "${GIT}" remote set-url origin "${remote_local_url}"
+      "${GIT}" checkout "${orphan_branch}" &> /dev/null
     else
       # If trying to clone a single branch from a bare repo that has only
       # been initialized, git 1.8 segfaults, leaving behind an initialized
       # .git directory
       rm -rf .git
-      ${GIT} init &> /dev/null
-      ${GIT} remote add origin "${remote_local_url}"
-      ${GIT} checkout --orphan "${orphan_branch}" &> /dev/null
+      "${GIT}" init &> /dev/null
+      "${GIT}" remote add origin "${remote_local_url}"
+      "${GIT}" checkout --orphan "${orphan_branch}" &> /dev/null
     fi
 
     echo "${repo_map}" > repo_map.env
 
     local message="the repo_map.env file needed by just:git_mirror that maps repo_paths to urls"
-    ${GIT} add repo_map.env
-    ${GIT} -c "user.name=just git_export-repo" \
+    "${GIT}" add repo_map.env
+    "${GIT}" -c "user.name=just git_export-repo" \
            -c "user.email=<just@export-repo.git>" commit \
            --allow-empty \
            -m "$(printf "${message}\n\n${refs_mapping}")"
-    ${GIT} push --force origin "${orphan_branch}" &> /dev/null
+    "${GIT}" push --force origin "${orphan_branch}" &> /dev/null
   popd &>/dev/null
 }
 
@@ -1055,7 +1040,7 @@ function add_import-repo_just_project()
   # does not include submodules, but that that's ok
   rm -rf "${prep_dir}"/.vsi_common
   pushd "${VSI_COMMON_DIR}" &>/dev/null
-    ${GIT} archive --format=tar --prefix=.vsi_common/ HEAD | ( cd "${prep_dir}" && tar xf - )
+    "${GIT}" archive --format=tar --prefix=.vsi_common/ HEAD | ( cd "${prep_dir}" && tar xf - )
   popd &>/dev/null
 
   uwecho 'These mirrored git repositories were automatically created by
@@ -1145,8 +1130,8 @@ function submodule-helper-relative-url()
     # the host & rpath of the URL could be extracted easily. While
     # parser.bsh:parse_url exists, it doesn't handle the various URL formats
     # supported by git: e.g., ssh://git@, git@, etc.)
-    ${GIT} init 1>/dev/null
-    ${GIT} config remote.origin.url "${remote_url}"
+    "${GIT}" init 1>/dev/null
+    "${GIT}" config remote.origin.url "${remote_url}"
     uwecho "[submodule \"${sm_path}\"]
               path = "${sm_path}"
               url = ${gitmodules_url}" > .gitmodules
@@ -1156,17 +1141,17 @@ function submodule-helper-relative-url()
     echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" > .git/modules/"${sm_path}"/refs/heads/master
 
     # from https://stackoverflow.com/a/37378302
-    ${GIT} update-index --add --cacheinfo 160000 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "${sm_path}" 1>/dev/null
+    "${GIT}" update-index --add --cacheinfo 160000 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "${sm_path}" 1>/dev/null
     # git submodule init sometimes outputs to stdout, sometimes to stderr
-    ${GIT} submodule init "${sm_path}" &>/dev/null
-    ${GIT} submodule sync "${sm_path}" 1>/dev/null
+    "${GIT}" submodule init "${sm_path}" &>/dev/null
+    "${GIT}" submodule sync "${sm_path}" 1>/dev/null
 
     if [ -n "${up_path}" ]; then
       pushd "${sm_path}" 1> /dev/null
-        ${GIT} config --get remote.origin.url
+        "${GIT}" config --get remote.origin.url
       popd 1> /dev/null
     else
-      ${GIT} config --get submodule.submod.url
+      "${GIT}" config --get submodule.submod.url
     fi
   popd 1>/dev/null
 }
@@ -1200,11 +1185,11 @@ function git_sync_submodules()
 
   local sm_key
   for sm_key in ${submodule_keys+"${submodule_keys[@]}"}; do
-    local sm_path="$(${GIT} config -f .gitmodules "${sm_key}".path)"
+    local sm_path="$("${GIT}" config -f .gitmodules "${sm_key}".path)"
     local sm_name="${sm_key#submodule.}"
     # Remove trailing slash
     sm_path="${sm_path%/}"
-    local submodule_url="$(${GIT} config -f "${PWD}"/.gitmodules "${sm_key}".url)"
+    local submodule_url="$("${GIT}" config -f "${PWD}"/.gitmodules "${sm_key}".url)"
     # URLs/paths relative to the CWD must either start with ./ or ../
     # according to git. This is how git-submodule.sh checks for this:
     # https://github.com/git/git/blob/v2.16.0/git-submodule.sh#L1059
@@ -1215,7 +1200,7 @@ function git_sync_submodules()
       local up_path="$(printf '%s\n' "$sm_path" | sed "s/[^/][^/]*/../g")"
       # guarantee a trailing /
       up_path=${up_path%/}/
-      local remote_url="$(${GIT} config remote."${remote_name}".url)"
+      local remote_url="$("${GIT}" config remote."${remote_name}".url)"
       # path from submodule work tree to submodule origin repo
       sub_origin_url="$(submodule-helper-relative-url "${remote_url}" "${submodule_url}" "${up_path}")"
       # path from superproject work tree to submodule origin repo
@@ -1230,8 +1215,8 @@ function git_sync_submodules()
       # See just_git_functions.bsh:safe_git_submodule_update:
       # This is my equivalent to "git submodule sync". It uses a specific remote
       # that it not one of the defaults to handle issue #186
-      ${GIT} remote add "${JUST_GIT_UPSTREAM}" "${submodule_url}" &> /dev/null || \
-        ${GIT} remote set-url "${JUST_GIT_UPSTREAM}" "${submodule_url}"
+      "${GIT}" remote add "${JUST_GIT_UPSTREAM}" "${submodule_url}" &> /dev/null || \
+        "${GIT}" remote set-url "${JUST_GIT_UPSTREAM}" "${submodule_url}"
 
       # Depth-first traversal
       if [ -n "${RECURSIVE:+set}" ]; then
@@ -1281,25 +1266,25 @@ function _check_submodules_are_pushed_recursively()
   local submodule_keys=($(get_config_submodule_names))
   # NOTE This command will actually skip a submodule that has been init'd but
   # not updated
-  #local tracked_shas=($(${GIT} submodule foreach --quiet 'echo "${prefix-${displaypath}}" ${sha1}'))
+  #local tracked_shas=($("${GIT}" submodule foreach --quiet 'echo "${prefix-${displaypath}}" ${sha1}'))
   IFS="${OLD_IFS}"
 
   local sm_key
   for sm_key in ${submodule_keys+"${submodule_keys[@]}"}; do
-    local sm_path="$(${GIT} config -f .gitmodules "${sm_key}".path)"
+    local sm_path="$("${GIT}" config -f .gitmodules "${sm_key}".path)"
     local sm_name="${sm_key#submodule.}"
     # Remove trailing slash
     sm_path="${sm_path%/}"
-    local tracked_sha="$(${GIT} submodule status --cached "${sm_path}" | cut -c2- | awk '{print $1}')"
-    local submodule_url="$(${GIT} config -f "${PWD}"/.gitmodules "${sm_key}".url)"
+    local tracked_sha="$("${GIT}" submodule status --cached "${sm_path}" | cut -c2- | awk '{print $1}')"
+    local submodule_url="$("${GIT}" config -f "${PWD}"/.gitmodules "${sm_key}".url)"
 
     pushd "${sm_path}" &>/dev/null
-      ${GIT} fetch "${JUST_GIT_UPSTREAM}"
+      "${GIT}" fetch "${JUST_GIT_UPSTREAM}"
 
       # git branch -r --contains SHA will show a list of remote/branch refs
       # that contain a SHA. If no remote/branch refs are returned, this means
       # the commit has not been pushed
-      if [ "$(${GIT} branch -r --contains "${tracked_sha}" | grep "^  ${JUST_GIT_UPSTREAM}")" = "" ]; then
+      if [ "$("${GIT}" branch -r --contains "${tracked_sha}" | grep "^  ${JUST_GIT_UPSTREAM}")" = "" ]; then
         echo "WARNING The commit tracked by the parent repository of the"
         echo "submodule, '${sm_name}', has not been pushed to the"
         echo "remote URL tracked by the parent repository:"
@@ -1407,7 +1392,7 @@ function relocate_git_defaultify()
 
       # NOTE if specifying a prep_dir, this isn't needed, but should probably
       # exist
-      local valid_remote_names=($(${GIT} remote))
+      local valid_remote_names=($("${GIT}" remote))
       if [ "${#valid_remote_names[@]}" -eq 0 ]; then
         # Either the repo is misconfigured or initialized locally.
         # REVIEW In the latter case at least, we could mirror the repo directly
@@ -1470,7 +1455,7 @@ function relocate_git_defaultify()
           # https://stackoverflow.com/a/17562858
           #
           # No quotes around subshell to create array (although IFS must be correct)
-          local remote_urls=($(${GIT} config --get-all remote."${remote_name}".url | awk '!a[$0]++'))
+          local remote_urls=($("${GIT}" config --get-all remote."${remote_name}".url | awk '!a[$0]++'))
           IFS="${OLD_IFS}"
           if [ "${#remote_urls[@]}" -eq 0 ]; then
             # This shouldn't happen; if the repo has a named remote, it should
@@ -1511,7 +1496,7 @@ function relocate_git_defaultify()
             remote_strings+=("$(printf "%s\t%s\n" "${associated_remote_names[$i]}" "${associated_remote_urls[$i]}")")
           done
 
-          local default_remote="$(printf "%s\t%s\n" origin "$(${GIT} config remote.origin.url)")"
+          local default_remote="$(printf "%s\t%s\n" origin "$("${GIT}" config remote.origin.url)")"
           local default_index="$(findin "${default_remote}" "${remote_strings[@]}")"
 
           echo "Please choose a remote:"
@@ -1528,7 +1513,7 @@ function relocate_git_defaultify()
           pushd "$(dirname "${JUST_USER_CWD}/${prep_dir}/"*"/config")" &> /dev/null
             # This is the only remote that exists in the prep_dir
             remote_name="origin"
-            remote_url="$(${GIT} config --get remote.origin.url)"
+            remote_url="$("${GIT}" config --get remote.origin.url)"
             # Simply treat the prep_dir as the output_dir
             # REVIEW I do this primarily because the the rest of this target
             # assumes it is operating on this repository.
@@ -1547,7 +1532,7 @@ function relocate_git_defaultify()
 
 
       # Branch names cannot have spaces
-      local valid_branches=($(${GIT} for-each-ref --format='%(refname:short)' refs/heads))
+      local valid_branches=($("${GIT}" for-each-ref --format='%(refname:short)' refs/heads))
       if [ "${#valid_branches[@]}" -eq 0 ]; then
         echo "ERROR This repository is misconfigured: it has no branches."
         echo "Please fix!"
@@ -1565,7 +1550,7 @@ function relocate_git_defaultify()
           echo "Using the only branch in this repository: '${branch}'"
           echo
         else
-          local current_branch="$(${GIT} rev-parse --abbrev-ref HEAD)"
+          local current_branch="$("${GIT}" rev-parse --abbrev-ref HEAD)"
           default_index="$(findin "${current_branch}" "${branches}")"
 
           local picked
@@ -1653,7 +1638,7 @@ function relocate_git_defaultify()
       local args=(${@+"${@}"})
       # If no arguments are specified, choose origin's (last) remote URL
       if [ "${#args[@]}" -eq 0 ]; then
-        local remote_url=$(${GIT} config --get remote.origin.url)
+        local remote_url=$("${GIT}" config --get remote.origin.url)
         args=("${remote_url}")
       fi
 
@@ -1726,7 +1711,7 @@ function relocate_git_defaultify()
     # TODO Move to just_git_functions
     git_convert_git_remote_http_to_git) # Change the remote urls to use the git@ \
                               # syntax instead of https
-      if ! command -v ${GIT} >& /dev/null; then
+      if ! command -v "${GIT}" >& /dev/null; then
         echo "Git not found, skipping remote url conversion" >&2
         return 0
       fi

--- a/linux/linux_accounts.bsh
+++ b/linux/linux_accounts.bsh
@@ -190,7 +190,7 @@ function add_to_passwd()
     fi
   done
   passwd=("${new_passwd}"
-          ${passwd+"${passwd[@]}"} )
+          ${passwd[@]+"${passwd[@]}"} )
 }
 
 #**
@@ -220,7 +220,7 @@ function add_to_shadow()
     fi
   done
   shadow=("${new_shadow}"
-          ${shadow+"${shadow[@]}"} )
+          ${shadow[@]+"${shadow[@]}"} )
 }
 
 #**
@@ -247,9 +247,9 @@ function read_user_data()
 #**
 function write_user_data()
 {
-  write_file "${LINUX_ACCOUNTS_PASSWD_FILE}" ${passwd+"${passwd[@]}"}
-  if [ "${shadow+set}" == "set" ]; then
-    write_file "${LINUX_ACCOUNTS_SHADOW_FILE}" ${shadow+"${shadow[@]}"}
+  write_file "${LINUX_ACCOUNTS_PASSWD_FILE}" ${passwd[@]+"${passwd[@]}"}
+  if [ " ""${shadow[@]+set}" = " set" ]; then
+    write_file "${LINUX_ACCOUNTS_SHADOW_FILE}" ${shadow[@]+"${shadow[@]}"}
   fi
 }
 

--- a/linux/pipenv_functions.bsh
+++ b/linux/pipenv_functions.bsh
@@ -26,13 +26,12 @@ fi
 # Reproduces what pipenv internally calculates for the hash of a Pipfile.
 #
 # :Arguments: ``$1`` - Pipfile filename
-#
 # :Output: ``stdout`` - hex sha256 sum of Pipfile data
+# :Uses: Requires  ``python`` with ``pipenv``
 #
 # .. note::
 #
-#     Need to be run in a python environment (such as a virtualenv) with pipenv
-#     installed.
+#     Need to be run in the python environment (virtualenv)
 #
 # .. seealso::
 #
@@ -53,12 +52,8 @@ function get_pipfile_hash()
 # Print the hash stored in a Pipfile.lock
 #
 # :Arguments: ``$1`` - Pipfile.lock filename
-#
 # :Output: ``stdout`` - hex sha256 sum of Pipfile data
-#
-# .. note::
-#
-#     Uses python, but does not need any libraries installed
+# :Uses: Requires ``python``
 #
 # .. seealso::
 #

--- a/linux/requirements.bsh
+++ b/linux/requirements.bsh
@@ -404,7 +404,7 @@ function tar_version_info()
 function openssh_version()
 {
   unset_flags xv # incase ssh is an alias or wrapped function, and user has xv on
-  local version_info="$("${SSH} -V 2>&1)"
+  local version_info="$("${SSH}" -V 2>&1)"
   reset_flags xv
   local pattern='OpenSSH_([^0-9]*_)?([^ ]*), (.*SSL) ([^ ]*).*'
   local version version_remainder

--- a/linux/requirements.bsh
+++ b/linux/requirements.bsh
@@ -11,6 +11,7 @@ fi
 source "${VSI_COMMON_DIR}/linux/findin"
 source "${VSI_COMMON_DIR}/linux/elements.bsh"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 source "${VSI_COMMON_DIR}/linux/set_flags.bsh"
 
 #*# linux/requirements
@@ -327,7 +328,7 @@ function split_version_string_and_remainder()
 #**
 function git_version()
 {
-  "${GIT-git}" --version | awk '{print $3}'
+  "${GIT}" --version | awk '{print $3}'
 }
 
 #**
@@ -340,7 +341,7 @@ function git_version()
 #**
 function docker_version()
 {
-  local version="$("${DOCKER-docker}" --version | awk '{print $3}')"
+  local version="$("${DOCKER}" --version | awk '{print $3}')"
   echo "${version%,}"
 }
 
@@ -354,7 +355,7 @@ function docker_version()
 #**
 function docker_compose_version()
 {
-  local version="$("${DOCKER_COMPOSE-docker-compose}" --version | awk '{print $3}')"
+  local version="$("${DOCKER_COMPOSE}" --version | awk '{print $3}')"
   echo "${version%,}"
 }
 
@@ -403,7 +404,7 @@ function tar_version_info()
 function openssh_version()
 {
   unset_flags xv # incase ssh is an alias or wrapped function, and user has xv on
-  local version_info="$(ssh -V 2>&1)"
+  local version_info="$("${SSH} -V 2>&1)"
   reset_flags xv
   local pattern='OpenSSH_([^0-9]*_)?([^ ]*), (.*SSL) ([^ ]*).*'
   local version version_remainder

--- a/linux/time_tools.bsh
+++ b/linux/time_tools.bsh
@@ -41,7 +41,7 @@ function get_time_seconds()
 #**
 # .. function:: get_time_nanoseconds
 #
-# Print the epoch time in nanoseconds. Same as :func:`get_time_seconds, but in nanoseconds and always an integer
+# Print the epoch time in nanoseconds. Same as :func:`get_time_seconds`, but in nanoseconds and always an integer
 #**
 function get_time_nanoseconds()
 {
@@ -121,7 +121,6 @@ if [[ ${OSTYPE-} = darwin* ]]; then
     perl -e 'use warnings;
 
       no warnings;
-      mt $t
       {
         local *STDOUT;
         eval "use Time::HiRes qw(ualarm)";

--- a/linux/time_tools.bsh
+++ b/linux/time_tools.bsh
@@ -22,30 +22,79 @@ fi
 #
 # Print the epoch time in seconds
 #
-# Uses the date command to print nanosecond-accurate epoch time, if your date command supports that feature.
+# :Output: **stdout** - The epoch time, in second with nanosecond precision seconds (if available)
 #
-# Else, uses python or ruby if available to get microsecond-accurate time. If all else fails, use the date command, which sometimes does not support more than second accuracy.
+# Uses the ``date`` command to print nanosecond-accurate epoch time, if your date command supports that feature.
+#
+# Else, uses ``python3``, ``ruby``, or ``perl`` if available to get microsecond-accurate time. If all else fails, use the ``date`` command, even if it does not support more than second precision.
 #**
-get_time_seconds()
+function get_time_seconds()
+{
+  local _get_time_decimal='.'
+  # local _get_time_nanoseconds_cmd=()
+  get_time_nanoseconds
+  # _get_time_seconds_cmd=("${_get_time_nanoseconds_cmd[@]}")
+
+  # _get_time_seconds_cmd
+}
+
+#**
+# .. function:: get_time_nanoseconds
+#
+# Print the epoch time in nanoseconds. Same as :func:`get_time_seconds, but in nanoseconds and always an integer
+#**
+function get_time_nanoseconds()
 {
   # If this date doesn't support nanoseconds
   if [[ ! $(date +%N) =~ ^[0-9]+$ ]]; then
-    local python_cmd="import time; print('%0.9f' % time.time())"
-    if command -v python &> /dev/null; then
-      python -c "${python_cmd}"
-    elif command -v python3 &> /dev/null; then
-      python3 -c "${python_cmd}"
+    local python_cmd="import time; t = time.time_ns(); print('%i${_get_time_decimal-}%09i' % (int(t/1e9), t % 1e9))"
+    if command -v python3 &> /dev/null; then
+      eval 'function get_time_nanoseconds(){ python3 -c "'"${python_cmd}"'"; }'
+    elif command -v python &> /dev/null; then
+      eval 'function get_time_nanoseconds(){ python -c "'"${python_cmd}"'"; }'
     elif command -v ruby &> /dev/null; then
-      ruby -e "print Time.now.to_f"
-    # Add other elif commands here for other common languages. Perl needs a
-    # plugin, so that's a no-go.
+      function get_time_nanoseconds()
+      {
+        ruby -e "t = Time.now; print '%i${_get_time_decimal-}%09i'\"\n\" % [t.tv_sec, t.tv_nsec]"
+      }
+    elif command -v perl &> /dev/null; then
+      # Only microsecond accurate
+      function get_time_nanoseconds()
+      {
+        perl -e 'use warnings;
+          my ($s, $us);
+          no warnings;
+          {
+            local *STDOUT;
+            eval "use Time::HiRes qw(gettimeofday); (\$s, \$us) = gettimeofday";
+            # Using eval here the same was as ualarm does NOT work, unknown why
+            # Use https://stackoverflow.com/a/7506859/4166604 workaround
+          }
+          if ($@){
+            printf("%i'"${_get_time_decimal-}"'000000000\n", time)
+          } else {
+            printf("%i'"${_get_time_decimal-}"'%09i\n", $s, $us*1000)
+          }'
+      }
+    # Add other elif commands here for other common languages
     else # Else, just do seconds; best I can do
-      date '+%s.0'
+      function get_time_nanoseconds()
+      {
+        date "+%s${_get_time_decimal-}000000000"
+      }
     fi
   else
-    date '+%s.%N'
+    function get_time_nanoseconds()
+    {
+      date "+%s${_get_time_decimal-}%N"
+    }
   fi
+
+  # This function redefines itself, for efficiency on multiple calls. Once here,
+  # it's been redefined, so it needs to be called once
+  get_time_nanoseconds
 }
+
 
 #**
 # .. function:: timeout
@@ -72,9 +121,12 @@ if [[ ${OSTYPE-} = darwin* ]]; then
     perl -e 'use warnings;
 
       no warnings;
+      mt $t
       {
         local *STDOUT;
         eval "use Time::HiRes qw(ualarm)";
+        # I have no idea what so ever why this works. The eval load of ualarm
+        # should not escape this scope, and yet it does
       }
 
       if ( $@ ) {
@@ -110,24 +162,6 @@ if [[ ${OSTYPE-} = darwin* ]]; then
   }
 fi
 
-if [[ ! $(date +%N) =~ ^[0-9]+$ ]]; then
-  if command -v perl &> /dev/null; then
-    # Another option on macOS/other perls
-    function _tictoc_fun()
-    { # The spaces in the argument means we have to wrap this in a function
-      # so that the _tictoc_cmd call works.
-      perl -e 'use Time::HiRes qw(gettimeofday);
-               ($s,$ms) = gettimeofday;
-               printf("%i%09i\n", $s, $ms*1000)';
-    }
-    _tictoc_cmd=_tictoc_fun
-  else
-    _tictoc_cmd="date +%s000000000"
-  fi
-else
-  _tictoc_cmd="date +%s%N"
-fi
-
 #**
 # .. function:: tic
 #
@@ -147,7 +181,7 @@ fi
 #**
 function tic()
 {
-  _time0="$($_tictoc_cmd)"
+  _time0="$(get_time_nanoseconds)"
 }
 
 #**
@@ -160,7 +194,7 @@ function tic()
 function toc()
 {
   # Make it round
-  toc_time=$(($($_tictoc_cmd)-_time0+500000000))
+  toc_time=$(($(get_time_nanoseconds)-_time0+500000000))
   # If less than 1 s, make it 0, or else removing 9 digits doesn't work
   if [ "${toc_time}" -lt "1000000000" ]; then
     toc_time=0
@@ -183,7 +217,7 @@ function toc()
 #**
 function toc_ms()
 {
-  toc_time=$(($($_tictoc_cmd)-_time0+500000))
+  toc_time=$(($(get_time_nanoseconds)-_time0+500000))
   # If less than 1 ms, make it 0, or else removing 6 digits doesn't work
   if [ "${toc_time}" -lt "1000000" ]; then
     toc_time=0
@@ -206,6 +240,6 @@ function toc_ms()
 #**
 function toc_ns()
 {
-  toc_time=$(($($_tictoc_cmd)-_time0))
+  toc_time=$(($(get_time_nanoseconds)-_time0))
   echo "${toc_time} ns"
 }

--- a/linux/time_tools.bsh
+++ b/linux/time_tools.bsh
@@ -22,7 +22,7 @@ fi
 #
 # Print the epoch time in seconds
 #
-# :Output: **stdout** - The epoch time, in second with nanosecond precision seconds (if available)
+# :Output: **stdout** - The epoch time, in seconds with nanosecond precision (if available)
 #
 # Uses the ``date`` command to print nanosecond-accurate epoch time, if your date command supports that feature.
 #
@@ -67,7 +67,7 @@ function get_time_nanoseconds()
           {
             local *STDOUT;
             eval "use Time::HiRes qw(gettimeofday); (\$s, \$us) = gettimeofday";
-            # Using eval here the same was as ualarm does NOT work, unknown why
+            # Using eval here the same way as ualarm does NOT work, unknown why
             # Use https://stackoverflow.com/a/7506859/4166604 workaround
           }
           if ($@){
@@ -90,7 +90,7 @@ function get_time_nanoseconds()
     }
   fi
 
-  # This function redefines itself, for efficiency on multiple calls. Once here,
+  # This function redefines itself for efficiency on multiple calls. Once here,
   # it's been redefined, so it needs to be called once
   get_time_nanoseconds
 }

--- a/tests/int/test-compat.bsh
+++ b/tests/int/test-compat.bsh
@@ -6,6 +6,7 @@ fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 
 function setup()
 {
@@ -36,25 +37,25 @@ function begin_git_cli_config_option_test()
   fi
 }
 
-command -v "${GIT-git}" &> /dev/null || skip_next_test
+command -v "${GIT}" &> /dev/null || skip_next_test
 begin_git_cli_config_option_test "Test if git supports the -c option"
 (
   setup_test
 
   begin_fail_zone
-  ${GIT-git} -c foo=bar version
+  "${GIT}" -c foo=bar version
   end_fail_zone
 )
 end_test
 
-command -v "${GIT-git}" &> /dev/null || skip_next_test
+command -v "${GIT}" &> /dev/null || skip_next_test
 git_feature_support_tls && tls=0 || tls=$?
 [ ${tls} -ge 2 ] && [ ${tls} -ne 125 ] || skip_next_test
 begin_test "Test git_feature_support_tls"
 (
   setup_test
 
-  ${GIT-git} ls-remote -h https://github.com/visionsystemsinc/small_trinkets.git
+  "${GIT}" ls-remote -h https://github.com/visionsystemsinc/small_trinkets.git
 )
 end_test
 
@@ -67,7 +68,7 @@ function begin_submodule_path_test()
   fi
 }
 
-command -v "${GIT-git}" &> /dev/null || skip_next_test
+command -v "${GIT}" &> /dev/null || skip_next_test
 begin_submodule_path_test "Test difficult git submodule path"
 (
   setup_test
@@ -80,27 +81,27 @@ begin_submodule_path_test "Test difficult git submodule path"
   # Sub module
   mkdir -p "${SUBMODULE_REPO}"
   pushd "${SUBMODULE_REPO}" &> /dev/null
-    ${GIT-git} init .
+    "${GIT}" init .
     touch readme_sub
-    ${GIT-git} add readme_sub
-    ${GIT-git} commit -m "initial commit"
+    "${GIT}" add readme_sub
+    "${GIT}" commit -m "initial commit"
   popd &> /dev/null
   mkdir -p "${SUBMODULE_URL}"
   pushd "${SUBMODULE_URL}" &> /dev/null
-    ${GIT-git} clone --mirror "${SUBMODULE_REPO}" .
+    "${GIT}" clone --mirror "${SUBMODULE_REPO}" .
   popd &> /dev/null
 
   # Main Repo
   mkdir -p "${GIT_TEST_REPO}"
   pushd "${GIT_TEST_REPO}" &> /dev/null
-    ${GIT-git} init .
-    ${GIT-git} submodule add "${SUBMODULE_URL}" "${DIFFICULT_PATH}"
-    ${GIT-git} commit -m "add submodule"
+    "${GIT}" init .
+    "${GIT}" submodule add "${SUBMODULE_URL}" "${DIFFICULT_PATH}"
+    "${GIT}" commit -m "add submodule"
   popd &> /dev/null
 
   # Test if git supports difficult submodule paths
   pushd "${GIT_TEST_REPO}" &> /dev/null
-    output="$(${GIT-git} submodule foreach -q 'echo "${sm_path}"')"
+    output="$("${GIT}" submodule foreach -q 'echo "${sm_path}"')"
     begin_fail_zone
     [ "${output}" = "${DIFFICULT_PATH}" ] # output="" when it fails
     end_fail_zone
@@ -117,7 +118,7 @@ function begin_submodule_update_test()
   fi
 }
 
-(command -v "${GIT-git}" &> /dev/null && git_feature_cli_config_option) || skip_next_test
+(command -v "${GIT}" &> /dev/null && git_feature_cli_config_option) || skip_next_test
 begin_submodule_update_test "Test git submodule update with custom command"
 (
   setup_test
@@ -129,35 +130,35 @@ begin_submodule_update_test "Test git submodule update with custom command"
   # Sub module
   mkdir -p "${SUBMODULE_REPO}"
   pushd "${SUBMODULE_REPO}" &> /dev/null
-    ${GIT-git} init .
+    "${GIT}" init .
     echo 1 > readme_sub
-    ${GIT-git} add readme_sub
-    ${GIT-git} commit -m "initial commit"
+    "${GIT}" add readme_sub
+    "${GIT}" commit -m "initial commit"
   popd &> /dev/null
   mkdir -p "${SUBMODULE_URL}"
   pushd "${SUBMODULE_URL}" &> /dev/null
-    ${GIT-git} clone --mirror "${SUBMODULE_REPO}" .
+    "${GIT}" clone --mirror "${SUBMODULE_REPO}" .
   popd &> /dev/null
 
   # Main Repo
   mkdir -p "${BUILD_REPO}"
   pushd "${BUILD_REPO}" &> /dev/null
-    ${GIT-git} init .
-    ${GIT-git} submodule add "${SUBMODULE_URL}"
-    ${GIT-git} commit -m "add submodule"
+    "${GIT}" init .
+    "${GIT}" submodule add "${SUBMODULE_URL}"
+    "${GIT}" commit -m "add submodule"
   popd &> /dev/null
 
   # Test if git supports custom commands in submodule.<name>.update
   pushd "${BUILD_REPO}" &> /dev/null
     pushd submod &> /dev/null
-      ${GIT-git} checkout master
+      "${GIT}" checkout master
       echo 2 >> readme_sub
-      ${GIT-git} add readme_sub
-      ${GIT-git} commit -m "second commit"
+      "${GIT}" add readme_sub
+      "${GIT}" commit -m "second commit"
     popd &> /dev/null
-    ${GIT-git} -c "submodule.submod.update"='!echo custom_command' submodule update submod
+    "${GIT}" -c "submodule.submod.update"='!echo custom_command' submodule update submod
     begin_fail_zone
-    output="$(cd submod && ${GIT-git} log -n1 --format="%s")"
+    output="$(cd submod && "${GIT}" log -n1 --format="%s")"
     # "Ahead (1)" when git does not support a custom command
     [ "${output}" = "second commit" ]
     end_fail_zone

--- a/tests/int/test-docker_compose_override.bsh
+++ b/tests/int/test-docker_compose_override.bsh
@@ -6,6 +6,7 @@ fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${VSI_COMMON_DIR}/linux/just_files/docker_compose_override"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 
 function head()
 {

--- a/tests/int/test-docker_functions.bsh
+++ b/tests/int/test-docker_functions.bsh
@@ -7,6 +7,7 @@ fi
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${TESTLIB_DIR}/test_utils.bsh"
 source "${VSI_COMMON_DIR}/linux/just_files/docker_functions.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 : ${DRYRUN=} # The only thing I need from just_functions
 
 setup()
@@ -137,7 +138,7 @@ end_test
 teardown()
 (
   # Docker cleanup
-  ${DOCKER} rm ${temp_image} &> /dev/null || :
+  "${DOCKER}" rm ${temp_image} &> /dev/null || :
 
   # teardown should always return true on success
 )

--- a/tests/int/test-git_mirror.bsh
+++ b/tests/int/test-git_mirror.bsh
@@ -6,7 +6,8 @@ fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${VSI_COMMON_DIR}/linux/web_tools.bsh"
-command -v "${GIT-git}" &> /dev/null && source "${VSI_COMMON_DIR}/linux/git_mirror"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
+command -v "${GIT}" &> /dev/null && source "${VSI_COMMON_DIR}/linux/git_mirror"
 source "${VSI_COMMON_DIR}/linux/requirements.bsh"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
 
@@ -15,7 +16,7 @@ TESTLIB_STOP_AFTER_FAILS=1
 unset TESTLIB_SKIP_TESTS TESTLIB_RUN_SINGLE_TEST
 
 if ! command -v unzip &> /dev/null || \
-   ! command -v "${GIT-git}" &> /dev/null || ! git lfs &> /dev/null; then
+   ! command -v "${GIT}" &> /dev/null || ! git lfs &> /dev/null; then
   TESTLIB_SKIP_TESTS='.*'
 fi
 

--- a/tests/int/test-just_git_airgap_repo.bsh
+++ b/tests/int/test-just_git_airgap_repo.bsh
@@ -6,7 +6,8 @@ fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${VSI_COMMON_DIR}/tests/test_utils.bsh"
-command -v "${GIT-git}" &> /dev/null && source "${VSI_COMMON_DIR}/linux/just_git_airgap_repo.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
+command -v "${GIT}" &> /dev/null && source "${VSI_COMMON_DIR}/linux/just_git_airgap_repo.bsh"
 source "${VSI_COMMON_DIR}/linux/requirements.bsh"
 source "${VSI_COMMON_DIR}/linux/real_path"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
@@ -15,7 +16,7 @@ source "${VSI_COMMON_DIR}/linux/compat.bsh"
 TESTLIB_STOP_AFTER_FAILS=1
 unset TESTLIB_SKIP_TESTS TESTLIB_RUN_SINGLE_TEST
 
-if ! command -v "${GIT-git}" &> /dev/null || ! git lfs &> /dev/null; then
+if ! command -v "${GIT}" &> /dev/null || ! git lfs &> /dev/null; then
   TESTLIB_SKIP_TESTS='.*'
 fi
 

--- a/tests/int/test-just_git_functions.bsh
+++ b/tests/int/test-just_git_functions.bsh
@@ -6,11 +6,12 @@ fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${TESTLIB_DIR}/test_utils.bsh"
-command -v "${GIT-git}" &> /dev/null && source "${VSI_COMMON_DIR}/linux/just_files/just_git_functions.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
+command -v "${GIT}" &> /dev/null && source "${VSI_COMMON_DIR}/linux/just_files/just_git_functions.bsh"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
 
 
-if ! command -v "${GIT-git}" &> /dev/null; then
+if ! command -v "${GIT}" &> /dev/null; then
   TESTLIB_SKIP_TESTS='.*'
 fi
 

--- a/tests/int/test-new_just.bsh
+++ b/tests/int/test-new_just.bsh
@@ -8,6 +8,7 @@ source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${VSI_COMMON_DIR}/linux/uwecho.bsh"
 source "${VSI_COMMON_DIR}/linux/just_files/just_version.bsh"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 export JUST_VERSION
 
 function setup()
@@ -316,7 +317,6 @@ begin_test "New just instructions test (git)"
 )
 end_test
 
-: ${DOCKER=docker}
 command -v "${DOCKER}" &> /dev/null || skip_next_test
 begin_test "New just docker test"
 (

--- a/tests/test-cuda_info.bsh
+++ b/tests/test-cuda_info.bsh
@@ -6,8 +6,7 @@ fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${TESTLIB_DIR}/test_utils.bsh"
-
-: ${NVIDIA_SMI=nvidia-smi}
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 
 if ! command -v "${NVIDIA_SMI}" &> /dev/null; then
   skip_next_test

--- a/tests/test-docker_functions.bsh
+++ b/tests/test-docker_functions.bsh
@@ -71,15 +71,6 @@ begin_test "Test DOCKER var"
 )
 end_test
 
-begin_test "Test NVIDIA_DOCKER var"
-(
-  setup_test
-  DRYRUN=echo
-  NVIDIA_DOCKER="NvIdIa-DoCkEr"
-  [ "$(Nvidia-docker run test)" = "NvIdIa-DoCkEr run --rm test" ]
-)
-end_test
-
 begin_test "is_dir_and_not_exist"
 (
   setup_test
@@ -248,7 +239,7 @@ begin_test "Docker command"
   export DRYRUN=print_command
 
   DOCKER_AUTOREMOVE=0
-  a=($DOCKER run -v '/test  this/:blah' 'debian:9')
+  a=("${DOCKER}" run -v '/test  this/:blah' 'debian:9')
   r="$(Docker run -v "/test  this/:blah" debian:9)"
   eval "r=($r)"
   cmp_elements_a a r
@@ -286,10 +277,6 @@ begin_test "DOCKER_EXTRA_ARGS"
   cmp_elements_a a r
 )
 end_test
-
-
-
-
 
 begin_test "Test DOCKER_COMPOSE var"
 (
@@ -590,7 +577,7 @@ begin_test "Docker-compose command"
   export JUSTFILE="${TESTDIR}/Justfile"
 
   DOCKER_COMPOSE_AUTOREMOVE=0
-  a=($DOCKER_COMPOSE run -v '/test  this/:blah' 'debian:9')
+  a=("${DOCKER_COMPOSE}" run -v '/test  this/:blah' 'debian:9')
   r="$(Docker-compose run -v "/test  this/:blah" debian:9)"
   eval "r=($r)"
   cmp_elements_a a r

--- a/tests/test-linux_accounts.bsh
+++ b/tests/test-linux_accounts.bsh
@@ -8,8 +8,6 @@ source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${TESTLIB_DIR}/test_utils.bsh"
 source "${VSI_COMMON_DIR}/linux/linux_accounts.bsh"
 
-: ${DOCKER=docker}
-
 begin_test "read file"
 (
   setup_test

--- a/tests/test-singularity_functions.bsh
+++ b/tests/test-singularity_functions.bsh
@@ -7,6 +7,7 @@ fi
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${TESTLIB_DIR}/test_utils.bsh"
 source "${VSI_COMMON_DIR}/linux/just_files/singularity_functions.bsh"
+source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 
 function SiNgUlArItY()
 {

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -276,6 +276,9 @@ atexit ()
   if [ -n "${test_description+set}" ]; then
     end_test $test_status
     echo "${TESTLIB_BAD_COLOR}WARNING${TESTLIB_RESET_COLOR}: end_test not added at end of last test." 1>&2
+  elif [ "${test_status}" != "0" ]; then
+    echo "${TESTLIB_BAD_COLOR}ERROR${TESTLIB_RESET_COLOR} Test failed out side of test. Maybe source file or test file is bad" 1>&2
+    exit 123
   fi
   unset test_status
 

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -277,7 +277,7 @@ atexit ()
     end_test $test_status
     echo "${TESTLIB_BAD_COLOR}WARNING${TESTLIB_RESET_COLOR}: end_test not added at end of last test." 1>&2
   elif [ "${test_status}" != "0" ]; then
-    echo "${TESTLIB_BAD_COLOR}ERROR${TESTLIB_RESET_COLOR} Test failed out side of test. Maybe source file or test file is bad" 1>&2
+    echo "${TESTLIB_BAD_COLOR}ERROR${TESTLIB_RESET_COLOR} Test failed outside of test. Maybe a sourced file or the test file has a problem" 1>&2
     exit 123
   fi
   unset test_status


### PR DESCRIPTION
- Un-hardcode non-core external command
- Consistently add quotes around these aliases.
  - The old rejected argument to leave the quotes off was to:
    - Support corner cases like `FOO='echo foo'`
    - At the sacrifice of supporting spaces, like `/foo/b a  r/stuff`
    - However this is just adding unexpected behavior
    - This can be also accomplished via `foo2(){ echo foo "${@}"); export -f foo2; export FOO=foo2`
      - This will work unless bash calls python which calls bash
      - Then you'll have to use an external file like `/tmp/foo2`
      - The takeaway is there are more normal workarounds to cover this corner case, so the missing quotes are purge
- `DRYRUN` is a different entity, and not the same as an "alias"