### PR TITLE
Updated cuda 11 info

### DIFF
--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -531,7 +531,12 @@ function cuda_capabilities()
         CUDA_MINIMAL_DRIVER_VERSION=440.33
       fi
       ;;
-    11.0.189) # also 11.0.1 RC, there were multiple RCs
+
+    # 11.0.194|11.0.207|11.0.2) # docs .207, CUDA .2 GA
+    # 11.0.221|11.0.228|11.0.3) # docs .228, CUDA .3 Update 1
+    # 11.0.189) # also 11.0.1 RC, there were multiple RCs
+    # RC 11.0.167 technically allowed sm/compute 30, but that didn't make it to release
+    11.0*) # all of 11.0
       CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80)
       CUDA_CODES=(35 37 50 52 53 60 61 62 70 72 75 80)
       CUDA_DEPRECATED=(35 37 50)
@@ -541,107 +546,22 @@ function cuda_capabilities()
         CUDA_MINIMAL_DRIVER_VERSION=450.36.06
       fi
       ;;
-    11.0.194|11.0.207|11.0.2) # docs .207, CUDA .2 GA
-      CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80)
-      CUDA_CODES=(35 37 50 52 53 60 61 62 70 72 75 80)
-      CUDA_DEPRECATED=(35 37 50)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=451.48
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=450.51.05
-      fi
-      ;;
-    11.0.221|11.0.228|11.0.3) # docs .228, CUDA .3 Update 1
-      CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80)
-      CUDA_CODES=(35 37 50 52 53 60 61 62 70 72 75 80)
-      CUDA_DEPRECATED=(35 37 50)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=451.82
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=450.51.06
-      fi
-      ;;
-    # Use the least common denominator, incase the answer "11.0" is retrieved
-    # from nvidia-smi
-    11.0*) #.167, CUDA .1 RC, doc .182
-      CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70 72 75 80)
-      CUDA_CODES=(30 32 35 37 50 52 53 60 61 62 70 72 75 80)
-      CUDA_DEPRECATED=(30 32 35 37 50)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=451.22
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=450.36.06
-      fi
-      ;;
-    11.1.74|11.1.0) # CUDA .0 GA
+
+    # 11.1.74|11.1.0) # CUDA .0 GA
+    # 11.1*) # .105, CUDA .1 Update 1
+    # 11.2.67|11.2.0) # CUDA .0
+    # 11.2.142|11.2.1) # CUDA .1 Update 1
+    # 11.2*) # .152, CUDA .2 Update 2
+    # 11.3.58|11.3.0|11.3.109|11.3.1)
+    11.1*|11.2*|11.3*) # Nothing has changed between 11.1.0 and 11.3.1
       CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
-      CUDA_CODES=(35 37 50 52 53 60 61 62 70 72 75 80 86) #sm_20 too? That can't be right
+      CUDA_CODES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
       CUDA_DEPRECATED=(35 37 50)
 
       if [ "${OS-}" == "Windows_NT" ]; then
         CUDA_MINIMAL_DRIVER_VERSION=456.38
       else
-        CUDA_MINIMAL_DRIVER_VERSION=455.23
-      fi
-      ;;
-    11.1*) # .105, CUDA .1 Update 1
-      CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
-      CUDA_CODES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
-      CUDA_DEPRECATED=(35 37 50)
-
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=456.81
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=455.32
-      fi
-      ;;
-    11.2.67|11.2.0) # CUDA .0
-      CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
-      CUDA_CODES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
-      CUDA_DEPRECATED=(35 37 50)
-
-      if [ "${OS-}" == "Windows_NT" ]; then
-        # Might actually be 460.89, docs changed in 11.2.1
-        CUDA_MINIMAL_DRIVER_VERSION=460.82
-      else
-        # Might actually be 460.27.04, docs changed in 11.2.1
-        CUDA_MINIMAL_DRIVER_VERSION=460.27.03
-      fi
-      ;;
-    11.2.142|11.2.1) # CUDA .1 Update 1
-      CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
-      CUDA_CODES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
-      CUDA_DEPRECATED=(35 37 50)
-
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=461.09
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=460.32.03
-      fi
-      ;;
-    11.2*) # .152, CUDA .2 Update 2
-      CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
-      CUDA_CODES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
-      CUDA_DEPRECATED=(35 37 50)
-
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=461.33
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=460.32.03
-      fi
-      ;;
-    # TODO: Fix this for 11.3.0 and 11.3.1
-    # TODO: Add "Enhanced" requirement too, starting in 11.0
-    11.3*)
-      # These came from 11.3.0
-      CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
-      CUDA_CODES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
-      CUDA_DEPRECATED=(35 37 50)
-
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=461.33
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=460.32.03
+        CUDA_MINIMAL_DRIVER_VERSION=450.80.02
       fi
       ;;
 
