### PR TITLE
appveyor ucrt64 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,7 +56,7 @@ install:
 
   # additional packages for test. This has to be a separate call from the pacman
   # install, due to pacman supporting a newer zip format
-  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S unzip"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy unzip"
 
   # debugging outputs
   - C:\msys64\usr\bin\bash -lc "cat ~/.bashrc"


### PR DESCRIPTION
Recent appveyor error:
> C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S unzip"
warning: database file for 'ucrt64' does not exist (use '-Sy' to download)
error: failed to prepare transaction (could not find database)

Fix by refreshing package database for ucrt64 repository after system upgrade.

