### PR TITLE
pipenv environment variables

### DIFF
--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -356,7 +356,7 @@ function conda-python-install()
 # Install a virtualenv containing pipenv.
 #
 # :Arguments: * [``--dir {dir}``] - Pipenv install directory
-#             * [``--version {version}``] - Pipenv version for install (default= ``${RECIPE_PIPENV_VERSION:-${PIPENV_VERSION:-2020.8.13}}``)
+#             * [``--version {version}``] - Pipenv version for install (default= ``${RECIPE_PIPENV_VERSION:-${PIPENV_VERSION:-2020.11.15}}``)
 #             * [``--python {PYTHON}``] - Python executable (default=(python3|python|python2))
 #             * [``--python-activate {script}``] - Optional python activation script, for example as created by :func:`conda-python-install`
 #             * [``--virtualenv-pyz {file}``] - Optional virtualenv zipapp file (default= ``${RECIPE_VIRTUALENV_PYZ:-${VIRTUALENV_PYZ:-}}``)

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -356,11 +356,11 @@ function conda-python-install()
 # Install a virtualenv containing pipenv.
 #
 # :Arguments: * [``--dir {dir}``] - Pipenv install directory
-#             * [``--version {version}``] - Pipenv version for install (default= ``${PIPENV_VERSION:-2020.8.13}``)
+#             * [``--version {version}``] - Pipenv version for install (default= ``${RECIPE_PIPENV_VERSION:-${PIPENV_VERSION:-2020.8.13}}``)
 #             * [``--python {PYTHON}``] - Python executable (default=(python3|python|python2))
 #             * [``--python-activate {script}``] - Optional python activation script, for example as created by :func:`conda-python-install`
-#             * [``--virtualenv-pyz {file}``] - Optional virtualenv zipapp file (default= ``${VIRTUALENV_PYZ-}``)
-#             * [``--virtualenv-version {version}``] - Optional viertualenv version (default= ``${VIRTUALENV_VERSION:-20.0.33}``)
+#             * [``--virtualenv-pyz {file}``] - Optional virtualenv zipapp file (default= ``${RECIPE_VIRTUALENV_PYZ:-${VIRTUALENV_PYZ:-}}``)
+#             * [``--virtualenv-version {version}``] - Optional viertualenv version (default= ``${RECIPE_VIRTUALENV_VERSION:-${VIRTUALENV_VERSION:-20.4.5}}``)
 #
 # :Output: * pipenv_exe - Pipenv executable
 #          * pipenv_version - Pipenv version
@@ -372,11 +372,11 @@ function conda-python-install()
 function pipenv-install()
 {
   local pipenv_dir  # install directory
-  local pipenv_ver="${PIPENV_VERSION:-2020.8.13}"  # pipenv version
+  local pipenv_ver="${RECIPE_PIPENV_VERSION:-${PIPENV_VERSION:-2020.11.15}}"  # pipenv version
   local PYTHON  # python executable
   local python_activate
-  local virtualenv_pyz="${VIRTUALENV_PYZ-}"
-  local virtualenv_ver="${VIRTUALENV_VERSION:-20.0.33}"
+  local virtualenv_pyz="${RECIPE_VIRTUALENV_PYZ:-${VIRTUALENV_PYZ:-}}"
+  local virtualenv_ver="${RECIPE_VIRTUALENV_VERSION:-${VIRTUALENV_VERSION:-20.4.5}}"
 
   parse_args pipenv_extra_args \
       --dir pipenv_dir: \

--- a/tests/int/test-just_install_functions.bsh
+++ b/tests/int/test-just_install_functions.bsh
@@ -144,7 +144,7 @@ begin_test "conda-python-install and pipenv-install"
   # --pipenv--
 
   # version info
-  PIPENV_VER="2020.6.2"
+  PIPENV_VER="2020.8.13"
   PIPENV_VER_FULL="pipenv, version ${PIPENV_VER}"
 
   # install


### PR DESCRIPTION
- update docker_recipes, now favoring `RECIPE_*` style environment variables in `30_get-pipenv`
- mimic  `RECIPE_*` style environment variables in `just_install_functions::pipenv-install`
- update default versions in `pipenv-install` (20.4.5 for virtualenv, 2020.11.15 for pipenv)