@@ -651,11 +571,31 @@ function cuda_capabilities()
     #   #
     #   # strings nvcc | \grep '^sm_' | sed 's|sm_||' | tr '\n' ' '; echo
     #   # strings nvcc | \grep '^compute_' | sed 's|compute_||' | tr '\n' ' '; echo
+    #
+    # Nvidia decided to make things MORE confusing starting in 11 docs.
+    # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html does
+    # NOT list the "minimal required version" for 11.0 and up. It lists the
+    # minimal version shipped with CUDA SDK... which WHO cares?!
+    # https://docs.nvidia.com/deploy/cuda-compatibility/index.html Shows the
+    # actual minimal versions, but without Windows. Which... is dumb!
+    # So extrapolating the Windows versions that match the Linux versions in
+    # first table to line up with the second table, you can fill in these
+    # values.
+    #   CUDA_ARCHES=(?)
+    #   CUDA_CODES=(?)
+    #   CUDA_DEPRECATED=(?)
+    #
+    #   if [ "${OS-}" == "Windows_NT" ]; then
+    #     CUDA_MINIMAL_DRIVER_VERSION=?
+    #   else
+    #     CUDA_MINIMAL_DRIVER_VERSION=?
+    #   fi
     #   ;;
     *)
       echo "CUDA Version ${CUDA_VERSION} is not programmed in here yet..." >&2
       CUDA_ARCHES=()
       CUDA_CODES=()
+      CUDA_MINIMAL_DRIVER_VERSION=0
       ;;
   esac
 }

--- a/tests/test-versions.bsh
+++ b/tests/test-versions.bsh
@@ -63,7 +63,8 @@ source "${VSI_COMMON_DIR}/linux/versions.bsh"
 # https://developer.download.nvidia.com/compute/cuda/11.2.0/local_installers/cuda_11.2.0_460.27.04_linux.run
 # https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux.run
 # https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux.run
-
+# https://developer.download.nvidia.com/compute/cuda/11.3.0/local_installers/cuda_11.3.0_465.19.01_linux.run
+# https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run
 ##########
 # Cuda 1 #
 ##########
@@ -643,6 +644,258 @@ version1122='{
       "version" : "460.32.03"
    }
 }'
