### PR TITLE
Improve load uvm script

### DIFF
--- a/linux/load_nvidia_uvm.py
+++ b/linux/load_nvidia_uvm.py
@@ -21,32 +21,39 @@ import os
 from glob import glob
 import sys
 
-def main(args=[]):
+def find_cudart(search_dirs):
   cuda_runtimes=[]
 
+  for search_dir in search_dirs:
+    for root, dirs, files in os.walk(search_dir, followlinks=False):
+      cuda_runtimes.extend([os.path.join(root, rt) \
+                            for rt in files \
+                            if rt.startswith('libcudart.so')])
+      for cuda_runtime in cuda_runtimes:
+        try:
+          return c.cdll.LoadLibrary(cuda_runtime)
+        except OSError:
+          continue
+
+  return None
+
+def main(args=[]):
+
   if args:
-    cuda_runtimes=args
+    cudart = c.cdll.LoadLibrary(args[0])
   else:
     # Attempt to discover cuda runtime
     common_dirs = glob('/usr/local/cuda*') + glob('/usr/cuda*') + ['/usr'] \
                   + [os.path.dirname(__file__)]
+    cudart = find_cudart(common_dirs)
 
-    for common_dir in common_dirs:
-      for root, dirs, files in os.walk(common_dir, followlinks=False):
-        cuda_runtimes.extend([os.path.join(root, rt) \
-                            for rt in files \
-                            if rt.startswith('libcudart.so')])
-        if cuda_runtimes:
-          break
-      if cuda_runtimes:
-        break
-
-  if not cuda_runtimes:
+  if not cudart:
     print("Could not find cuda runtime. "
           "Please pass the full path of a cuda runtime as an argument")
+    print("Try running:")
+    print("  python " + __file__ + " path_to_libcudart.so")
     exit(1)
 
-  cudart = c.cdll.LoadLibrary(cuda_runtimes[0])
   cudart.cudaGetDeviceCount.argtypes = (c.POINTER(c.c_int),)
 
   gpu_count = c.c_int(-1)

--- a/linux/load_nvidia_uvm.py
+++ b/linux/load_nvidia_uvm.py
@@ -26,10 +26,9 @@ def find_cudart(search_dirs):
 
   for search_dir in search_dirs:
     for root, dirs, files in os.walk(search_dir, followlinks=False):
-      cuda_runtimes.extend([os.path.join(root, rt) \
-                            for rt in files \
-                            if rt.startswith('libcudart.so')])
-      for cuda_runtime in cuda_runtimes:
+      for cuda_runtime in [os.path.join(root, rt) \
+                           for rt in files \
+                           if rt.startswith('libcudart.so')]:
         try:
           return c.cdll.LoadLibrary(cuda_runtime)
         except OSError:


### PR DESCRIPTION
Prevent accidentally loading a non-`.so` file (like a man page), and keep searching until either a success or no common dirs left to search