### PR TITLE
New just improvements

### DIFF
--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -368,7 +368,7 @@ function write_justfile()
                       #T# to be run the first time sync is run.
                       touch "${'"${PROJECT_PREFIX}"'_CWD}/.just_synced"
                     fi
-                    # Add any extra steps run when syncing
+                    # Add any extra steps to run when syncing
                     Docker-compose down
                     justify git_submodule-update # For those users who don'"'"'t remember!
                     justify build
@@ -381,14 +381,14 @@ function write_justfile()
                     extra_args=$#
                     ;;
                   clean_all) # Delete all local volumes
-                    #T# Optional ask question to protect accidental deletion.
-                    ask_question "Are you sure? This will remove packages not in Pipfile!" n
+                    #T# Confirm action to protect accidental deletion. Can be removed if you don't want it.
+                    ask_question "Are you sure you want to delete all docker volumes?" n
                     justify docker-compose clean --all
                     ;;
               ' >> "${1}"
     fi
     uwecho   '    *)
-                    #T# Forward targets to all other plugins, when they do not match any
+                    #T# Forward targets to all other plugins when they do not match any
                     #T# targets in this caseify.
                     defaultify "${just_arg}" ${@+"${@}"}
                     ;;
@@ -479,15 +479,16 @@ function write_dockerfile()
 {
   exists "${1}" && return 0
 
-  uwecho   '#T# Dockers use gosu instead of sudo for smoother operation
+  uwecho   '#T# Dockers use gosu instead of sudo because sudo is poorly designed for use in a docker
+  uwecho   '#T# Note: A function "sudo" is added to call "gosu root" for convenience
             FROM vsiri/recipe:gosu as gosu
-            #T# Dockers do not have a zombies reape by default, tini does this
+            #T# Dockers do not reap zombies by default, tini does this
             FROM vsiri/recipe:tini as tini
             #T# Just dockers use vsi common
             FROM vsiri/recipe:vsi as vsi' >> "${1}"
 
   if [ "${USE_PIPENV}" = "1" ]; then
-    uwecho '#T# Download and setups up pipenv for you
+    uwecho '#T# pipenv manages the python virtual env and installs a consistent set of packages
             FROM vsiri/recipe:pipenv as pipenv
             #T# # Uncomment for GDAL
             #T# FROM vsiri/recipe:gdal as gdal
@@ -529,18 +530,18 @@ function write_dockerfile()
             #T# COPY --from=gdal /usr/local /usr/local
             COPY --from=pipenv /usr/local /usr/local
 
-            #T# The universal "run all build steps for docker recipes like pipevn" command.
-            #T# Only has to be done once, after any number of COPY from commands.
+            #T# Run post-install scripts for docker recipes (like pipevn).
+            #T# Should be run after all of the "COPY --from" commands.
             #T# See https://git.io/JOcp6 for more details about docker recipes
             RUN for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
 
             ###############################################################################
 
-            #T# The pipenv_cache stage is a build staged dedicated to the smooth operation of
-            #T# "pipenv sync" and "pipenv install" commands. While the final stage stage does
-            #T# not need build dependencies for python packages, "pipenv sync" below will need
-            #T# all of the dependencies installed in order to compile wheels that are not
-            #T# pre-built wheels.
+            #T# The pipenv_cache stage is a build stage intended to make the operation of the
+            #T# "pipenv sync" and "pipenv install" commands more efficient. It also helps to
+            #T# minimize the size of the final build stage, which does not require any build
+            #T# dependencies needed by this stage to compile python packages during
+            #T# "pipenv sync" that, for example, do not have a pre-built wheels
             FROM dep_stage as pipenv_cache
 
             # Install your build dependencies for python packages here
@@ -557,12 +558,12 @@ function write_dockerfile()
             #T#     # this is difficult; the --keep-outdated flag is currently buggy)
             #T#     just sync # (optionally updates the docker image)
             #T# - Or editing your Pipfile manually (https://pipenv.pypa.io/en/latest/advanced/)
-            #T#   and then run
+            #T#   and then running
             #T#     just sync
 
-            #T# GDAL, for example, is a more complicated example
+            #T# A more complicated python package, for example, is GDAL
             #T# - The GDAL Docker recipe will build the GDAL C Library for you
-            #T# - The GDAL pypi packages needs numpy installed before it is built,
+            #T# - The GDAL pypi package needs numpy installed before it is built,
             #T#   otherwise, numpy integration will not be compiled and
             #T#   "import osgeo.gdal_array" will fail
             ##
@@ -570,9 +571,11 @@ function write_dockerfile()
             #T# 1) Uncomment all the "Uncomment for GDAL" sections
             #T# 2) just sync # Update the image
             #T# 3) just pipenv install numpy gdal==3.2.1 # Or edit the Pipfile manually
-            #T#    This will add the latest version of numpy and the version of the
-            #T#    pypi package gdal compatible with the GDAL C Library from the recipe.
-            #T#    Note: the version of the pypi GDAL and C GDAL should match as closely as possible
+            #T#    This will add the latest version of numpy (although a specific version can
+            #T#    be specified) and a version of the pypi package GDAL compatible with the
+            #T#    GDAL C Library from the recipe.
+            #T#    Note: the version of the pypi GDAL and C GDAL should match as closely as
+            #T#    possible
             #T# 4) just sync # (optionally updates the docker image)
 
 
@@ -587,9 +590,9 @@ function write_dockerfile()
                 # Cleanup and make way for the real /src that will be mounted at runtime
                 rm -rf /src/* /tmp/pip*
 
-            # These recipes are added hear instead of dep_stage do that the docker
-            # cache is not constantly rerunning pipenv sycn everytime the slightest
-            # change to vsi_common is made.
+            # These recipes are added here instead of in the dep_stage so that docker
+            # is not constantly rerunning pipenv sync everytime the slightest change
+            # to vsi_common is made.
             COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
             COPY --from=vsi /vsi /vsi
 
@@ -600,7 +603,7 @@ function write_dockerfile()
             ###############################################################################
 
             #T# The final stage is the runtime stage for the application, where everything
-            #T# that is needed is installed and setup
+            #T# else that is needed is installed and setup
             FROM dep_stage
             ' >> "${1}"
   else
@@ -629,7 +632,7 @@ function write_dockerfile()
               rm -rf /var/lib/apt/lists/*
 
             #T# Another typical example of installing a package, using it, and then removing
-            #T# it right away, for efficientcy/stability
+            #T# it by the end of the RUN command to minimize the size of the docker image
             #T# RUN build_deps="wget ca-certificates"; \
             #T#     apt-get update; \
             #T#     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${build_deps}; \
@@ -673,7 +676,7 @@ function write_app_justfile()
   uwecho   '#!/usr/bin/env false bash
             #T# Env false because you should never run this file directly.
             #T# bash is added because most code editors will detect this as a shell
-            #T# script and use the proper syntax color highlighter
+            #T# script and use the proper syntax highlighting
 
             source "${VSI_COMMON_DIR}/linux/just_files/just_default_run_functions.bsh"
 
@@ -1235,7 +1238,7 @@ function new_just()
   #
   # Flag to turn on tutorial comments
   #**
-  ask_question "Add tutorial comments? (only good if you are unfamiliar with just)" USE_TUTORIAL n
+  ask_question "Add tutorial comments? (good if you are unfamiliar with just)" USE_TUTORIAL n
 
   #**
   # .. env:: REPO_NAME

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -11,7 +11,7 @@ fi
 
 # Use a command like true, so that when I comment, it still works
 # COMMENT NEXT LINE when developing, uncomment before commiting.
-# cat - << 'true' > "${temp_file}"
+cat - << 'true' > "${temp_file}"
 
 #*# just/new_just
 
@@ -211,7 +211,7 @@ function write_project_env()
   exists "${1}" && return 0
 
   uwecho   'JUST_PROJECT_PREFIX='"${PROJECT_PREFIX}"'
-            JUST_VERSION="'"${JUST_VERSION-new_just}"'"
+            JUST_VERSION="'"${JUST_VERSION-JUST_VERSION unset in ${1}}"'"
             if [ -z "${'"${PROJECT_PREFIX}"'_CWD+set}" ]; then
               '"${PROJECT_PREFIX}"'_CWD="$(\cd "$(\dirname "${BASH_SOURCE[0]}")"; \pwd)"
             fi
@@ -293,7 +293,7 @@ function write_readme_md()
   fi
   uwecho   '```
 
-            #T# Just usage:
+            ## Just usage:
 
             ```' >> "${1}"
 
@@ -904,6 +904,17 @@ function write_gitignore()
   fi
 }
 
+function format_tutorial()
+{
+  if [ "${USE_TUTORIAL-}" = "1" ]; then
+    # Convert #T# to #
+    sed -i '/^ *#T# /{ s/#T#/#/; }' "${1}"
+  else
+    # Remove #T# lines
+    sed -i '/^ *#T# /d' "${1}"
+  fi
+}
+
 #**
 # .. function:: new_just
 #
@@ -1303,8 +1314,12 @@ function new_just()
   fi
 
   write_project_env "${PROJECT_NAME}.env"
+  format_tutorial "${PROJECT_NAME}.env"
+
   write_readme_md "README.md"
-  write_justfile "${JUSTFILE}" 755
+
+  write_justfile "${JUSTFILE}"
+  format_tutorial "${JUSTFILE}"
 
   if [ "${USE_PIPENV}" = "1" ]; then
     write_pipfile Pipfile
@@ -1315,19 +1330,24 @@ function new_just()
     mkdir -p docker
 
     write_dockerfile "docker/${APP_NAME}.Dockerfile"
+    format_tutorial "docker/${APP_NAME}.Dockerfile"
+
     write_app_justfile "docker/${APP_NAME}.Justfile"
+    format_tutorial "docker/${APP_NAME}.Justfile"
+
     write_docker_compose_yml docker-compose.yml
+    format_tutorial docker-compose.yml
+
     write_dockerignore .dockerignore
+    format_tutorial .dockerignore
   else
     write_hi_cpp hi.cpp
   fi
 
-  ###
   # Some final bookkeeping...
-  ###
-
-  write_gitattributes .gitattributes
   write_gitignore .gitignore
+  write_gitattributes .gitattributes
+  format_tutorial .gitattributes
 
   # ****************************************************************************
   # ****DONE****DONE****DONE****DONE****DONE****DONE****DONE****DONE****DONE****
@@ -1405,13 +1425,14 @@ function new_just()
 
   if [ "${USE_DOCKER}" = "1" ]; then
     uwecho "${just_cmd} sync
-            ${just_cmd} run ${APP_NAME} bash"
+            ${just_cmd} shell"
   else
     uwecho "${just_cmd} compile
             ${just_cmd} run"
   fi
 }
 
+# Don't remove this "true", this is part curl compatibility
 true
 
 # If statement in case mktemp is commented out for development purposes

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -11,7 +11,7 @@ fi
 
 # Use a command like true, so that when I comment, it still works
 # COMMENT NEXT LINE when developing, uncomment before commiting.
-cat - << 'true' > "${temp_file}"
+# cat - << 'true' > "${temp_file}"
 
 #*# just/new_just
 
@@ -474,21 +474,30 @@ function write_dockerfile()
 {
   exists "${1}" && return 0
 
-  uwecho   'FROM vsiri/recipe:gosu as gosu
+  uwecho   '## Dockers use gosu instead of sudo for smoother operation
+            FROM vsiri/recipe:gosu as gosu
+            ## Dockers do not have a zombies reape by default, tini does this
             FROM vsiri/recipe:tini as tini
+            ## Just dockers use vsi common
             FROM vsiri/recipe:vsi as vsi' >> "${1}"
 
   if [ "${USE_PIPENV}" = "1" ]; then
-    uwecho 'FROM vsiri/recipe:pipenv as pipenv
+    uwecho '## Download and setups up pipenv for you
+            FROM vsiri/recipe:pipenv as pipenv
             ## # Uncomment for GDAL
-            FROM vsiri/recipe:gdal as gdal
+            ## FROM vsiri/recipe:gdal as gdal
 
             ###############################################################################
 
+            ## The dep_stage stage is the common stage that all other stages can use. You
+            ## can install and setup any programs that are common to all of the other stages
             FROM debian:stretch as dep_stage
+
+            ## Unlike normal docker shells, this shell will stop after any error, so you
+            ## no longer need to end command lines with "&& \", you can just use a "; \"
             SHELL ["/usr/bin/env", "bash", "-euxvc"]
 
-            ## Install any runtime dependencies
+            # Install your common dependencies here
             RUN apt-get update; \
                 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
                   python3 tzdata ca-certificates; \
@@ -497,6 +506,7 @@ function write_dockerfile()
             ENV \
                 ## Move all virtualenvs to /venv
                 WORKON_HOME=/venv \
+                ## Make pipenv work from any directory in the container
                 PIPENV_PIPFILE=/src/Pipfile \
                 ## The pipenv cache is how we avoid recompiling packages at runtime
                 ## when the build dependencies are no longer available
@@ -513,11 +523,26 @@ function write_dockerfile()
             ## # Uncomment for GDAL
             ## COPY --from=gdal /usr/local /usr/local
             COPY --from=pipenv /usr/local /usr/local
+
+            ## The universal "run all build steps for docker recipes like pipevn" command.
+            ## Only has to be done once, after any number of COPY from commands.
+            ## See https://git.io/JOcp6 for more details about docker recipes
             RUN for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
 
             ###############################################################################
 
+            ## The pipenv_cache stage is a build staged dedicated to the smooth operation of
+            ## "pipenv sync" and "pipenv install" commands. While the final stage stage does
+            ## not need build dependencies for python packages, "pipenv sync" below will need
+            ## all of the dependencies installed in order to compile wheels that are not
+            ## pre-built wheels.
             FROM dep_stage as pipenv_cache
+
+            # Install your build dependencies for python packages here
+            ## RUN apt-get update; \
+            ##     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            ##       libxml-devel; \
+            ##     rm -r /var/lib/apt/lists/*
 
             ADD Pipfile Pipfile.lock /src/
             ## Simple packages can be added as dependencies to your project by:
@@ -525,34 +550,26 @@ function write_dockerfile()
             ##     just pipenv install scipy
             ##     # installs scipy (Note: all other packages will be updated. Avoiding
             ##     # this is difficult; the --keep-outdated flag is currently buggy)
-            ##     just sync (optionally update docker image)
+            ##     just sync # (optionally update docker image)
+            ## - Or editing your Pipfile manually (https://pipenv.pypa.io/en/latest/advanced/)
+            ##   and then run
+            ##     just sync
 
             ## GDAL, for example, is a more complicated example
             ## - The GDAL Docker recipe will build the GDAL C Library for you
-            ## - GDAL needs numpy installed before it is built, otherwise, numpy
-            ##   integration will not be compiled
+            ## - The GDAL pypi packages needs numpy installed before it is built,
+            ##   otherwise, numpy integration will not be compiled and
+            ##   "import osgeo.gdal_array" will fail
             ##
             ## To test this out:
             ## 1) Uncomment all the "Uncomment for GDAL" sections
-            ## 2) just sync
-            ## 3) Remove the existing pipenv install section below
-            ## 4) Edit your Pipfile and add the following lines (or similar) to the
-            ##    [packages] section
-            ##        gdal = "==2.1.0"
-            ##        numpy = "*"
-            ##    This will add the latest version of numpy and the version of
-            ##    gdal compatible with debian:stretch to your pipenv environment.
-            ##    Note: the version of the pypi package should match (as closely as
-            ##    possible) to the version of the GDAL-binary dependency (gdal-bin)
-            ## 5) just pipenv install
-            ## 6) just sync (optionally update docker image)
-            ##
-            ## Steps 4 and 5 can also be done by:
-            ## - just pipenv install numpy gdal==2.1.0
-            ## - These can be combined because numpy is already installed at
-            ##   just sync time, so numpy was already installed before gdal
-            ## - All other pipenv install arguments can be passed in, such as
-            ##   --pre, etc...
+            ## 2) just sync # Update the image
+            ## 3) just pipenv install numpy gdal==3.2.1 # Or edit the Pipfile manually
+            ##    This will add the latest version of numpy and the version of the
+            ##    pypi package gdal compatible with the GDAL C Library from the recipe.
+            ##    Note: the version of the pypi gdal and C should match as closely as possible
+            ## 4) just sync # (optionally update docker image)
+
 
             RUN \
             ## # Uncomment for GDAL
@@ -565,6 +582,9 @@ function write_dockerfile()
                 # Cleanup and make way for the real /src that will be mounted at runtime
                 rm -rf /src/* /tmp/pip*
 
+            # These recipes are added hear instead of dep_stage do that the docker
+            # cache is not constantly rerunning pipenv sycn everytime the slightest
+            # change to vsi_common is made.
             COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
             COPY --from=vsi /vsi /vsi
 
@@ -574,31 +594,37 @@ function write_dockerfile()
 
             ###############################################################################
 
-            FROM dep_stage' >> "${1}"
+            ## The final stage is the runtime stage for the application, where everything
+            ## that is needed is installed and setup
+            FROM dep_stage
+            ' >> "${1}"
   else
     uwecho '
             ###############################################################################
 
             FROM debian:stretch
-            SHELL ["/usr/bin/env", "bash", "-euxvc"]
 
-            # Install any runtime dependencies
-            RUN apt-get update; \
-                DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-                  tzdata; \
-                rm -r /var/lib/apt/lists/*' >> "${1}"
+            ## Unlike normal docker shells, this shell will stop after any error, so you
+            ## no longer need to end command lines with "&& \", you can just use a "; \"
+            SHELL ["/usr/bin/env", "bash", "-euxvc"]
+            ' >> "${1}"
   fi
 
-  uwecho   '
-            # Install any additional packages
-            RUN apt-get update; \
-                DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-                  ## Example of a package
-                  ## qbs-examples \
-                  ; \
-                rm -rf /var/lib/apt/lists/*
+  uwecho '# Install your runtime dependencies here
+          RUN apt-get update; \
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+                ## Example of a package
+                ## qbs-examples \' >> "${1}"
 
-            ## Another typical example of installing a package
+  if [ "${USE_PIPENV}" != "1" ]; then
+    echo '      tzdata \' >> "${1}"
+  fi
+
+  uwecho '      ; \
+              rm -rf /var/lib/apt/lists/*
+
+            ## Another typical example of installing a package, using it, and then removing
+            ## it right away, for efficientcy/stability
             ## RUN build_deps="wget ca-certificates"; \
             ##     apt-get update; \
             ##     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${build_deps}; \
@@ -607,10 +633,9 @@ function write_dockerfile()
             ##     rm -rf /var/lib/apt/lists/*
 
             COPY --from=tini /usr/local /usr/local
-
             COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
             ## Allow non-privileged to run gosu (remove this to take root away from user)
-            ## Do not use this in production!
+            ## Do not leave this in for production!
             RUN chmod u+s /usr/local/bin/gosu
             ' >> "${1}"
 
@@ -618,8 +643,7 @@ function write_dockerfile()
     uwecho 'COPY --from=pipenv_cache /venv /venv' >> "${1}"
   fi
 
-  uwecho   '
-            COPY --from=vsi /vsi /vsi
+  uwecho   'COPY --from=vsi /vsi /vsi
             ADD ["'"$(docker_add_quote_escape "${PROJECT_NAME}.env")"'", "Pipfile", "Pipfile.lock", "/src/"]
             ADD ["'"$(docker_add_quote_escape docker/"${APP_NAME}.Justfile")"'", "/src/docker/"]
 
@@ -630,6 +654,7 @@ function write_dockerfile()
             ## Does not require execute permissions, unlike:
             ## ENTRYPOINT ["/usr/local/bin/tini", "--", "/vsi/linux/just_files/just_entrypoint.sh"]
 
+            ## Update the default '"${APP_NAME}.Justfile"' target
             CMD ["'"${APP_NAME}"'-cmd"]' >> "${1}"
 }
 
@@ -641,6 +666,9 @@ function write_app_justfile()
   exists "${1}" 755 && return 0
 
   uwecho   '#!/usr/bin/env false bash
+            ## Env false because you should never run this file directly.
+            ## bash is added because most code editors will detect this as a shell
+            ## script and use the proper syntax color highlighter
 
             source "${VSI_COMMON_DIR}/linux/just_files/just_default_run_functions.bsh"
 

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -241,7 +241,7 @@ function write_project_env()
                   ${'"${PROJECT_PREFIX}"'_VOLUMES+"${'"${PROJECT_PREFIX}"'_VOLUMES[@]}"})
             fi
 
-            ## Example of a Dynamic Volume, that is created programmatically instead
+            ## Example of a Dynamic Volume that is created programmatically instead of
             ## always there. This directory is added to the container using '"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES.
             ## This mechanism is better when the directory doesn'"'"'t exist, as the directory
             ## will be created and owned properly, unlike docker'"'"'s default behavior
@@ -352,8 +352,13 @@ function write_justfile()
     uwecho   '      fi
                     ;;' >> "${1}"
     uwecho   '    run_'"${APP_NAME}"') # Run '"${APP_NAME}"' 1
+                    # These commands should run your app
                     Just-docker-compose run --service-ports '"${APP_NAME}"' ${@+"${@}"}
                     extra_args=$#
+                    ;;
+
+                  shell) # Start a bash shell in your runtime environment
+                    Just-docker-compose run '"${APP_NAME}"' shell
                     ;;
 
                   sync) # Synchronize the many aspects of the project when new code changes \
@@ -363,7 +368,7 @@ function write_justfile()
                       ## to be run the first time sync is run.
                       touch "${'"${PROJECT_PREFIX}"'_CWD}/.just_synced"
                     fi
-                    ## Add any extra steps run when syncing every time
+                    # Add any extra steps run when syncing
                     Docker-compose down
                     justify git_submodule-update # For those users who don'"'"'t remember!
                     justify build
@@ -550,7 +555,7 @@ function write_dockerfile()
             ##     just pipenv install scipy
             ##     # installs scipy (Note: all other packages will be updated. Avoiding
             ##     # this is difficult; the --keep-outdated flag is currently buggy)
-            ##     just sync # (optionally update docker image)
+            ##     just sync # (optionally updates the docker image)
             ## - Or editing your Pipfile manually (https://pipenv.pypa.io/en/latest/advanced/)
             ##   and then run
             ##     just sync
@@ -567,8 +572,8 @@ function write_dockerfile()
             ## 3) just pipenv install numpy gdal==3.2.1 # Or edit the Pipfile manually
             ##    This will add the latest version of numpy and the version of the
             ##    pypi package gdal compatible with the GDAL C Library from the recipe.
-            ##    Note: the version of the pypi gdal and C should match as closely as possible
-            ## 4) just sync # (optionally update docker image)
+            ##    Note: the version of the pypi GDAL and C GDAL should match as closely as possible
+            ## 4) just sync # (optionally updates the docker image)
 
 
             RUN \
@@ -634,7 +639,7 @@ function write_dockerfile()
 
             COPY --from=tini /usr/local /usr/local
             COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
-            ## Allow non-privileged to run gosu (remove this to take root away from user)
+            ## Allow non-privileged user to run gosu (remove this to take root away from user)
             ## Do not leave this in for production!
             RUN chmod u+s /usr/local/bin/gosu
             ' >> "${1}"
@@ -714,7 +719,7 @@ function write_app_justfile()
                 ## When a container runs, its docker "command" is passed to this Justfile.
                 ## This command is matched to the just targets above. When none of those
                 ## targets are matched, this defaultify will run the command exactly as is
-                ## (by the just_default_run_functions plugin)
+                ## (thanks to the just_default_run_functions plugin)
                 defaultify "${cmd}" ${@+"${@}"}
                 ;;
             esac
@@ -794,7 +799,7 @@ function write_docker_compose_yml()
 function write_dockerignore()
 {
   if ! exists "${1}"; then
-    uwecho "## Just dockers ignore all files by default, and you have to add exceptions
+    uwecho "## Just dockers ignore all files by default, and you must add exceptions
             ## for each file you want to have added to the docker context. This results
             ## in faster build times, and does not add minutes when you add GBs of data
             ## to a folder that do not need to part of the docker image.
@@ -834,8 +839,8 @@ function write_gitattributes()
 {
   if ! exists "${1}"; then
     uwecho '## These file types are being explicitly set to linux line endings for windows.
-            ## This is to allow windows user to edit and run these files inside a linux docker
-            ## this list may need additions as time goes on' > "${1}"
+            ## This is to allow a windows user to edit and run these files inside a linux docker.
+            ## This list may need additions as time goes on' > "${1}"
   elif [ "$(tail -c 1 "${1}")" != "" ]; then
     echo >> "${1}"
   fi

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -229,26 +229,27 @@ function write_project_env()
             : ${'"${PROJECT_PREFIX}"'_GID=${'"${PROJECT_PREFIX}"'_GIDS%% *}}
             : ${'"${PROJECT_PREFIX}"'_GROUP_NAMES=$(group_names)}
 
-            # This directory is added to the container using the docker-compose file. This mechanism
-            # should only be used when the directory is guaranteed to exist
+            ## This directory is added to the container using the docker-compose file. This mechanism
+            ## should only be used when the directory is guaranteed to exist
             : ${'"${PROJECT_PREFIX}"'_SOURCE_DIR=${'"${PROJECT_PREFIX}"'_CWD}}
             : ${'"${PROJECT_PREFIX}"'_SOURCE_DIR_DOCKER=/src}
             : ${'"${PROJECT_PREFIX}"'_SOURCE_DIR_TYPE=bind}
 
+            ## Add graphical support for Linux containers on Linux
             if [ -d /tmp/.X11-unix ]; then
               '"${PROJECT_PREFIX}"'_VOLUMES=("/tmp/.X11-unix:/tmp/.X11-unix:ro"
                   ${'"${PROJECT_PREFIX}"'_VOLUMES+"${'"${PROJECT_PREFIX}"'_VOLUMES[@]}"})
             fi
 
-            # Example of a Dynamic Volume, that is created programmatically instead
-            # always there. This directory is added to the container using '"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES.
-            # This mechanism is better when the directory doesn'"'"'t exist, as the directory
-            # will be created and owned properly, unlike docker'"'"'s default behavior
-            # : ${'"${PROJECT_PREFIX}"'_DATA_DIR=${'"${PROJECT_PREFIX}"'_SOURCE_DIR}/new-data}
-            # : ${'"${PROJECT_PREFIX}"'_DATA_DIR_DOCKER=/data}
-            # '"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES=(
-            #     "${'"${PROJECT_PREFIX}"'_DATA_DIR}:${'"${PROJECT_PREFIX}"'_DATA_DIR_DOCKER}"
-            #     ${'"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES+"${'"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES[@]}"})
+            ## Example of a Dynamic Volume, that is created programmatically instead
+            ## always there. This directory is added to the container using '"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES.
+            ## This mechanism is better when the directory doesn'"'"'t exist, as the directory
+            ## will be created and owned properly, unlike docker'"'"'s default behavior
+            ## : ${'"${PROJECT_PREFIX}"'_DATA_DIR=${'"${PROJECT_PREFIX}"'_SOURCE_DIR}/new-data}
+            ## : ${'"${PROJECT_PREFIX}"'_DATA_DIR_DOCKER=/data}
+            ## '"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES=(
+            ##     "${'"${PROJECT_PREFIX}"'_DATA_DIR}:${'"${PROJECT_PREFIX}"'_DATA_DIR_DOCKER}"
+            ##     ${'"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES+"${'"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES[@]}"})
 
             ###############################################################################
             # Non-'"${PROJECT_PREFIX}"' Settings
@@ -358,11 +359,11 @@ function write_justfile()
                   sync) # Synchronize the many aspects of the project when new code changes \
                         # are applied e.g. after "git checkout"
                     if [ ! -e "${'"${PROJECT_PREFIX}"'_CWD}/.just_synced" ]; then
-                      # Add any commands here, like initializing a database, etc... that need
-                      # to be run the first time sync is run.
+                      ## Add any commands here, like initializing a database, etc... that need
+                      ## to be run the first time sync is run.
                       touch "${'"${PROJECT_PREFIX}"'_CWD}/.just_synced"
                     fi
-                    # Add any extra steps run when syncing everytime
+                    ## Add any extra steps run when syncing every time
                     Docker-compose down
                     justify git_submodule-update # For those users who don'"'"'t remember!
                     justify build
@@ -375,17 +376,21 @@ function write_justfile()
                     extra_args=$#
                     ;;
                   clean_all) # Delete all local volumes
+                    ## Optional ask question to protect accidental deletion.
                     ask_question "Are you sure? This will remove packages not in Pipfile!" n
                     justify docker-compose clean --all
                     ;;
               ' >> "${1}"
     fi
     uwecho   '    *)
+                    ## Forward targets to all other plugins, when they do not match any
+                    ## targets in this caseify.
                     defaultify "${just_arg}" ${@+"${@}"}
                     ;;
                 esac
               }
 
+              ## Add support to have Justfile called directly
               if ! command -v justify &> /dev/null; then caseify ${@+"${@}"};fi' >> "${1}"
   else
     uwecho   'cd "${'"${PROJECT_PREFIX}"'_CWD}"
@@ -475,36 +480,38 @@ function write_dockerfile()
 
   if [ "${USE_PIPENV}" = "1" ]; then
     uwecho 'FROM vsiri/recipe:pipenv as pipenv
+            ## # Uncomment for GDAL
+            FROM vsiri/recipe:gdal as gdal
 
             ###############################################################################
 
             FROM debian:stretch as dep_stage
             SHELL ["/usr/bin/env", "bash", "-euxvc"]
 
-            # Install any runtime dependencies
+            ## Install any runtime dependencies
             RUN apt-get update; \
                 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-                  # # Uncomment for GDAL
-                  # gdal-bin \
                   python3 tzdata ca-certificates; \
                 rm -r /var/lib/apt/lists/*
 
             ENV \
-                # Move all virtualenvs to /venv
+                ## Move all virtualenvs to /venv
                 WORKON_HOME=/venv \
                 PIPENV_PIPFILE=/src/Pipfile \
-                # The pipenv cache is how we avoid recompiling packages at runtime
-                # when the build dependencies are no longer available
+                ## The pipenv cache is how we avoid recompiling packages at runtime
+                ## when the build dependencies are no longer available
                 PIPENV_CACHE_DIR=/venv/cache \
-                # Needed for pipenv shell
+                ## Needed for pipenv shell
                 PYENV_SHELL=/bin/bash \
-                # pipenv recommends that these env variables be set to en_US.UTF-8.
-                # On debian, C.UTF-8 exists by default instead, and seems to work.
-                # More detail: https://stackoverflow.com/a/38553499
-                # Note: en_US.UTF-8 exists by default in Centos/Fedora base images
+                ## pipenv recommends that these env variables be set to en_US.UTF-8.
+                ## On debian, C.UTF-8 exists by default instead, and seems to work.
+                ## More detail: https://stackoverflow.com/a/38553499
+                ## Note: en_US.UTF-8 exists by default in Centos/Fedora base images
                 LC_ALL=C.UTF-8 \
                 LANG=C.UTF-8
 
+            ## # Uncomment for GDAL
+            ## COPY --from=gdal /usr/local /usr/local
             COPY --from=pipenv /usr/local /usr/local
             RUN for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
 
@@ -512,74 +519,51 @@ function write_dockerfile()
 
             FROM dep_stage as pipenv_cache
 
-            # # Uncomment for GDAL
-            # # Install any build dependencies
-            # RUN apt-get update; \
-            #     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            #       libgdal-dev python3-dev g++ ; \
-            #     rm -r /var/lib/apt/lists/*
-            #
-            #     # GDAL specific hacks
-            # ENV CPLUS_INCLUDE_PATH=/usr/include/gdal \
-            #     C_INCLUDE_PATH=/usr/include/gdal
-
             ADD Pipfile Pipfile.lock /src/
-            # Simple packages can be added as dependencies to your project by:
-            # - Running the container and installing them directly with pipenv; e.g.,
-            #     just pipenv install scipy
-            #     # installs scipy (Note: all other packages will be updated. Avoiding
-            #     # this is difficult; the --keep-outdated flag is currently buggy)
-            #     just sync (optionally update docker image)
+            ## Simple packages can be added as dependencies to your project by:
+            ## - Running the container and installing them directly with pipenv; e.g.,
+            ##     just pipenv install scipy
+            ##     # installs scipy (Note: all other packages will be updated. Avoiding
+            ##     # this is difficult; the --keep-outdated flag is currently buggy)
+            ##     just sync (optionally update docker image)
 
-            # GDAL, for example, is a more complicated example
-            # - GDAL has extra build dependencies. The apt-get pattern above will install
-            #   these dependencies.
-            # - GDAL'"'"'s build script needs some customization. The ENV exports
-            #   above accomplish this
-            # - GDAL needs numpy installed before it is built, otherwise, numpy
-            #   integration will not be compiled
-            #
-            # To test this out:
-            # 1) Uncomment all the "Uncomment for GDAL" sections
-            # 2) just sync
-            # 3) Remove the existing pipenv install section below
-            # 4) Edit your Pipfile and add the following lines (or similar) to the
-            #    [packages] section
-            #        gdal = "==2.1.0"
-            #        numpy = "*"
-            #    This will add the latest version of numpy and the version of
-            #    gdal compatible with debian:stretch to your pipenv environment.
-            #    Note: the version of the pypi package should match (as closely as
-            #    possible) to the version of the GDAL-binary dependency (gdal-bin)
-            # 5) just pipenv install
-            # 6) just sync (optionally update docker image)
-            #
-            # Steps 4 and 5 can also be done by:
-            # - just pipenv install numpy gdal==2.1.0
-            # - These can be combined because numpy is already installed at
-            #   just sync time, so numpy was already installed before gdal
-            # - All other pipenv install arguments can be passed in, such as
-            #   --pre, etc...
-
-            # # Uncomment for GDAL
-            # RUN \
-            #     # Get the version marker of numpy specified in the lock file, else blank
-            #     numpy_version="$(python -c "import json; print(json.load(open('"'"'${PIPENV_PIPFILE}.lock'"'"', '"'"'r'"'"'))['"'"'default'"'"']['"'"'numpy'"'"']['"'"'version'"'"'])" 2>/dev/null)" || :; \
-            #     # Install numpy first, so that the gdal install works.
-            #     pipenv run pip install numpy${numpy_version}; \
-            #     # Now install all the packages.
-            #     pipenv sync; \
-            #     rm -rf /src/* /tmp/pip*
+            ## GDAL, for example, is a more complicated example
+            ## - The GDAL Docker recipe will build the GDAL C Library for you
+            ## - GDAL needs numpy installed before it is built, otherwise, numpy
+            ##   integration will not be compiled
+            ##
+            ## To test this out:
+            ## 1) Uncomment all the "Uncomment for GDAL" sections
+            ## 2) just sync
+            ## 3) Remove the existing pipenv install section below
+            ## 4) Edit your Pipfile and add the following lines (or similar) to the
+            ##    [packages] section
+            ##        gdal = "==2.1.0"
+            ##        numpy = "*"
+            ##    This will add the latest version of numpy and the version of
+            ##    gdal compatible with debian:stretch to your pipenv environment.
+            ##    Note: the version of the pypi package should match (as closely as
+            ##    possible) to the version of the GDAL-binary dependency (gdal-bin)
+            ## 5) just pipenv install
+            ## 6) just sync (optionally update docker image)
+            ##
+            ## Steps 4 and 5 can also be done by:
+            ## - just pipenv install numpy gdal==2.1.0
+            ## - These can be combined because numpy is already installed at
+            ##   just sync time, so numpy was already installed before gdal
+            ## - All other pipenv install arguments can be passed in, such as
+            ##   --pre, etc...
 
             RUN \
+            ## # Uncomment for GDAL
+            ##     # Get the version marker of numpy specified in the lock file, else blank
+            ##     numpy_version="$(python -c "import json; print(json.load(open('"'"'${PIPENV_PIPFILE}.lock'"'"', '"'"'r'"'"'))['"'"'default'"'"']['"'"'numpy'"'"']['"'"'version'"'"'])" 2>/dev/null)" || :; \
+            ##     # Install numpy first, so that the gdal install works.
+            ##     pipenv run pip install numpy${numpy_version}; \
                 # Install all packages into the image
                 pipenv sync; \
                 # Cleanup and make way for the real /src that will be mounted at runtime
                 rm -rf /src/* /tmp/pip*
-
-            ###############################################################################
-
-            FROM pipenv_cache as pipenv_run
 
             COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
             COPY --from=vsi /vsi /vsi
@@ -609,22 +593,24 @@ function write_dockerfile()
             # Install any additional packages
             RUN apt-get update; \
                 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-                  # Example of a package
-                  qbs-examples; \
+                  ## Example of a package
+                  ## qbs-examples \
+                  ; \
                 rm -rf /var/lib/apt/lists/*
 
-            # Another typical example of installing a package
-            # RUN build_deps="wget ca-certificates"; \
-            #     apt-get update; \
-            #     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${build_deps}; \
-            #     wget -q https://www.vsi-ri.com/bin/deviceQuery; \
-            #     DEBIAN_FRONTEND=noninteractive apt-get purge -y --autoremove ${build_deps}; \
-            #     rm -rf /var/lib/apt/lists/*
+            ## Another typical example of installing a package
+            ## RUN build_deps="wget ca-certificates"; \
+            ##     apt-get update; \
+            ##     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${build_deps}; \
+            ##     wget -q https://www.vsi-ri.com/bin/deviceQuery; \
+            ##     DEBIAN_FRONTEND=noninteractive apt-get purge -y --autoremove ${build_deps}; \
+            ##     rm -rf /var/lib/apt/lists/*
 
             COPY --from=tini /usr/local /usr/local
 
             COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
-            # Allow non-privileged to run gosu (remove this to take root away from user)
+            ## Allow non-privileged to run gosu (remove this to take root away from user)
+            ## Do not use this in production!
             RUN chmod u+s /usr/local/bin/gosu
             ' >> "${1}"
 
@@ -641,8 +627,8 @@ function write_dockerfile()
                 JUST_SETTINGS="/src/'"$(docker_env_quote_escape "${PROJECT_NAME}.env")"'"
 
             ENTRYPOINT ["/usr/local/bin/tini", "--", "/usr/bin/env", "bash", "/vsi/linux/just_files/just_entrypoint.sh"]
-            # Does not require execute permissions, unlike:
-            # ENTRYPOINT ["/usr/local/bin/tini", "--", "/vsi/linux/just_files/just_entrypoint.sh"]
+            ## Does not require execute permissions, unlike:
+            ## ENTRYPOINT ["/usr/local/bin/tini", "--", "/vsi/linux/just_files/just_entrypoint.sh"]
 
             CMD ["'"${APP_NAME}"'-cmd"]' >> "${1}"
 }
@@ -666,9 +652,12 @@ function write_app_justfile()
             ' >> "${1}"
 
   if [ "${USE_PIPENV}" = "1" ]; then
-    uwecho '    # default CMD
-                '"${APP_NAME}"'-cmd) # Run example shell
+    uwecho '    ## default CMD
+                '"${APP_NAME}"'-cmd) # Run '"${APP_NAME}"'
                   echo "Run '"${APP_NAME}"' here: ${cmd} ${@+${@}}"
+                  ;;
+
+                shell) # Start interactive shell
                   pipenv shell
                   ;;
 
@@ -679,26 +668,29 @@ function write_app_justfile()
                 pipenv) # Run pipenv command
                   exec "${cmd}" ${@+"${@}"}
                   ;;
-
-                *)
-                  defaultify "${cmd}" ${@+"${@}"}
-                  ;;
-              esac
-            }' >> "${1}"
+            ' >> "${1}"
   else
-    uwecho '    # default CMD
+    uwecho '    ## default CMD
                 '"${APP_NAME}"'-cmd) # Run example
                   echo "Run '"${APP_NAME}"' here: ${cmd} ${@+${@}}"
-                  bash
                   extra_args=$#
                   ;;
 
-                *)
-                  defaultify "${cmd}" ${@+"${@}"}
+                shell) # Start interactive shell
+                  bash
                   ;;
-              esac
-            }' >> "${1}"
+            ' >> "${1}"
   fi
+
+  uwecho '    *)
+                ## When a container runs, its docker "command" is passed to this Justfile.
+                ## This command is matched to the just targets above. When none of those
+                ## targets are matched, this defaultify will run the command exactly as is
+                ## (by the just_default_run_functions plugin)
+                defaultify "${cmd}" ${@+"${@}"}
+                ;;
+            esac
+          }' >> "${1}"
 }
 
 ##########################
@@ -721,10 +713,10 @@ function write_docker_compose_yml()
   fi
   uwecho   '      context: .
                   dockerfile: docker/'"${APP_NAME}"'.Dockerfile
-                # prevent different users from clobbering each others images
+                ## prevent different users from clobbering each others images
                 image: ${'"${PROJECT_PREFIX}"'_DOCKER_REPO}:'"${APP_NAME}"'_${'"${PROJECT_PREFIX}"'_USERNAME}
                 environment:
-                  # Variables for just_entrypoint_functions
+                  ## Variables for just_entrypoint_functions
                   - DOCKER_UID=${'"${PROJECT_PREFIX}"'_UID}
                   - DOCKER_GIDS=${'"${PROJECT_PREFIX}"'_GIDS}
                   - DOCKER_GROUP_NAMES=${'"${PROJECT_PREFIX}"'_GROUP_NAMES}
@@ -756,7 +748,7 @@ function write_docker_compose_yml()
                 <<: *'"${APP_NAME}"'
                 build:
                   <<: *'"${APP_NAME}"'_build
-                  target: pipenv_run
+                  target: pipenv_cache
                 image: ${'"${PROJECT_PREFIX}"'_DOCKER_REPO}:'"${APP_NAME}"'_pipenv_${'"${PROJECT_PREFIX}"'_USERNAME}
             volumes:
               venv:
@@ -795,9 +787,9 @@ function write_dockerignore()
 function write_gitattributes()
 {
   exists "${1}" && return 0
-  uwecho '# These file types are being explicitly set to linux line endings for windows.
-          # This is to allow windows user to edit and run these files inside a linux docker
-          # this list may need additions as time goes on
+  uwecho '## These file types are being explicitly set to linux line endings for windows.
+          ## This is to allow windows user to edit and run these files inside a linux docker
+          ## this list may need additions as time goes on
           *.sh eol=lf
           *.bsh eol=lf
           *.py eol=lf

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -479,7 +479,7 @@ function write_dockerfile()
 {
   exists "${1}" && return 0
 
-  uwecho   '#T# Dockers use gosu instead of sudo because sudo is poorly designed for use in a docker
+  uwecho   '#T# Dockers use gosu instead of sudo because sudo is a poor fit for docker.
   uwecho   '#T# Note: A function "sudo" is added to call "gosu root" for convenience
             FROM vsiri/recipe:gosu as gosu
             #T# Dockers do not reap zombies by default, tini does this
@@ -803,9 +803,10 @@ function write_dockerignore()
 {
   if ! exists "${1}"; then
     uwecho "#T# Just dockers ignore all files by default, and you must add exceptions
-            #T# for each file you want to have added to the docker context. This results
-            #T# in faster build times, and does not add minutes when you add GBs of data
-            #T# to a folder that do not need to part of the docker image.
+            #T# for each file you want to have added to the docker context. This is for cases
+            #T# where large amounts of data exist in the source folder, e.g., for development
+            #T# purposes, which are not need for docker build; ignoring these files results
+            #T# in faster build time.
             *" > "${1}"
   # https://stackoverflow.com/a/40919/4166604
   elif [ "$(tail -c 1 "${1}")" != "" ]; then

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -1382,8 +1382,15 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${
   exec 1>&2 # Copy stderr to 1
   just_stdout=3 new_just ${@+"${@}"}
 
-  # Stop new_just_cleanup from being called twice
-  trap -- EXIT
-fi
+  # # Stop new_just_cleanup from being called twice
+  # trap -- EXIT
+else
+  # uwecho won't work right unless this file is kept around, so if being sourced,
+  # then vsi_common_dir is there, and use trap_chain
 
-new_just_cleanup
+  source "${VSI_COMMON_DIR}/linux/signal_tools.bsh"
+
+  trap_chain "new_just_cleanup exit" EXIT
+  trap_chain "new_just_cleanup int" INT
+  trap_chain "new_just_cleanup term" TERM
+fi

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -765,19 +765,37 @@ function write_docker_compose_yml()
 #####################
 function write_dockerignore()
 {
-  exists "${1}" && return 0
-
-  echo   '*' >> "${1}"
-  echo   '!docker' >> "${1}"
-  if [ "${USE_VSI_COMMON}" = "1" ]; then
-    echo '!'"${RELATIVE_PATH}" >> "${1}"
+  if ! exists "${1}"; then
+    uwecho "## Just dockers ignore all files by default, and you have to add exceptions
+            ## for each file you want to have added to the docker context. This results
+            ## in faster build times, and does not add minutes when you add GBs of data
+            ## to a folder that do not need to part of the docker image.
+            *" > "${1}"
+  # https://stackoverflow.com/a/40919/4166604
+  elif [ "$(tail -c 1 "${1}")" != "" ]; then
+    echo >> "${1}"
   fi
 
-  echo   '!'"${PROJECT_NAME}.env" >> "${1}"
+  if ! grep -q '!docker' "${1}" 2>/dev/null; then
+    uwecho '## Add the entire docker subdir, everything in there should be for building images.
+            !docker' >> "${1}"
+  fi
+  if [ "${USE_VSI_COMMON}" = "1" ] && ! grep -q '!'"${RELATIVE_PATH}" "${1}" 2>/dev/null; then
+    uwecho '## We need the vsi common dir for the vsi recipe
+            !'"${RELATIVE_PATH}" >> "${1}"
+  fi
+
+  if ! grep -q '!'"${PROJECT_NAME}.env" "${1}" 2>/dev/null; then
+    echo   '!'"${PROJECT_NAME}.env" >> "${1}"
+  fi
 
   if [ "${USE_PIPENV}" = "1" ]; then
-    echo '!Pipfile' >> "${1}"
-    echo '!Pipfile.lock' >> "${1}"
+    if ! grep -q '!Pipfile$' "${1}" 2>/dev/null; then
+      echo '!Pipfile' >> "${1}"
+    fi
+    if ! grep -q '!Pipfile.lock$' "${1}" 2>/dev/null; then
+      echo '!Pipfile.lock' >> "${1}"
+    fi
   fi
 }
 
@@ -786,17 +804,33 @@ function write_dockerignore()
 ######################
 function write_gitattributes()
 {
-  exists "${1}" && return 0
-  uwecho '## These file types are being explicitly set to linux line endings for windows.
-          ## This is to allow windows user to edit and run these files inside a linux docker
-          ## this list may need additions as time goes on
-          *.sh eol=lf
-          *.bsh eol=lf
-          *.py eol=lf
-          *.env eol=lf
-          .justplugins eol=lf
-          Justfile eol=lf' >> "${1}"
-  if [ "${USE_DOCKER}" = "1" ]; then
+  if ! exists "${1}"; then
+    uwecho '## These file types are being explicitly set to linux line endings for windows.
+            ## This is to allow windows user to edit and run these files inside a linux docker
+            ## this list may need additions as time goes on' > "${1}"
+  elif [ "$(tail -c 1 "${1}")" != "" ]; then
+    echo >> "${1}"
+  fi
+
+  if ! grep -q "\*\.sh" "${1}" 2>/dev/null; then
+    echo '*.sh eol=lf' >> "${1}"
+  fi
+  if ! grep -q "\*\.bsh" "${1}" 2>/dev/null; then
+    echo '*.bsh eol=lf' >> "${1}"
+  fi
+  if ! grep -q "\*\.py" "${1}" 2>/dev/null; then
+    echo '*.py eol=lf' >> "${1}"
+  fi
+  if ! grep -q "\*\.env" "${1}" 2>/dev/null; then
+    echo '*.env eol=lf' >> "${1}"
+  fi
+  if ! grep -q "\.justplugins" "${1}" 2>/dev/null; then
+    echo '.justplugins eol=lf' >> "${1}"
+  fi
+  if ! grep -q "Justfile" "${1}" 2>/dev/null; then
+    echo 'Justfile eol=lf' >> "${1}"
+  fi
+  if [ "${USE_DOCKER}" = "1" ] && ! grep -q "\*\.Justfile" "${1}" 2>/dev/null; then
     echo '*.Justfile eol=lf' >> "${1}"
   fi
 }
@@ -820,6 +854,10 @@ function write_hi_cpp()
 ##################
 function write_gitignore()
 {
+  if [ "$(tail -c 1 "${1}")" != "" ]; then
+    echo >> "${1}"
+  fi
+
   if ! grep -q local.env "${1}" 2>/dev/null; then
     echo local.env >> "${1}"
   fi

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -229,27 +229,27 @@ function write_project_env()
             : ${'"${PROJECT_PREFIX}"'_GID=${'"${PROJECT_PREFIX}"'_GIDS%% *}}
             : ${'"${PROJECT_PREFIX}"'_GROUP_NAMES=$(group_names)}
 
-            ## This directory is added to the container using the docker-compose file. This mechanism
-            ## should only be used when the directory is guaranteed to exist
+            #T# This directory is added to the container using the docker-compose file. This mechanism
+            #T# should only be used when the directory is guaranteed to exist
             : ${'"${PROJECT_PREFIX}"'_SOURCE_DIR=${'"${PROJECT_PREFIX}"'_CWD}}
             : ${'"${PROJECT_PREFIX}"'_SOURCE_DIR_DOCKER=/src}
             : ${'"${PROJECT_PREFIX}"'_SOURCE_DIR_TYPE=bind}
 
-            ## Add graphical support for Linux containers on Linux
+            #T# Add graphical support for Linux containers on Linux
             if [ -d /tmp/.X11-unix ]; then
               '"${PROJECT_PREFIX}"'_VOLUMES=("/tmp/.X11-unix:/tmp/.X11-unix:ro"
                   ${'"${PROJECT_PREFIX}"'_VOLUMES+"${'"${PROJECT_PREFIX}"'_VOLUMES[@]}"})
             fi
 
-            ## Example of a Dynamic Volume that is created programmatically instead of
-            ## always there. This directory is added to the container using '"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES.
-            ## This mechanism is better when the directory doesn'"'"'t exist, as the directory
-            ## will be created and owned properly, unlike docker'"'"'s default behavior
-            ## : ${'"${PROJECT_PREFIX}"'_DATA_DIR=${'"${PROJECT_PREFIX}"'_SOURCE_DIR}/new-data}
-            ## : ${'"${PROJECT_PREFIX}"'_DATA_DIR_DOCKER=/data}
-            ## '"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES=(
-            ##     "${'"${PROJECT_PREFIX}"'_DATA_DIR}:${'"${PROJECT_PREFIX}"'_DATA_DIR_DOCKER}"
-            ##     ${'"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES+"${'"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES[@]}"})
+            #T# Example of a Dynamic Volume that is created programmatically instead of
+            #T# always there. This directory is added to the container using '"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES.
+            #T# This mechanism is better when the directory doesn'"'"'t exist, as the directory
+            #T# will be created and owned properly, unlike docker'"'"'s default behavior
+            #T# : ${'"${PROJECT_PREFIX}"'_DATA_DIR=${'"${PROJECT_PREFIX}"'_SOURCE_DIR}/new-data}
+            #T# : ${'"${PROJECT_PREFIX}"'_DATA_DIR_DOCKER=/data}
+            #T# '"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES=(
+            #T#     "${'"${PROJECT_PREFIX}"'_DATA_DIR}:${'"${PROJECT_PREFIX}"'_DATA_DIR_DOCKER}"
+            #T#     ${'"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES+"${'"${PROJECT_PREFIX}"'_'"${APP_NAME_UPPER}"'_VOLUMES[@]}"})
 
             ###############################################################################
             # Non-'"${PROJECT_PREFIX}"' Settings
@@ -293,7 +293,7 @@ function write_readme_md()
   fi
   uwecho   '```
 
-            ## Just usage:
+            #T# Just usage:
 
             ```' >> "${1}"
 
@@ -364,8 +364,8 @@ function write_justfile()
                   sync) # Synchronize the many aspects of the project when new code changes \
                         # are applied e.g. after "git checkout"
                     if [ ! -e "${'"${PROJECT_PREFIX}"'_CWD}/.just_synced" ]; then
-                      ## Add any commands here, like initializing a database, etc... that need
-                      ## to be run the first time sync is run.
+                      #T# Add any commands here, like initializing a database, etc... that need
+                      #T# to be run the first time sync is run.
                       touch "${'"${PROJECT_PREFIX}"'_CWD}/.just_synced"
                     fi
                     # Add any extra steps run when syncing
@@ -381,21 +381,21 @@ function write_justfile()
                     extra_args=$#
                     ;;
                   clean_all) # Delete all local volumes
-                    ## Optional ask question to protect accidental deletion.
+                    #T# Optional ask question to protect accidental deletion.
                     ask_question "Are you sure? This will remove packages not in Pipfile!" n
                     justify docker-compose clean --all
                     ;;
               ' >> "${1}"
     fi
     uwecho   '    *)
-                    ## Forward targets to all other plugins, when they do not match any
-                    ## targets in this caseify.
+                    #T# Forward targets to all other plugins, when they do not match any
+                    #T# targets in this caseify.
                     defaultify "${just_arg}" ${@+"${@}"}
                     ;;
                 esac
               }
 
-              ## Add support to have Justfile called directly
+              #T# Add support to have Justfile called directly
               if ! command -v justify &> /dev/null; then caseify ${@+"${@}"};fi' >> "${1}"
   else
     uwecho   'cd "${'"${PROJECT_PREFIX}"'_CWD}"
@@ -479,27 +479,27 @@ function write_dockerfile()
 {
   exists "${1}" && return 0
 
-  uwecho   '## Dockers use gosu instead of sudo for smoother operation
+  uwecho   '#T# Dockers use gosu instead of sudo for smoother operation
             FROM vsiri/recipe:gosu as gosu
-            ## Dockers do not have a zombies reape by default, tini does this
+            #T# Dockers do not have a zombies reape by default, tini does this
             FROM vsiri/recipe:tini as tini
-            ## Just dockers use vsi common
+            #T# Just dockers use vsi common
             FROM vsiri/recipe:vsi as vsi' >> "${1}"
 
   if [ "${USE_PIPENV}" = "1" ]; then
-    uwecho '## Download and setups up pipenv for you
+    uwecho '#T# Download and setups up pipenv for you
             FROM vsiri/recipe:pipenv as pipenv
-            ## # Uncomment for GDAL
-            ## FROM vsiri/recipe:gdal as gdal
+            #T# # Uncomment for GDAL
+            #T# FROM vsiri/recipe:gdal as gdal
 
             ###############################################################################
 
-            ## The dep_stage stage is the common stage that all other stages can use. You
-            ## can install and setup any programs that are common to all of the other stages
+            #T# The dep_stage stage is the common stage that all other stages can use. You
+            #T# can install and setup any programs that are common to all of the other stages
             FROM debian:stretch as dep_stage
 
-            ## Unlike normal docker shells, this shell will stop after any error, so you
-            ## no longer need to end command lines with "&& \", you can just use a "; \"
+            #T# Unlike normal docker shells, this shell will stop after any error, so you
+            #T# no longer need to end command lines with "&& \", you can just use a "; \"
             SHELL ["/usr/bin/env", "bash", "-euxvc"]
 
             # Install your common dependencies here
@@ -509,79 +509,79 @@ function write_dockerfile()
                 rm -r /var/lib/apt/lists/*
 
             ENV \
-                ## Move all virtualenvs to /venv
+                #T# Move all virtualenvs to /venv
                 WORKON_HOME=/venv \
-                ## Make pipenv work from any directory in the container
+                #T# Make pipenv work from any directory in the container
                 PIPENV_PIPFILE=/src/Pipfile \
-                ## The pipenv cache is how we avoid recompiling packages at runtime
-                ## when the build dependencies are no longer available
+                #T# The pipenv cache is how we avoid recompiling packages at runtime
+                #T# when the build dependencies are no longer available
                 PIPENV_CACHE_DIR=/venv/cache \
-                ## Needed for pipenv shell
+                #T# Needed for pipenv shell
                 PYENV_SHELL=/bin/bash \
-                ## pipenv recommends that these env variables be set to en_US.UTF-8.
-                ## On debian, C.UTF-8 exists by default instead, and seems to work.
-                ## More detail: https://stackoverflow.com/a/38553499
-                ## Note: en_US.UTF-8 exists by default in Centos/Fedora base images
+                #T# pipenv recommends that these env variables be set to en_US.UTF-8.
+                #T# On debian, C.UTF-8 exists by default instead, and seems to work.
+                #T# More detail: https://stackoverflow.com/a/38553499
+                #T# Note: en_US.UTF-8 exists by default in Centos/Fedora base images
                 LC_ALL=C.UTF-8 \
                 LANG=C.UTF-8
 
-            ## # Uncomment for GDAL
-            ## COPY --from=gdal /usr/local /usr/local
+            #T# # Uncomment for GDAL
+            #T# COPY --from=gdal /usr/local /usr/local
             COPY --from=pipenv /usr/local /usr/local
 
-            ## The universal "run all build steps for docker recipes like pipevn" command.
-            ## Only has to be done once, after any number of COPY from commands.
-            ## See https://git.io/JOcp6 for more details about docker recipes
+            #T# The universal "run all build steps for docker recipes like pipevn" command.
+            #T# Only has to be done once, after any number of COPY from commands.
+            #T# See https://git.io/JOcp6 for more details about docker recipes
             RUN for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
 
             ###############################################################################
 
-            ## The pipenv_cache stage is a build staged dedicated to the smooth operation of
-            ## "pipenv sync" and "pipenv install" commands. While the final stage stage does
-            ## not need build dependencies for python packages, "pipenv sync" below will need
-            ## all of the dependencies installed in order to compile wheels that are not
-            ## pre-built wheels.
+            #T# The pipenv_cache stage is a build staged dedicated to the smooth operation of
+            #T# "pipenv sync" and "pipenv install" commands. While the final stage stage does
+            #T# not need build dependencies for python packages, "pipenv sync" below will need
+            #T# all of the dependencies installed in order to compile wheels that are not
+            #T# pre-built wheels.
             FROM dep_stage as pipenv_cache
 
             # Install your build dependencies for python packages here
-            ## RUN apt-get update; \
-            ##     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            ##       libxml-devel; \
-            ##     rm -r /var/lib/apt/lists/*
+            #T# RUN apt-get update; \
+            #T#     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            #T#       libxml-devel; \
+            #T#     rm -r /var/lib/apt/lists/*
 
             ADD Pipfile Pipfile.lock /src/
-            ## Simple packages can be added as dependencies to your project by:
-            ## - Running the container and installing them directly with pipenv; e.g.,
-            ##     just pipenv install scipy
-            ##     # installs scipy (Note: all other packages will be updated. Avoiding
-            ##     # this is difficult; the --keep-outdated flag is currently buggy)
-            ##     just sync # (optionally updates the docker image)
-            ## - Or editing your Pipfile manually (https://pipenv.pypa.io/en/latest/advanced/)
-            ##   and then run
-            ##     just sync
+            #T# Simple packages can be added as dependencies to your project by:
+            #T# - Running the container and installing them directly with pipenv; e.g.,
+            #T#     just pipenv install scipy
+            #T#     # installs scipy (Note: all other packages will be updated. Avoiding
+            #T#     # this is difficult; the --keep-outdated flag is currently buggy)
+            #T#     just sync # (optionally updates the docker image)
+            #T# - Or editing your Pipfile manually (https://pipenv.pypa.io/en/latest/advanced/)
+            #T#   and then run
+            #T#     just sync
 
-            ## GDAL, for example, is a more complicated example
-            ## - The GDAL Docker recipe will build the GDAL C Library for you
-            ## - The GDAL pypi packages needs numpy installed before it is built,
-            ##   otherwise, numpy integration will not be compiled and
-            ##   "import osgeo.gdal_array" will fail
+            #T# GDAL, for example, is a more complicated example
+            #T# - The GDAL Docker recipe will build the GDAL C Library for you
+            #T# - The GDAL pypi packages needs numpy installed before it is built,
+            #T#   otherwise, numpy integration will not be compiled and
+            #T#   "import osgeo.gdal_array" will fail
             ##
-            ## To test this out:
-            ## 1) Uncomment all the "Uncomment for GDAL" sections
-            ## 2) just sync # Update the image
-            ## 3) just pipenv install numpy gdal==3.2.1 # Or edit the Pipfile manually
-            ##    This will add the latest version of numpy and the version of the
-            ##    pypi package gdal compatible with the GDAL C Library from the recipe.
-            ##    Note: the version of the pypi GDAL and C GDAL should match as closely as possible
-            ## 4) just sync # (optionally updates the docker image)
+            #T# To test this out:
+            #T# 1) Uncomment all the "Uncomment for GDAL" sections
+            #T# 2) just sync # Update the image
+            #T# 3) just pipenv install numpy gdal==3.2.1 # Or edit the Pipfile manually
+            #T#    This will add the latest version of numpy and the version of the
+            #T#    pypi package gdal compatible with the GDAL C Library from the recipe.
+            #T#    Note: the version of the pypi GDAL and C GDAL should match as closely as possible
+            #T# 4) just sync # (optionally updates the docker image)
 
 
             RUN \
-            ## # Uncomment for GDAL
-            ##     # Get the version marker of numpy specified in the lock file, else blank
-            ##     numpy_version="$(python -c "import json; print(json.load(open('"'"'${PIPENV_PIPFILE}.lock'"'"', '"'"'r'"'"'))['"'"'default'"'"']['"'"'numpy'"'"']['"'"'version'"'"'])" 2>/dev/null)" || :; \
-            ##     # Install numpy first, so that the gdal install works.
-            ##     pipenv run pip install numpy${numpy_version}; \
+            #T# # Uncomment for GDAL
+            #T#     # Get the version marker of numpy specified in the lock file, else blank
+            #T#     numpy_version="$(python -c "import json; print(json.load(open('"'"'${PIPENV_PIPFILE}.lock'"'"', '"'"'r'"'"'))['"'"'default'"'"']['"'"'numpy'"'"']['"'"'version'"'"'])" 2>/dev/null)" || :; \
+            #T#     # Install numpy first, so that the gdal install works.
+            #T#     pipenv run pip install numpy${numpy_version}; \
                 # Install all packages into the image
                 pipenv sync; \
                 # Cleanup and make way for the real /src that will be mounted at runtime
@@ -599,8 +599,8 @@ function write_dockerfile()
 
             ###############################################################################
 
-            ## The final stage is the runtime stage for the application, where everything
-            ## that is needed is installed and setup
+            #T# The final stage is the runtime stage for the application, where everything
+            #T# that is needed is installed and setup
             FROM dep_stage
             ' >> "${1}"
   else
@@ -609,8 +609,8 @@ function write_dockerfile()
 
             FROM debian:stretch
 
-            ## Unlike normal docker shells, this shell will stop after any error, so you
-            ## no longer need to end command lines with "&& \", you can just use a "; \"
+            #T# Unlike normal docker shells, this shell will stop after any error, so you
+            #T# no longer need to end command lines with "&& \", you can just use a "; \"
             SHELL ["/usr/bin/env", "bash", "-euxvc"]
             ' >> "${1}"
   fi
@@ -618,8 +618,8 @@ function write_dockerfile()
   uwecho '# Install your runtime dependencies here
           RUN apt-get update; \
               DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-                ## Example of a package
-                ## qbs-examples \' >> "${1}"
+                #T# Example of a package
+                #T# qbs-examples \' >> "${1}"
 
   if [ "${USE_PIPENV}" != "1" ]; then
     echo '      tzdata \' >> "${1}"
@@ -628,19 +628,19 @@ function write_dockerfile()
   uwecho '      ; \
               rm -rf /var/lib/apt/lists/*
 
-            ## Another typical example of installing a package, using it, and then removing
-            ## it right away, for efficientcy/stability
-            ## RUN build_deps="wget ca-certificates"; \
-            ##     apt-get update; \
-            ##     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${build_deps}; \
-            ##     wget -q https://www.vsi-ri.com/bin/deviceQuery; \
-            ##     DEBIAN_FRONTEND=noninteractive apt-get purge -y --autoremove ${build_deps}; \
-            ##     rm -rf /var/lib/apt/lists/*
+            #T# Another typical example of installing a package, using it, and then removing
+            #T# it right away, for efficientcy/stability
+            #T# RUN build_deps="wget ca-certificates"; \
+            #T#     apt-get update; \
+            #T#     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${build_deps}; \
+            #T#     wget -q https://www.vsi-ri.com/bin/deviceQuery; \
+            #T#     DEBIAN_FRONTEND=noninteractive apt-get purge -y --autoremove ${build_deps}; \
+            #T#     rm -rf /var/lib/apt/lists/*
 
             COPY --from=tini /usr/local /usr/local
             COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
-            ## Allow non-privileged user to run gosu (remove this to take root away from user)
-            ## Do not leave this in for production!
+            #T# Allow non-privileged user to run gosu (remove this to take root away from user)
+            #T# Do not leave this in for production!
             RUN chmod u+s /usr/local/bin/gosu
             ' >> "${1}"
 
@@ -656,10 +656,10 @@ function write_dockerfile()
                 JUST_SETTINGS="/src/'"$(docker_env_quote_escape "${PROJECT_NAME}.env")"'"
 
             ENTRYPOINT ["/usr/local/bin/tini", "--", "/usr/bin/env", "bash", "/vsi/linux/just_files/just_entrypoint.sh"]
-            ## Does not require execute permissions, unlike:
-            ## ENTRYPOINT ["/usr/local/bin/tini", "--", "/vsi/linux/just_files/just_entrypoint.sh"]
+            #T# Does not require execute permissions, unlike:
+            #T# ENTRYPOINT ["/usr/local/bin/tini", "--", "/vsi/linux/just_files/just_entrypoint.sh"]
 
-            ## Update the default '"${APP_NAME}.Justfile"' target
+            #T# Update the default '"${APP_NAME}.Justfile"' target
             CMD ["'"${APP_NAME}"'-cmd"]' >> "${1}"
 }
 
@@ -671,9 +671,9 @@ function write_app_justfile()
   exists "${1}" 755 && return 0
 
   uwecho   '#!/usr/bin/env false bash
-            ## Env false because you should never run this file directly.
-            ## bash is added because most code editors will detect this as a shell
-            ## script and use the proper syntax color highlighter
+            #T# Env false because you should never run this file directly.
+            #T# bash is added because most code editors will detect this as a shell
+            #T# script and use the proper syntax color highlighter
 
             source "${VSI_COMMON_DIR}/linux/just_files/just_default_run_functions.bsh"
 
@@ -685,7 +685,7 @@ function write_app_justfile()
             ' >> "${1}"
 
   if [ "${USE_PIPENV}" = "1" ]; then
-    uwecho '    ## default CMD
+    uwecho '    #T# default CMD
                 '"${APP_NAME}"'-cmd) # Run '"${APP_NAME}"'
                   echo "Run '"${APP_NAME}"' here: ${cmd} ${@+${@}}"
                   ;;
@@ -703,7 +703,7 @@ function write_app_justfile()
                   ;;
             ' >> "${1}"
   else
-    uwecho '    ## default CMD
+    uwecho '    #T# default CMD
                 '"${APP_NAME}"'-cmd) # Run example
                   echo "Run '"${APP_NAME}"' here: ${cmd} ${@+${@}}"
                   extra_args=$#
@@ -716,10 +716,10 @@ function write_app_justfile()
   fi
 
   uwecho '    *)
-                ## When a container runs, its docker "command" is passed to this Justfile.
-                ## This command is matched to the just targets above. When none of those
-                ## targets are matched, this defaultify will run the command exactly as is
-                ## (thanks to the just_default_run_functions plugin)
+                #T# When a container runs, its docker "command" is passed to this Justfile.
+                #T# This command is matched to the just targets above. When none of those
+                #T# targets are matched, this defaultify will run the command exactly as is
+                #T# (thanks to the just_default_run_functions plugin)
                 defaultify "${cmd}" ${@+"${@}"}
                 ;;
             esac
@@ -746,10 +746,10 @@ function write_docker_compose_yml()
   fi
   uwecho   '      context: .
                   dockerfile: docker/'"${APP_NAME}"'.Dockerfile
-                ## prevent different users from clobbering each others images
+                #T# prevent different users from clobbering each others images
                 image: ${'"${PROJECT_PREFIX}"'_DOCKER_REPO}:'"${APP_NAME}"'_${'"${PROJECT_PREFIX}"'_USERNAME}
                 environment:
-                  ## Variables for just_entrypoint_functions
+                  #T# Variables for just_entrypoint_functions
                   - DOCKER_UID=${'"${PROJECT_PREFIX}"'_UID}
                   - DOCKER_GIDS=${'"${PROJECT_PREFIX}"'_GIDS}
                   - DOCKER_GROUP_NAMES=${'"${PROJECT_PREFIX}"'_GROUP_NAMES}
@@ -799,10 +799,10 @@ function write_docker_compose_yml()
 function write_dockerignore()
 {
   if ! exists "${1}"; then
-    uwecho "## Just dockers ignore all files by default, and you must add exceptions
-            ## for each file you want to have added to the docker context. This results
-            ## in faster build times, and does not add minutes when you add GBs of data
-            ## to a folder that do not need to part of the docker image.
+    uwecho "#T# Just dockers ignore all files by default, and you must add exceptions
+            #T# for each file you want to have added to the docker context. This results
+            #T# in faster build times, and does not add minutes when you add GBs of data
+            #T# to a folder that do not need to part of the docker image.
             *" > "${1}"
   # https://stackoverflow.com/a/40919/4166604
   elif [ "$(tail -c 1 "${1}")" != "" ]; then
@@ -810,11 +810,11 @@ function write_dockerignore()
   fi
 
   if ! grep -q '!docker' "${1}" 2>/dev/null; then
-    uwecho '## Add the entire docker subdir, everything in there should be for building images.
+    uwecho '#T# Add the entire docker subdir, everything in there should be for building images.
             !docker' >> "${1}"
   fi
   if [ "${USE_VSI_COMMON}" = "1" ] && ! grep -q '!'"${RELATIVE_PATH}" "${1}" 2>/dev/null; then
-    uwecho '## We need the vsi common dir for the vsi recipe
+    uwecho '#T# We need the vsi common dir for the vsi recipe
             !'"${RELATIVE_PATH}" >> "${1}"
   fi
 
@@ -838,9 +838,9 @@ function write_dockerignore()
 function write_gitattributes()
 {
   if ! exists "${1}"; then
-    uwecho '## These file types are being explicitly set to linux line endings for windows.
-            ## This is to allow a windows user to edit and run these files inside a linux docker.
-            ## This list may need additions as time goes on' > "${1}"
+    uwecho '#T# These file types are being explicitly set to linux line endings for windows.
+            #T# This is to allow a windows user to edit and run these files inside a linux docker.
+            #T# This list may need additions as time goes on' > "${1}"
   elif [ "$(tail -c 1 "${1}")" != "" ]; then
     echo >> "${1}"
   fi
@@ -940,6 +940,7 @@ function new_just()
         echo "  --[no-]vsi - Enable/[disable] using the vsi submodule"
         echo "  --[no-]docker - Enable/[disable] setting up docker"
         echo "  --[no-]pipenv - Enable/[disable] using pipenv in docker"
+        echo "  --[no-]tutorial - Enable/[disable] adding tutorial comments"
         echo "  --app APP - Application name for docker-compose service"
         echo "  --repo REPO - Docker repo name for compiled images"
         echo "  --defaults - Use all defaults without prompting"
@@ -952,6 +953,7 @@ function new_just()
         USE_DEFAULTS=1
         : ${USE_DOCKER=y}
         : ${USE_PIPENV=y}
+        : ${USE_TUTORIAL=n}
         : ${SETUP_GIT=n}
         ;;
       --project-dir)
@@ -1012,6 +1014,12 @@ function new_just()
         ;;
       --no-git)
         SETUP_GIT=n
+        ;;
+      --tutorial)
+        USE_TUTORIAL=y
+        ;;
+      --no-tutorial)
+        USE_TUTORIAL=n
         ;;
       *)
         echo "Unknown argument: $arg"
@@ -1212,6 +1220,13 @@ function new_just()
     APP_NAME_UPPER=$(echo "${APP_NAME}" | tr '[a-z]' '[A-Z]')
 
   #**
+  # .. env:: USE_TUTORIAL
+  #
+  # Flag to turn on tutorial comments
+  #**
+  ask_question "Add tutorial comments? (only good if you are unfamiliar with just)" USE_TUTORIAL n
+
+  #**
   # .. env:: REPO_NAME
   #
   # When docker images are built, they need to be named, or else the only way to
@@ -1253,6 +1268,7 @@ function new_just()
       printf "%-40s | %-40s\n" "VSI Common Directory" "${VSI_DIR}"
     fi
   fi
+  printf "%-40s | %-40s\n" "Add Tutorial" "${USE_TUTORIAL}"
   echo
   # Ask y/n question
   ask_question "Continue?" CONTINUE y

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -1366,6 +1366,7 @@ function new_just_cleanup()
   return "${rv}"
 }
 
+# If new_just is being executed
 if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
   set -eu
 
@@ -1385,9 +1386,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${
   # # Stop new_just_cleanup from being called twice
   # trap -- EXIT
 else
-  # uwecho won't work right unless this file is kept around, so if being sourced,
-  # then vsi_common_dir is there, and use trap_chain
-
+  # uwecho won't work right unless this file is kept around. If being sourced,
+  # then VSI_COMMON_DIR is there, and use trap_chain
   source "${VSI_COMMON_DIR}/linux/signal_tools.bsh"
 
   trap_chain "new_just_cleanup exit" EXIT

--- a/linux/uwecho.bsh
+++ b/linux/uwecho.bsh
@@ -71,11 +71,11 @@ source "${VSI_COMMON_DIR}/linux/compat.bsh"
 #
 # .. note::
 #
-#    - This only works in when called directly from a script saved in a file. Will not work in a script that is piped in or on interactive command line.
+#    - This only works when called directly from a script saved in a file. Will not work in a script that is piped in or on an interactive command line.
 #    - Will not work correctly if you are using ``$'\n'`` or similar methods to add a newline without an actual newline.
 #    - Will not work correctly if you use hard tab in your indents. Use here doc if you want to use hard tabs
 #    - Not smart enough to work unless line starts with spaces and ``uwecho``. No inline environment variables setting, or execution of wrappers, etc...
-#    - Does not work if you cd after the script is started, unless you use full path name to call the script
+#    - Does not work if you cd after the script is started, unless you use the full path name to call the script
 #    - Does not work in $() or ` ` or any process subprocess
 #
 #    .. code-block:: bash

--- a/linux/uwecho.bsh
+++ b/linux/uwecho.bsh
@@ -36,50 +36,81 @@ source "${VSI_COMMON_DIR}/linux/compat.bsh"
 #
 # .. code-block:: bash
 #
-#   $   echo "This
-#   > is
-#   >   a
-#   >   test"
+#    $   echo "This
+#    > is
+#    >   a
+#    >   test"
 #
 # uwecho will determine how many spaces up to the quote on the first line, and remove that many spaces if they are leading in all the subsequent lines
 #
 #
 # .. code-block:: bash
 #
-#   $   uwecho "This
-#   >           is
-#   >             a
-#   >             test"
+#    $   uwecho "This
+#    >           is
+#    >             a
+#    >             test"
 #
 # Much easier to read. Even handles:
 #
 # .. code-block:: bash
 #
-#   $   uwecho "  This
-#   >           is
-#   >             a test"
+#    $   uwecho "  This
+#    >           is
+#    >             a test"
 #
 # One odd side-effect is this looks a little weird:
 #
 # .. code-block:: bash
 #
-#  $   uwecho 'Use "quote" and get: '"${Variable}"'
-#              '"${Another_variable}"' goes here
-#              * <-- This is where the indent is'
+#    $   uwecho 'Use "quote" and get: '"${Variable}"'
+#                '"${Another_variable}"' goes here
+#                * <-- This is where the indent is'
 #
 # The second line looks like it has one too many spaces when, in fact, it has the right number of spaces.
 #
 # .. note::
-#   - This only works in when called directly from a script saved in a file. Will not work in a script that is piped in or on interactive command line.
-#   - Will not work correctly if you are using ``\n``
-#   - Will not work correctly if you use hard tab in your indents. Use here doc if you want to use hard tabs
-#   - Not smart enough to work unless line starts with spaces and ``uwecho``. No inline environment variables setting, or execution of wrappers, etc...
-#   - Does not work if you cd after the script is started, unless you use full path name to call the script
-#   - Does not work in $() or ` ` or any as any subprocess
+#
+#    - This only works in when called directly from a script saved in a file. Will not work in a script that is piped in or on interactive command line.
+#    - Will not work correctly if you are using ``\n``
+#    - Will not work correctly if you use hard tab in your indents. Use here doc if you want to use hard tabs
+#    - Not smart enough to work unless line starts with spaces and ``uwecho``. No inline environment variables setting, or execution of wrappers, etc...
+#    - Does not work if you cd after the script is started, unless you use full path name to call the script
+#    - Does not work in $() or ` ` or any process subprocess
+#
+#    .. code-block:: bash
+#
+#       # Interactive can sometimes work, but is still discouraged.
+#       $ cat foo.bsh
+#       foo()
+#       {
+#         uwecho "foo
+#                 bar"
+#       }
+#       bar(){ foo; }
+#       bar
+#
+#       # Always works
+#       $ bash foo.bsh
+#
+#       # Will not work, foo is being called directly in interactive mode
+#       # (internal bar call does work in bash 4.1 and newer)
+#       $ source foo.bsh; foo
+#
+#       # Will not work, bar is being called directly in interactive mode
+#       # (internal bar call does work in bash 4.1 and newer)
+#       $ source foo.bsh; bar
+#
+#       # Does work in bash 4.1 or newer
+#       $ source foo.bsh; source <(echo foo)
 #**
 
 function uwecho()
 {
+  if [[ $- = *i* ]]; then
+    echo "WARNING: uwecho does not work when directly called in an interactive bash" >&2
+  fi
+
   # Get caller info
   local line_number="$(caller)"
   # Extract filename

--- a/linux/uwecho.bsh
+++ b/linux/uwecho.bsh
@@ -72,7 +72,7 @@ source "${VSI_COMMON_DIR}/linux/compat.bsh"
 # .. note::
 #
 #    - This only works in when called directly from a script saved in a file. Will not work in a script that is piped in or on interactive command line.
-#    - Will not work correctly if you are using ``\n``
+#    - Will not work correctly if you are using ``$'\n'`` or similar methods to add a newline without an actual newline.
 #    - Will not work correctly if you use hard tab in your indents. Use here doc if you want to use hard tabs
 #    - Not smart enough to work unless line starts with spaces and ``uwecho``. No inline environment variables setting, or execution of wrappers, etc...
 #    - Does not work if you cd after the script is started, unless you use full path name to call the script

--- a/tests/int/test-new_just.bsh
+++ b/tests/int/test-new_just.bsh
@@ -72,6 +72,7 @@ begin_test "New Just"
                                      --project-name "je.  t e's\"t" \
                                      --vsi-dir "v.s.i  d i'r\"" \
                                      --app yaan \
+                                     --tutorial \
                                      --repo atest/btest
 
   if [ "${OS-}" = "Windows_NT" ]; then
@@ -98,7 +99,7 @@ begin_test "New Just"
           exit 0' > ss/docker
   chmod 755 ss/docker
 
-  [ "$(just build)" = "mockdc -f ${TESTDIR}/v.s.i  d i'r\"/docker/recipes/docker-compose.yml build gdal gosu pipenv tini vsi
+  [ "$(just build)" = "mockdc -f ${TESTDIR}/v.s.i  d i'r\"/docker/recipes/docker-compose.yml build gosu pipenv tini vsi
 mockdc -f ${TESTDIR}/docker-compose.yml build
 mockd volume rm testpro_venv" ]
   [ "$(just build example)" = "mockdc -f ${TESTDIR}/docker-compose.yml build example" ]
@@ -224,6 +225,7 @@ begin_test "New Just no docker"
                                      --project-name "je.  t e's\"t" \
                                      --vsi-dir "v.s.i  d i'r\"" \
                                      --app yaan \
+                                     --no-tutorial \
                                      --repo atest/btest
 
   mkdir -p "${TESTDIR}/external"
@@ -297,6 +299,7 @@ begin_test "New just instructions test (git)"
                                              --project-name "je.  t e's${tough_name}t" \
                                              --vsi-dir "v.s.i  d i'r${tough_name}" \
                                              --app yaan \
+                                             --tutorial \
                                              --repo tmp || rv=$?
 
   if [ "${git_email_set}" = "0" ]; then
@@ -337,6 +340,7 @@ begin_test "New just docker test"
                                      --vsi-dir "v.s.i  d i'r${tough_name}" \
                                      --project-dir "${TESTDIR}" \
                                      --prefix JTEST \
+                                     --no-tutorial \
                                      --app yaan --repo tmp
 
   if [ "${OS-}" = "Windows_NT" ]; then

--- a/tests/int/test-new_just.bsh
+++ b/tests/int/test-new_just.bsh
@@ -98,7 +98,7 @@ begin_test "New Just"
           exit 0' > ss/docker
   chmod 755 ss/docker
 
-  [ "$(just build)" = "mockdc -f ${TESTDIR}/v.s.i  d i'r\"/docker/recipes/docker-compose.yml build gosu pipenv tini vsi
+  [ "$(just build)" = "mockdc -f ${TESTDIR}/v.s.i  d i'r\"/docker/recipes/docker-compose.yml build gdal gosu pipenv tini vsi
 mockdc -f ${TESTDIR}/docker-compose.yml build
 mockd volume rm testpro_venv" ]
   [ "$(just build example)" = "mockdc -f ${TESTDIR}/docker-compose.yml build example" ]

--- a/tests/test-new_just.bsh
+++ b/tests/test-new_just.bsh
@@ -11,6 +11,9 @@ source "${VSI_COMMON_DIR}/linux/just_files/new_just"
 begin_test "new_just docker_add_quote_escape"
 (
   setup_test
+
+###  source "${VSI_COMMON_DIR}/linux/just_files/new_just"
+
   [ 'foo bar' = "$(docker_add_quote_escape 'foo bar')" ]
   [ "foo \\\\'bar" = "$(docker_add_quote_escape "foo 'bar")" ]
   [ 'foo\\bar' = "$(docker_add_quote_escape 'foo\bar')" ]
@@ -24,6 +27,8 @@ begin_test "new_just docker_env_quote_escape"
 (
   setup_test
 
+###  source "${VSI_COMMON_DIR}/linux/just_files/new_just"
+
   [ "foo bar" = "$(docker_env_quote_escape "foo bar")" ]
   [ "foo 'bar" = "$(docker_env_quote_escape "foo 'bar")" ]
   [ 'foo\\bar' = "$(docker_env_quote_escape 'foo\bar')" ]
@@ -35,6 +40,8 @@ end_test
 begin_test "new_just set_default"
 (
   setup_test
+
+###  source "${VSI_COMMON_DIR}/linux/just_files/new_just"
 
   unset foo
   USE_DEFAULTS=1 not set_default foo n "Enter x"
@@ -65,6 +72,8 @@ end_test
 begin_test "new_just exists"
 (
   setup_test
+
+###  source "${VSI_COMMON_DIR}/linux/just_files/new_just"
 
   touch foo
   exists foo
@@ -177,7 +186,7 @@ begin_test "new_just write docker_pipenv_version"
     }
 
     . Justfile
-    ans="docker-compose -f ${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml build gosu pipenv tini vsi
+    ans="docker-compose -f ${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml build gdal gosu pipenv tini vsi
 docker-compose -f ${TESTDIR}/docker-compose.yml build
 docker volume rm $(id -u -n)${project_name}_venv"
 # set +x
@@ -212,12 +221,7 @@ Justify build"
   (
     . docker/example.Justfile
 
-    function pipenv()
-    {
-      echo "pe ${@}"
-    }
-    ans="Run example here: example-cmd foo bar
-pe shell"
+    ans="Run example here: example-cmd foo bar"
     [ "$(caseify example-cmd foo bar)" = "${ans}" ]
     function exec()
     {

--- a/tests/test-new_just.bsh
+++ b/tests/test-new_just.bsh
@@ -139,11 +139,11 @@ begin_test "new_just write no_docker_version"
   grep -q '^local_post.env$' .gitignore
 
   # .gitattributes
-  grep -q '*.sh eol=lf' .gitattributes
-  grep -q '*.bsh eol=lf' .gitattributes
-  grep -q '*.py eol=lf' .gitattributes
-  grep -q '*.env eol=lf' .gitattributes
-  grep -q '.justplugins eol=lf' .gitattributes
+  grep -q '\*\.sh eol=lf' .gitattributes
+  grep -q '\*\.bsh eol=lf' .gitattributes
+  grep -q '\*\.py eol=lf' .gitattributes
+  grep -q '\*\.env eol=lf' .gitattributes
+  grep -q '\.justplugins eol=lf' .gitattributes
   grep -q 'Justfile eol=lf' .gitattributes
 )
 end_test

--- a/tests/test-new_just.bsh
+++ b/tests/test-new_just.bsh
@@ -178,7 +178,7 @@ begin_test "new_just write docker_pipenv_version"
     }
 
     . Justfile
-    ans="docker-compose -f ${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml build gdal gosu pipenv tini vsi
+    ans="docker-compose -f ${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml build gosu pipenv tini vsi
 docker-compose -f ${TESTDIR}/docker-compose.yml build
 docker volume rm $(id -u -n)${project_name}_venv"
 # set +x

--- a/tests/test-new_just.bsh
+++ b/tests/test-new_just.bsh
@@ -12,8 +12,6 @@ begin_test "new_just docker_add_quote_escape"
 (
   setup_test
 
-###  source "${VSI_COMMON_DIR}/linux/just_files/new_just"
-
   [ 'foo bar' = "$(docker_add_quote_escape 'foo bar')" ]
   [ "foo \\\\'bar" = "$(docker_add_quote_escape "foo 'bar")" ]
   [ 'foo\\bar' = "$(docker_add_quote_escape 'foo\bar')" ]
@@ -27,8 +25,6 @@ begin_test "new_just docker_env_quote_escape"
 (
   setup_test
 
-###  source "${VSI_COMMON_DIR}/linux/just_files/new_just"
-
   [ "foo bar" = "$(docker_env_quote_escape "foo bar")" ]
   [ "foo 'bar" = "$(docker_env_quote_escape "foo 'bar")" ]
   [ 'foo\\bar' = "$(docker_env_quote_escape 'foo\bar')" ]
@@ -40,8 +36,6 @@ end_test
 begin_test "new_just set_default"
 (
   setup_test
-
-###  source "${VSI_COMMON_DIR}/linux/just_files/new_just"
 
   unset foo
   USE_DEFAULTS=1 not set_default foo n "Enter x"
@@ -72,8 +66,6 @@ end_test
 begin_test "new_just exists"
 (
   setup_test
-
-###  source "${VSI_COMMON_DIR}/linux/just_files/new_just"
 
   touch foo
   exists foo


### PR DESCRIPTION
- The `.gitignore` writer was smart enough to work if a `.gitignore` file already exists. Extended the same logic to the `.dockerignore` and `.gitattributes` writers
    - Make sure that these files end in newlines before appending lines
- "Tutorial comments" are in `##`, so a new user is more aware what they can delete
- Updated GDAL example to use new recipe
- Example app no longer starts a shell. It's an example of an app, not a shell. There will never be a shell target like this EVER again...
- NEW Shell target, starts a shell!!!
- Fixed issue in `new_just` when source, it was deleting the "curl compatibility temp file" too soon. Now it wait
- Further documented and added a warning how `uwecho` is not happy in an interactive terminal.