### PR TITLE
Fix failed test not being caught

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |Linux|Windows|macos|docs|
 |--|--|--|--|
-|[![CircleCI](https://circleci.com/gh/VisionSystemsInc/vsi_common.svg?style=shield)](https://circleci.com/gh/VisionSystemsInc/vsi_common)|[![Build status](https://ci.appveyor.com/api/projects/status/3a3hd3m41clxd5gw/branch/master?svg=true)](https://ci.appveyor.com/project/andyneff/vsi-common/branch/master)|[![Build Status](https://travis-ci.org/VisionSystemsInc/vsi_common.svg?branch=master)](https://travis-ci.org/VisionSystemsInc/vsi_common)|[![Docs](https://img.shields.io/circleci/build/gh/VisionSystemsInc/vsi_common/master?label=docs)](https://visionsystemsinc.github.io/vsi_common)|
+|[![CircleCI](https://circleci.com/gh/VisionSystemsInc/vsi_common.svg?style=shield)](https://circleci.com/gh/VisionSystemsInc/vsi_common)|[![Build status](https://ci.appveyor.com/api/projects/status/3a3hd3m41clxd5gw/branch/master?svg=true)](https://ci.appveyor.com/project/andyneff/vsi-common/branch/master)|[![Build Status](https://travis-ci.com/VisionSystemsInc/vsi_common.svg?branch=master)](https://travis-ci.com/VisionSystemsInc/vsi_common)|[![Docs](https://img.shields.io/circleci/build/gh/VisionSystemsInc/vsi_common/master?label=docs)](https://visionsystemsinc.github.io/vsi_common)|
 
 In order to use these directories, all you have to do is
 

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -473,6 +473,8 @@ function load_vsi_compat()
   #
   # There is a bug in bash 3.2, where ``set -u`` will not return non-zero for an unbound variable if an ``EXIT`` trap is set. Unfortunately, there is no way to detect this happens in the ``EXIT`` trap code, nor is there any way to cope with it. This means an unbound variable could potentially go undetected.
   #
+  # This is probably related to a similar phenomena where and error code is lost by the trap being called.
+  #
   # :Value: * ``0`` Bash has the bug
   #         * ``1`` Unbound variables error as expected
   #**

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -78,16 +78,11 @@ function load_vsi_compat()
   #
   # Flag to enable extended regex support in sed. The GNU flag is ``-r``, while the BSD flag is ``-E``. macOS does not support ``-r`` and GNU sed prior to 4.2 does not accept ``-E``. Using this variable should always yield the correct flag.
   #
-  # .. note::
-  #
-  #   No quotes around the flag
-  #
   # .. rubric:: Example
   #
   # .. code-block:: bash
   #
-  #   sed -${sed_flag_rE} 's|foo(.*)|bar\1.|'
-  #   # Notice no quotes above
+  #   sed "-${sed_flag_rE}" 's|foo(.*)|bar\1.|'
   #**
   # Needed for CentOS 6 running sed 4.1.5
   if [ "${VSI_SED_COMPAT-}" = "gnu" ]; then
@@ -100,10 +95,6 @@ function load_vsi_compat()
   # .. var:: sed_flags_i
   #
   # When using inplace replacement on sed, the macOS version requires an argument to the ``-i`` flag, the extension added to the output file. The GNU version does not support this. Using this flag will perform an inplace replacement with no added extension. The :var:`sed_flags_i` cannot be combined with other flags (see example below).
-  #
-  # .. note::
-  #
-  #   No quotes around the flag
   #
   # .. rubric:: Example
   #

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -11,7 +11,7 @@ fi
 
 # Use a command like true, so that when I comment, it still works
 # COMMENT NEXT LINE when developing, uncomment before commiting.
-# cat - << 'true' > "${temp_file}"
+cat - << 'true' > "${temp_file}"
 
 #*# just/new_just
 

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -11,7 +11,7 @@ fi
 
 # Use a command like true, so that when I comment, it still works
 # COMMENT NEXT LINE when developing, uncomment before commiting.
-cat - << 'true' > "${temp_file}"
+# cat - << 'true' > "${temp_file}"
 
 #*# just/new_just
 
@@ -809,7 +809,7 @@ function write_dockerignore()
             #T# in faster build time.
             *" > "${1}"
   # https://stackoverflow.com/a/40919/4166604
-  elif [ "$(tail -c 1 "${1}")" != "" ]; then
+  elif [ "$(tail -c 1 "${1}" 2>/dev/null)" != "" ]; then
     echo >> "${1}"
   fi
 
@@ -845,7 +845,7 @@ function write_gitattributes()
     uwecho '#T# These file types are being explicitly set to linux line endings for windows.
             #T# This is to allow a windows user to edit and run these files inside a linux docker.
             #T# This list may need additions as time goes on' > "${1}"
-  elif [ "$(tail -c 1 "${1}")" != "" ]; then
+  elif [ "$(tail -c 1 "${1}" 2>/dev/null)" != "" ]; then
     echo >> "${1}"
   fi
 
@@ -891,7 +891,7 @@ function write_hi_cpp()
 ##################
 function write_gitignore()
 {
-  if [ "$(tail -c 1 "${1}")" != "" ]; then
+  if [ "$(tail -c 1 "${1}" 2>/dev/null)" != "" ]; then
     echo >> "${1}"
   fi
 
@@ -912,10 +912,10 @@ function format_tutorial()
 {
   if [ "${USE_TUTORIAL-}" = "1" ]; then
     # Convert #T# to #
-    sed -i '/^ *#T# /{ s/#T#/#/; }' "${1}"
+    sed "${sed_flags_i[@]}" '/^ *#T# /{ s/#T#/#/; }' "${1}"
   else
     # Remove #T# lines
-    sed -i '/^ *#T# /d' "${1}"
+    sed "${sed_flags_i[@]}" '/^ *#T# /d' "${1}"
   fi
 }
 
@@ -1404,12 +1404,7 @@ function new_just()
     done
 
     . "${VSI_DIR}/linux/just_files/just_version.bsh"
-    local sed_inplace=(sed -i)
-    if [[ ${OSTYPE} == darwin* ]]; then
-      sed_inplace+=('')
-    fi
-
-    "${sed_inplace[@]}" 's|^JUST_VERSION="new_just"$|JUST_VERSION="'"${JUST_VERSION}"'"|' "${PROJECT_NAME}.env"
+    sed "${sed_flags_i[@]}" 's|^JUST_VERSION="new_just"$|JUST_VERSION="'"${JUST_VERSION}"'"|' "${PROJECT_NAME}.env"
   fi
 
   uwecho "

--- a/linux/signal_tools.bsh
+++ b/linux/signal_tools.bsh
@@ -34,7 +34,22 @@ source "${VSI_COMMON_DIR}/linux/compat.bsh"
 #**
 function set_bashpid()
 {
+  local f
   if [ "${bash_feature_bashpid}" = "1" ]; then
+    for f in "${FUNCNAME[@]}"; do
+      # Check if "source/." was called  FUNCNAME, multiple source only produce one "phantom" fork
+      # A source means we need the grandparent
+      if [ "${f}" == "source" ]; then
+        if [ -d /proc ]; then
+          BASHPID="$(bash -c "sed -E 's|.*\) [^ ]* ([^ ]*) .*|\1|' /proc/\${PPID}/stat")"
+          return
+        else
+          # Not all ps's support -fp, but this should work on mac where these is no /proc
+          BASHPID="$(bash -c "ps -fp \${PPID} | awk '(NR>1) {print \$3}'")"
+          return
+        fi
+      fi
+    done
     BASHPID=$(bash -c 'echo ${PPID}')
   fi
 }

--- a/linux/signal_tools.bsh
+++ b/linux/signal_tools.bsh
@@ -37,14 +37,14 @@ function set_bashpid()
   local f
   if [ "${bash_feature_bashpid}" = "1" ]; then
     for f in "${FUNCNAME[@]}"; do
-      # Check if "source/." was called  FUNCNAME, multiple source only produce one "phantom" fork
+      # Check if "source/." was called in FUNCNAME; multiple sources only produce one "phantom" fork.
       # A source means we need the grandparent
       if [ "${f}" == "source" ]; then
         if [ -d /proc ]; then
           BASHPID="$(bash -c "sed -E 's|.*\) [^ ]* ([^ ]*) .*|\1|' /proc/\${PPID}/stat")"
           return
         else
-          # Not all ps's support -fp, but this should work on mac where these is no /proc
+          # Not all ps's support -fp, but this should work on macOS where these is no /proc
           BASHPID="$(bash -c "ps -fp \${PPID} | awk '(NR>1) {print \$3}'")"
           return
         fi

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -623,7 +623,7 @@ setup_test()
 # .. seealso::
 #   :func:`begin_test`
 #**
-end_test ()
+end_test()
 {
   test_status="${1:-$?}" # This MUST be the first line of this function
   set +x -e


### PR DESCRIPTION
There was a bug in bash 3.2 that wasn't running all of the traps in test that had more than one exit trap, and failed tests weren't being detected