+# 11.3.0
+nvcc1130='nvcc: NVIDIA (R) Cuda compiler driver
+Copyright (c) 2005-2021 NVIDIA Corporation
+Built on Sun_Mar_21_19:15:46_PDT_2021
+Cuda compilation tools, release 11.3, V11.3.58
+Build cuda_11.3.r11.3/compiler.29745058_0'
+version1130='{
+   "cuda" : {
+      "name" : "CUDA SDK",
+      "version" : "11.3.20210326"
+   },
+   "cuda_cudart" : {
+      "name" : "CUDA Runtime (cudart)",
+      "version" : "11.3.58"
+   },
+   "cuda_cuobjdump" : {
+      "name" : "cuobjdump",
+      "version" : "11.3.58"
+   },
+   "cuda_cupti" : {
+      "name" : "CUPTI",
+      "version" : "11.3.58"
+   },
+   "cuda_cuxxfilt" : {
+      "name" : "CUDA cu++ filt",
+      "version" : "11.3.58"
+   },
+   "cuda_demo_suite" : {
+      "name" : "CUDA Demo Suite",
+      "version" : "11.3.58"
+   },
+   "cuda_gdb" : {
+      "name" : "CUDA GDB",
+      "version" : "11.3.58"
+   },
+   "cuda_memcheck" : {
+      "name" : "CUDA Memcheck",
+      "version" : "11.3.58"
+   },
+   "cuda_nsight" : {
+      "name" : "Nsight Eclipse Plugins",
+      "version" : "11.3.58"
+   },
+   "cuda_nvcc" : {
+      "name" : "CUDA NVCC",
+      "version" : "11.3.58"
+   },
+   "cuda_nvdisasm" : {
+      "name" : "CUDA nvdisasm",
+      "version" : "11.3.58"
+   },
+   "cuda_nvml_dev" : {
+      "name" : "CUDA NVML Headers",
+      "version" : "11.3.58"
+   },
+   "cuda_nvprof" : {
+      "name" : "CUDA nvprof",
+      "version" : "11.3.58"
+   },
+   "cuda_nvprune" : {
+      "name" : "CUDA nvprune",
+      "version" : "11.3.58"
+   },
+   "cuda_nvrtc" : {
+      "name" : "CUDA NVRTC",
+      "version" : "11.3.58"
+   },
+   "cuda_nvtx" : {
+      "name" : "CUDA NVTX",
+      "version" : "11.3.58"
+   },
+   "cuda_nvvp" : {
+      "name" : "CUDA NVVP",
+      "version" : "11.3.58"
+   },
+   "cuda_samples" : {
+      "name" : "CUDA Samples",
+      "version" : "11.3.58"
+   },
+   "cuda_sanitizer_api" : {
+      "name" : "CUDA Compute Sanitizer API",
+      "version" : "11.3.58"
+   },
+   "libcublas" : {
+      "name" : "CUDA cuBLAS",
+      "version" : "11.4.2.10064"
+   },
+   "libcufft" : {
+      "name" : "CUDA cuFFT",
+      "version" : "10.4.2.58"
+   },
+   "libcurand" : {
+      "name" : "CUDA cuRAND",
+      "version" : "10.2.4.58"
+   },
+   "libcusolver" : {
+      "name" : "CUDA cuSOLVER",
+      "version" : "11.1.1.58"
+   },
+   "libcusparse" : {
+      "name" : "CUDA cuSPARSE",
+      "version" : "11.5.0.58"
+   },
+   "libnpp" : {
+      "name" : "CUDA NPP",
+      "version" : "11.3.3.44"
+   },
+   "libnvjpeg" : {
+      "name" : "CUDA nvJPEG",
+      "version" : "11.4.1.58"
+   },
+   "nsight_compute" : {
+      "name" : "Nsight Compute",
+      "version" : "2021.1.0.18"
+   },
+   "nsight_systems" : {
+      "name" : "Nsight Systems",
+      "version" : "2021.1.3.14"
+   },
+   "nvidia_driver" : {
+      "name" : "NVIDIA Linux Driver",
+      "version" : "465.19.01"
+   }
+}'
+# 11.3.1
+nvcc1131='nvcc: NVIDIA (R) Cuda compiler driver
+Copyright (c) 2005-2021 NVIDIA Corporation
+Built on Mon_May__3_19:15:13_PDT_2021
+Cuda compilation tools, release 11.3, V11.3.109
+Build cuda_11.3.r11.3/compiler.29920130_0'
+version1131='{
+   "cuda" : {
+      "name" : "CUDA SDK",
+      "version" : "11.3.20210513"
+   },
+   "cuda_cudart" : {
+      "name" : "CUDA Runtime (cudart)",
+      "version" : "11.3.109"
+   },
+   "cuda_cuobjdump" : {
+      "name" : "cuobjdump",
+      "version" : "11.3.58"
+   },
+   "cuda_cupti" : {
+      "name" : "CUPTI",
+      "version" : "11.3.111"
+   },
+   "cuda_cuxxfilt" : {
+      "name" : "CUDA cu++ filt",
+      "version" : "11.3.58"
+   },
+   "cuda_demo_suite" : {
+      "name" : "CUDA Demo Suite",
+      "version" : "11.3.58"
+   },
+   "cuda_gdb" : {
+      "name" : "CUDA GDB",
+      "version" : "11.3.109"
+   },
+   "cuda_memcheck" : {
+      "name" : "CUDA Memcheck",
+      "version" : "11.3.109"
+   },
+   "cuda_nsight" : {
+      "name" : "Nsight Eclipse Plugins",
+      "version" : "11.3.109"
+   },
+   "cuda_nvcc" : {
+      "name" : "CUDA NVCC",
+      "version" : "11.3.109"
+   },
+   "cuda_nvdisasm" : {
+      "name" : "CUDA nvdisasm",
+      "version" : "11.3.58"
+   },
+   "cuda_nvml_dev" : {
+      "name" : "CUDA NVML Headers",
+      "version" : "11.3.58"
+   },
+   "cuda_nvprof" : {
+      "name" : "CUDA nvprof",
+      "version" : "11.3.111"
+   },
+   "cuda_nvprune" : {
+      "name" : "CUDA nvprune",
+      "version" : "11.3.58"
+   },
+   "cuda_nvrtc" : {
+      "name" : "CUDA NVRTC",
+      "version" : "11.3.109"
+   },
+   "cuda_nvtx" : {
+      "name" : "CUDA NVTX",
+      "version" : "11.3.109"
+   },
+   "cuda_nvvp" : {
+      "name" : "CUDA NVVP",
+      "version" : "11.3.111"
+   },
+   "cuda_samples" : {
+      "name" : "CUDA Samples",
+      "version" : "11.3.58"
+   },
+   "cuda_sanitizer_api" : {
+      "name" : "CUDA Compute Sanitizer API",
+      "version" : "11.3.111"
+   },
+   "cuda_thrust" : {
+      "name" : "CUDA Thrust",
+      "version" : "11.3.109"
+   },
+   "libcublas" : {
+      "name" : "CUDA cuBLAS",
+      "version" : "11.5.1.109"
+   },
+   "libcufft" : {
+      "name" : "CUDA cuFFT",
+      "version" : "10.4.2.109"
+   },
+   "libcurand" : {
+      "name" : "CUDA cuRAND",
+      "version" : "10.2.4.109"
+   },
+   "libcusolver" : {
+      "name" : "CUDA cuSOLVER",
+      "version" : "11.1.2.109"
+   },
+   "libcusparse" : {
+      "name" : "CUDA cuSPARSE",
+      "version" : "11.6.0.109"
+   },
+   "libnpp" : {
+      "name" : "CUDA NPP",
+      "version" : "11.3.3.95"
+   },
+   "libnvjpeg" : {
+      "name" : "CUDA nvJPEG",
+      "version" : "11.5.0.109"
+   },
+   "nsight_compute" : {
+      "name" : "Nsight Compute",
+      "version" : "2021.1.1.5"
+   },
+   "nsight_systems" : {
+      "name" : "Nsight Systems",
+      "version" : "2021.1.3.14"
+   },
+   "nvidia_driver" : {
+      "name" : "NVIDIA Linux Driver",
+      "version" : "465.19.01"
+   }
+}'
 
 nvccs=("${nvcc1}" "${nvcc11}"
        "${nvcc2}" "${nvcc21}" "${nvcc22}" "${nvcc23}"
@@ -654,7 +907,7 @@ nvccs=("${nvcc1}" "${nvcc11}"
        "${nvcc8}" "${nvcc8ga2}"
        "${nvcc9}" "${nvcc91}" "${nvcc92}"
        "${nvcc10}" "${nvcc101}" "${nvcc101u1}" "${nvcc101u2}" "${nvcc102}"
-       "${nvcc1101}" "${nvcc1102}" "${nvcc1103}" "${nvcc111}" "${nvcc1111}" "${nvcc112}" "${nvcc1121}" "${nvcc1122}")
+       "${nvcc1101}" "${nvcc1102}" "${nvcc1103}" "${nvcc111}" "${nvcc1111}" "${nvcc112}" "${nvcc1121}" "${nvcc1122}" "${nvcc1130}" "${nvcc1131}")
 
 nvccs_ans=(1.0 1.1
            2.0 2.1 2.2 2.3
@@ -666,7 +919,7 @@ nvccs_ans=(1.0 1.1
            8.0.44 8.0.61
            9.0.176 9.1.85 9.2.148
            10.0.130 10.1.105 10.1.168 10.1.243 10.2.89
-           11.0.167 11.0.194 11.0.221 11.1.74 11.1.105 11.2.67 11.2.142 11.2.152)
+           11.0.167 11.0.194 11.0.221 11.1.74 11.1.105 11.2.67 11.2.142 11.2.152 11.3.58 11.3.109)
 
 versions_txt=("${version75}"
               "${version8}" "${version8ga}" "${version8ga2p2}"
@@ -678,8 +931,8 @@ versions_txt_ans=(7.5.18
                   9.0.176 9.0.176.1 9.0.176.2 9.0.176.3 9.0.176.4 9.1.85 9.1.85.1 9.1.85.2 9.1.85.3 9.2.148 9.2.148.1
                   10.0.130 10.0.130.1 10.1.105 10.1.168 10.1.243 10.2.89
                   11.0.182 11.0.207 11.0.228)
-versions_json=("${version1121}" "${version1122}")
-versions_json_ans=(11.2.142 11.2.152)
+versions_json=("${version1121}" "${version1122}" "${version1130}" "${version1131}")
+versions_json_ans=(11.2.142 11.2.152 11.3.58 11.3.109)
 
 begin_test "program versions"
 (


### PR DESCRIPTION
- Added Cuda 11.3.0 and Cuda 11.3.1
- It turns out Table 3 from the release notes is not what we want, it's really Table 2
- Completely regrouped all the Cuda 11.* sections to reflect this new understanding.