### PR TITLE
intersphinx non-default objects.inv

### DIFF
--- a/docker/vsi_common/sphinx.Justfile
+++ b/docker/vsi_common/sphinx.Justfile
@@ -129,7 +129,12 @@ function caseify()
         URL="$(find /docs -name objects.inv)"
       else
         INPUT="${1}"
-        URL="$(pipenv run python -c "import conf,posixpath; url=posixpath.join(conf.intersphinx_mapping['${INPUT}'][0], 'objects.inv'); print(url)" 2>/dev/null || echo "${INPUT}")"
+        URL=$(pipenv run python -c "if True:
+            import conf, posixpath
+            url = conf.intersphinx_mapping['${INPUT}'][0]
+            inv = conf.intersphinx_mapping['${INPUT}'][1] or 'objects.inv'
+            print(posixpath.join(url, inv))
+            ")
         echo "Fetch intersphinx mapping from <${URL}>..."
       fi
       exec pipenv run python -m sphinx.ext.intersphinx "${URL}"

--- a/docker/vsi_common/sphinx.Justfile
+++ b/docker/vsi_common/sphinx.Justfile
@@ -131,9 +131,9 @@ function caseify()
         INPUT="${1}"
         URL=$(pipenv run python -c "if True:
             import conf, posixpath
-            url = conf.intersphinx_mapping['${INPUT}'][0]
-            inv = conf.intersphinx_mapping['${INPUT}'][1] or 'objects.inv'
-            print(posixpath.join(url, inv))
+            url = (conf.intersphinx_mapping['${INPUT}'][1] or
+                   posixpath.join(conf.intersphinx_mapping['${INPUT}'][0], 'objects.inv'))
+            print(url)
             ")
         echo "Fetch intersphinx mapping from <${URL}>..."
       fi


### PR DESCRIPTION
update intersphinx capability to allow non-default `objects.inv` specification.  For example, django stores its object file at
https://docs.djangoproject.com/en/3.1/_objects

See first example here
https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping