### PR TITLE
Python tools rewrite

### DIFF
--- a/linux/just_files/docker_functions.bsh
+++ b/linux/just_files/docker_functions.bsh
@@ -1240,6 +1240,7 @@ function Just-docker-compose()
   local docker_compose_files
   local DOCKER_COMPOSE_FILES
   local docker_compose_project_name
+  local COMPOSE_VERSION="${COMPOSE_VERSION-}"
 
   local override_file="$(mktemp)"
 

--- a/linux/python_tools.bsh
+++ b/linux/python_tools.bsh
@@ -41,29 +41,58 @@ source "${VSI_COMMON_DIR}/linux/elements.bsh"
 #**
 function array_to_python_ast_list_of_strings()
 {
-  if is_array "${1}"; then
-    unset "${1}"
+  _array_to_python "[" "]" '"' ${@+"${@}"}
+}
+
+#**
+# .. function:: array_to_python_ast_list_of_literals
+#
+# :Arguments: * ``$1`` - Variable to set result to. If the destination is an array, it will be unset (and become global)
+#             * [``$2``...] - Array elements (to be treated literally)
+#
+# Set ``$1`` to a python ast.literal_eval compliant string for an list of strings
+#
+# .. rubric:: Example
+#
+# .. code-block:: bash
+#
+#   array_to_python_ast_list_of_literals x 1 '"1\"1"' "\"2'2\"" 3.3
+#   # x=[1, "1\"1", "2'2", 3.3]
+#
+#   array_to_python_ast_list_of_literals x 1+1
+#   # x=[1+1], valid for python eval, but ast.literal_eval
+#
+#   array_to_python_ast_list_of_literals x $((1+1))
+#   # x=[2], valid for ast.literal_eval
+#**
+function array_to_python_ast_list_of_literals()
+{
+  _array_to_python "[" "]" '' ${@+"${@}"}
+}
+
+function _array_to_python()
+{
+  local __array_to_python_open_array="${1}"
+  local __array_to_python_close_array="${2}"
+  local __array_to_python_quote_element="${3}"
+
+  if is_array "${4}"; then
+    unset "${4}"
   fi
 
-  if [ "${1}" != "indirect" ]; then
-    local indirect
-  fi
-  if [ "${1}" != "string" ]; then
-    local string
-  fi
+  local __array_to_python_indirect="${4}"
+  shift 4
 
-  indirect="${1}"
-  shift 1
-  string='['
+  local __array_to_python_string="${__array_to_python_open_array}"
   if (( $# )); then
-    string+="\"${1//\"/\\\"}\""
+    __array_to_python_string+="${__array_to_python_quote_element}${1//${__array_to_python_quote_element}/\\${__array_to_python_quote_element}}${__array_to_python_quote_element}"
     shift 1
   fi
   while (( $# )); do
-    string+=", \"${1//\"/\\\"}\""
+    __array_to_python_string+=", ${__array_to_python_quote_element}${1//${__array_to_python_quote_element}/\\${__array_to_python_quote_element}}${__array_to_python_quote_element}"
     shift 1
   done
-  string="${string}]"
+  __array_to_python_string="${__array_to_python_string}${__array_to_python_close_array}"
 
-  dynamic_set "${indirect}" "${string}"
+  dynamic_set "${__array_to_python_indirect}" "${__array_to_python_string}"
 }

--- a/linux/python_tools.bsh
+++ b/linux/python_tools.bsh
@@ -50,7 +50,7 @@ function array_to_python_ast_list_of_strings()
 # :Arguments: * ``$1`` - Variable to set result to. If the destination is an array, it will be unset (and become global)
 #             * [``$2``...] - Array elements (to be treated literally)
 #
-# Set ``$1`` to a python ast.literal_eval compliant string for an list of strings
+# Set ``$1`` to a python ast.literal_eval compliant string representing a "list of strings"
 #
 # .. rubric:: Example
 #
@@ -60,7 +60,7 @@ function array_to_python_ast_list_of_strings()
 #   # x=[1, "1\"1", "2'2", 3.3]
 #
 #   array_to_python_ast_list_of_literals x 1+1
-#   # x=[1+1], valid for python eval, but ast.literal_eval
+#   # x=[1+1], valid for python eval, but not ast.literal_eval
 #
 #   array_to_python_ast_list_of_literals x $((1+1))
 #   # x=[2], valid for ast.literal_eval

--- a/tests/test-python_tools.bsh
+++ b/tests/test-python_tools.bsh
@@ -14,23 +14,63 @@ begin_test "Array to python ast literal eval list of strings"
 
   x=(11 22 33)
   is_array x
-  array_to_python_ast_list_of_strings x "${x[@]}"
-  [ "${x}" = '["11", "22", "33"]' ]
-  # Test array replacement works
-  not is_array x
-  # Make sure local variables aren't leaking
-  not declare -p string
-  not declare -p indirect
+  array_to_python_ast_list_of_strings y "${x[@]}"
+  [ "${y}" = '["11", "22", "33"]' ]
 
   x=('1"1' "2'2" "3  3")
-  array_to_python_ast_list_of_strings indirect "${x[@]}"
-  [ "${indirect}" = '["1\"1", "2'"'"'2", "3  3"]' ]
-  not declare -p string
+  array_to_python_ast_list_of_strings z "${x[@]}"
+  [ "${z}" = '["1\"1", "2'"'"'2", "3  3"]' ]
 
   x=()
-  array_to_python_ast_list_of_strings string ${x[@]+"${x[@]}"}
-  [ "${indirect}" = '["1\"1", "2'"'"'2", "3  3"]' ]
-  [ "${string}" = '[]' ]
+  array_to_python_ast_list_of_strings w ${x[@]+"${x[@]}"}
+  [ "${w}" = '[]' ]
+)
+end_test
+
+begin_test "Array to python ast literal eval list of literals"
+(
+  setup_test
+
+  x=(11 '2"2' '3  3')
+  is_array x
+  array_to_python_ast_list_of_literals y "${x[@]}"
+  [ "${y}" = '[11, 2"2, 3  3]' ]
+
+  x=()
+  array_to_python_ast_list_of_literals y ${x[@]+"${x[@]}"}
+  [ "${y}" = '[]' ]
+)
+end_test
+
+begin_test "Common Array to python function"
+(
+  setup_test
+
+  x=('1"1' "2'2" "3  3")
+  _array_to_python '[' ']' "" y "${x[@]}"
+  [ "${y}" = '[1"1, 2'"'"'2, 3  3]' ]
+
+  _array_to_python '(' ')' "'" y ${x[@]+"${x[@]}"}
+  [ "${y}" = "('1\"1', '2\\'2', '3  3')" ]
+
+  _array_to_python '{' '}' '"' y ${x[@]+"${x[@]}"}
+  [ "${y}" = "{\"1\\\"1\", \"2'2\", \"3  3\"}" ]
+
+  _array_to_python 'set((' '))' '"' y ${x[@]+"${x[@]}"}
+  [ "${y}" = "set((\"1\\\"1\", \"2'2\", \"3  3\"))" ]
+
+  y=('"1\"1"' "\"2'2\"" '"3  3"')
+  _array_to_python '[' ']' '' y ${y[@]+"${y[@]}"}
+  [ "${y}" = "[\"1\\\"1\", \"2'2\", \"3  3\"]" ]
+  is_array x
+  not is_array y
+
+  # Make sure local variables aren't leaking
+  not declare -p __array_to_python_open_array
+  not declare -p __array_to_python_close_array
+  not declare -p __array_to_python_quote_element
+  not declare -p __array_to_python_string
+  not declare -p __array_to_python_indirect
 )
 end_test
 


### PR DESCRIPTION
- Fix a minor variable leak in Just-docker-compose
- Added a literal version of converting a bash array to a string for `ast.literal_eval`, this will allow a user to make arrays of integers and floats, not just strings.