### PR TITLE
create sync_submodules

### DIFF
--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -43,8 +43,8 @@ GIT_MIRROR_SOURCE="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"/"$(basename "${B
 #
 # .. code-block:: bash
 #
-#     repos[.]=https://git-server.com/foobar/vsi_common.git
-#     repos[docker/recipes]=https://git-server.com/foobar/recipes.git
+#    repos[.]=https://git-server.com/foobar/vsi_common.git
+#    repos[docker/recipes]=https://git-server.com/foobar/recipes.git
 #
 # 6. ``git_mirror push ./info.env ./transfer_extracted_dir/`` - Push the mirrored repository and all submodules to a new git server as defined by info.env
 # #. ``git_mirror clone ./info.env ./my_project_dir/`` - Clone recursively from the new mirror
@@ -95,8 +95,8 @@ GIT_VERSION="$(git_version)"
 #
 # .. code-block:: bash
 #
-#   get_config_submodule_names() # from within ./vsi_common/
-#   # submodule.docker/recipes
+#    $ get_config_submodule_names() # from within ./vsi_common/
+#    submodule.docker/recipes
 #
 # .. note::
 #
@@ -463,8 +463,8 @@ function sync_submodules()
 #
 # .. code-block:: bash
 #
-# git_mirror_main https://github.com/visionsystemsinc/vsi_common.git master
-# # produces ./vsi_common_prep/transfer_2020_03_02_14_16_09.tgz
+#    git_mirror_main https://github.com/visionsystemsinc/vsi_common.git master
+#    # produces ./vsi_common_prep/transfer_2020_03_02_14_16_09.tgz
 #
 # .. rubric:: Example
 #
@@ -472,8 +472,8 @@ function sync_submodules()
 #
 # .. code-block:: bash
 #
-# git_mirror_main vsi_common_prep
-# # produces ./vsi_common_prep/transfer_2020_03_02_14_24_12_transfer_2020_03_02_14_16_09.tgz
+#    git_mirror_main vsi_common_prep
+#    # produces ./vsi_common_prep/transfer_2020_03_02_14_24_12_transfer_2020_03_02_14_16_09.tgz
 #
 # .. rubric:: Example
 #
@@ -481,12 +481,12 @@ function sync_submodules()
 #
 # .. code-block:: bash
 #
-# tar zxf transfer_2020_03_02_14_16_09.tgz
-# tar --incremental zxf transfer_2020_03_02_14_24_12_transfer_2020_03_02_14_16_09.tgz
+#    tar zxf transfer_2020_03_02_14_16_09.tgz
+#    tar --incremental zxf transfer_2020_03_02_14_24_12_transfer_2020_03_02_14_16_09.tgz
 #
-# ###
+# .. code-block:: bash
 #
-# tar zxf transfer_2020_03_02_14_24_12.tgz
+#    tar zxf transfer_2020_03_02_14_24_12.tgz
 #
 # .. note::
 #
@@ -795,7 +795,7 @@ function _git_mirror_get_url()
 #
 # .. code-block:: bash
 #
-# git_clone_main init.env ~/
+#    git_clone_main init.env ~/
 #**
 
 function git_clone_main()
@@ -842,11 +842,11 @@ function git_clone_main()
 #
 # .. code-block:: bash
 #
-# cat info.env
-# repos[.]=https://git-server.com/foobar/vsi_common.git
-# repos[docker/recipes]=https://git-server.com/foobar/recipes.git
+#    $ cat info.env
+#    repos[.]=https://git-server.com/foobar/vsi_common.git
+#    repos[docker/recipes]=https://git-server.com/foobar/recipes.git
 #
-# git_push_main info.env vsi_common_prep
+#    $ git_push_main info.env vsi_common_prep
 #**
 
 function git_push_main()

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -360,12 +360,11 @@ function update_submodules()
   local current_repo="$(_git_mirror_get_url "${base_submodule_path:-.}")"
   next_section "Initializing ${current_repo}'s submodules"
 
-  # This is only done once when initially cloning the repo, so should not need
-  # a sync
   "${GIT}" submodule init
   local IFS=$'\n'
   local submodule_names=($(get_config_submodule_names))
 
+  # Sync the submodules to the mirrored repository
   for submodule_name in ${submodule_names[@]+"${submodule_names[@]}"}; do
     full_relative_path="${base_submodule_path}${base_submodule_path:+/}$( \
         "${GIT}" config -f .gitmodules ${submodule_name}.path)"

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -356,25 +356,19 @@ function update_submodules()
   # Arrays aren't exported, reload
   _git_mirror_load_info "${1}" # Sets repo_paths and repo_urls
 
-  local submodule_name
-  local full_relative_path
+  # In the root of the project repository (the first pass through this
+  # function), base_submodule_path is unset
   local base_submodule_path="${base_submodule_path-}${base_submodule_path:+/}${prefix-${displaypath-}}"
   # Remove trailing slashes because on some versions of git (1.8.3, 2.17.1)
   # prefix has a trailing slash
   base_submodule_path="${base_submodule_path%/}"
   local current_repo="$(_git_mirror_get_url "${base_submodule_path:-.}")"
-  next_section "Initializing ${current_repo}'s submodules"
 
   "${GIT}" submodule init
-  local IFS=$'\n'
-  local submodule_names=($(get_config_submodule_names))
 
   # Sync the submodules to the mirrored repository
-  for submodule_name in ${submodule_names[@]+"${submodule_names[@]}"}; do
-    full_relative_path="${base_submodule_path}${base_submodule_path:+/}$( \
-        "${GIT}" config -f .gitmodules ${submodule_name}.path)"
-    "${GIT}" config "${submodule_name}.url" "$(_git_mirror_get_url "${full_relative_path}")"
-  done
+  sync_submodules ${base_submodule_path:+"${base_submodule_path}"}
+
   next_section "Updating ${current_repo}'s submodules"
   "${GIT}" submodule update
 
@@ -384,6 +378,61 @@ function update_submodules()
   base_submodule_path="${base_submodule_path-}" \
       "${GIT}" submodule foreach --quiet "export prefix displaypath; bash -euc \
           'unset GIT_DIR; source \"${GIT_MIRROR_SOURCE[0]}\"; update_submodules \"${1}\"'"
+}
+
+#**
+# .. function:: sync_submodules
+#
+# Sync the submodules to the mirrored remote (non-recursive)
+#
+# This is a helper function to :func:`update_submodules`. Sync the submodules' remote urls (non-recursively), a la ``git submodule sync``, however, instead of referring to the .gitmodules file, use the mapping specified by ``repo_paths`` and ``repo_urls``.
+#
+# :Arguments: ``$1`` - The (relative) path from the project repository to a submodule (a repository itself) with, potentially, submodules of its own that need to be sync'ed (i.e., a path as printed by ``git submodule foreach -q 'echo "$displaypath"'`` assuming the CWD is the root of the project repository)
+# :Parameters: ``repo_paths`` - The array of (relative) paths from the root of the project repository to each submodule (recursively); see :func:`_git_mirror_load_info`
+#              ``repo_urls`` - The corresponding URL of each repo_path
+#
+# .. note::
+#
+#   This function assumes ``$1`` is also the PWD
+#
+# .. rubric:: Example
+#
+# .. code-block:: bash
+#
+#    repo_paths=(
+#      .
+#      docker/recipes
+#    )
+#    repo_urls=(
+#      https://git-server.com/foobar/vsi_common.git
+#      https://git-server.com/foobar/recipes.git
+#    )
+#**
+
+# TODO RE the above .. note:: use just_git_airgap_repo.bsh:git_project_root_dir
+# to find the project root and compute base_submodule_path from the PWD
+# RE It would be good to refactor those functions into git_functions.bsh,
+# otherwise the import would be circular
+#
+# NOTE Unlike just_git_functions:safe_git_submodule_update, we don't want to
+# use a custom remote here because there would be no way to update the default
+# remote, and then things like git fetch could stop working
+function sync_submodules()
+{
+  local base_submodule_path="${1-}"
+
+  local IFS=$'\n'
+  local submodule_names=($(get_config_submodule_names))
+
+  local submodule_name
+  local sm_path
+  local full_relative_path
+  for submodule_name in ${submodule_names[@]+"${submodule_names[@]}"}; do
+    # NOTE Assumes we are in the top-level directory
+    sm_path="$("${GIT}" config -f .gitmodules ${submodule_name}.path)"
+    full_relative_path="${base_submodule_path}${base_submodule_path:+/}${sm_path}"
+    "${GIT}" config "${submodule_name}.url" "$(_git_mirror_get_url "${full_relative_path}")"
+  done
 }
 
 #**

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -39,7 +39,7 @@ GIT_MIRROR_SOURCE="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"/"$(basename "${B
 # #. Transfer ``vsi_common_prep/transfer_{date}.tgz`` to your destination
 # #. On the destination, create a directory, e.g., vsi_common_prep, and move the archive into it
 # #. Extract the archive (the archive will extract directly into this directory)
-# #. Write an ``info.env`` file:
+# #. Write an ``info.env`` file mapping each repository to its mirrored URL:
 #
 # .. code-block:: bash
 #
@@ -163,9 +163,13 @@ function git_mirror_has_lfs()
 # WARNING: ``git submodule foreach`` runs commands via sh because git is weird; however I start bash and source this script for its vars and functions, so it's really bash again.
 #
 # :Parameters: ``GIT_MIRROR_PREP_DIR`` - The directory in which to mirror the repositories
-#              [``base_submodule_path``] - The (relative) path from the project repository to a submodule (a repository itself) with, potentially, submodules of its own that need to be mirrored/updated (i.e., a path as printed by ``git submodule foreach -q 'echo "$displaypath"'`` assuming the CWD is the root of the project repository)
+#              [``base_submodule_path``] - The (relative) path from the project repository to a submodule with, potentially, submodules of its own that need to be mirrored/updated. This must also be the CWD. If unset, mirror the submodules of the parent repository.
 #
 # :Output: A mirrored submodule located at ``GIT_MIRROR_PREP_DIR/{temp_dir}/base_submodule_path``
+#
+# .. note::
+#
+#   This function assumes ``base_submodule_path`` is also the PWD
 #**
 
 function clone_submodules()
@@ -334,17 +338,21 @@ function clone_submodules()
 #**
 # .. function:: update_submodules
 #
-# Clone a submodule and any of its submodules (recursively)
+# Init/update a submodule and any of its submodules (recursively)
 #
-# This is a helper function to :func:`git_clone_main`. Recursively clone a submodule mirrored with :func:`git_mirror_main`, and fixup the submodules' remote urls according to the mapping specified by ``$1``.
+# This is a helper function to :func:`git_clone_main`. Recursively clone a submodule mirrored with :func:`git_mirror_main`, and fixup the submodules' remote URLs according to the mapping specified by ``$1``.
 #
 # WARNING: ``git submodule foreach`` runs commands via sh because git is weird; however I start bash and source this script for its vars and functions, so it's really bash again.
 #
-# :Arguments: ``$1`` - A file specifying the mapping between each repository's original url and its mirror url
-#              [``base_submodule_path``] - The (relative) path from the project repository to a submodule (a repository itself) with, potentially,  submodules of its own that need to be cloned/updated (i.e., a path as printed by ``git submodule foreach -q 'echo "$displaypath"'`` assuming the CWD is the root of the project repository)
+# :Arguments: ``$1`` - A file specifying the mapping between each repository and its mirror URL; see :func:`_git_mirror_load_info`
+#              [``base_submodule_path``] - The (relative) path from the project repository to a submodule with, potentially, submodules of its own that need to be cloned/updated. This must also be the CWD. If unset, update the submodules of the parent repository.
 #              [``prefix``] - A variable set when calling ``git submodule foreach`` (and, by necessity, re-exported by this function) to the submodule path (sm_path) from the .gitmodules file. After git v1.8.3, ``prefix`` was replaced with ``displaypath``
 #              [``displaypath``] - A variable set when calling ``git submodule foreach`` (and, by necessity, re-exported by this function) to the relative path from the current working directory to the submodules root directory
 # :Output: The recursively cloned submodule
+#
+# .. note::
+#
+#   This function assumes ``base_submodule_path`` is also the PWD
 #**
 
 # NOTE This function could be refactored in the same manner as suggested in
@@ -385,28 +393,15 @@ function update_submodules()
 #
 # Sync the submodules to the mirrored remote (non-recursive)
 #
-# This is a helper function to :func:`update_submodules`. Sync the submodules' remote urls (non-recursively), a la ``git submodule sync``, however, instead of referring to the .gitmodules file, use the mapping specified by ``repo_paths`` and ``repo_urls``.
+# This is a helper function to :func:`update_submodules`. Sync the submodules' remote URLs (non-recursively), a la ``git submodule sync``, however, instead of referring to the .gitmodules file, use the mapping specified by ``repo_paths`` and ``repo_urls``.
 #
-# :Arguments: ``$1`` - The (relative) path from the project repository to a submodule (a repository itself) with, potentially, submodules of its own that need to be sync'ed (i.e., a path as printed by ``git submodule foreach -q 'echo "$displaypath"'`` assuming the CWD is the root of the project repository)
+# :Arguments: ``$1`` - The (relative) path from the project repository to a submodule with, potentially, submodules of its own that need to be sync'ed. This must also be the CWD. If unset, sync the submodules of the parent repository.
 # :Parameters: ``repo_paths`` - The array of (relative) paths from the root of the project repository to each submodule (recursively); see :func:`_git_mirror_load_info`
 #              ``repo_urls`` - The corresponding URL of each repo_path
 #
 # .. note::
 #
 #   This function assumes ``$1`` is also the PWD
-#
-# .. rubric:: Example
-#
-# .. code-block:: bash
-#
-#    repo_paths=(
-#      .
-#      docker/recipes
-#    )
-#    repo_urls=(
-#      https://git-server.com/foobar/vsi_common.git
-#      https://git-server.com/foobar/recipes.git
-#    )
 #**
 
 # TODO RE the above .. note:: use just_git_airgap_repo.bsh:git_project_root_dir
@@ -490,7 +485,7 @@ function sync_submodules()
 #
 # .. note::
 #
-#   ``git_mirror_main`` does not mirror all submodules that have ever been part of the repo, only those from a specific branch/SHA/tag you specify (master by default). This is because trying to mirror all submodules from the past could be very lengthy, and is very likely to include urls that do not exist anymore.
+#   ``git_mirror_main`` does not mirror all submodules that have ever been part of the repo, only those from a specific branch/SHA/tag you specify (master by default). This is because trying to mirror all submodules from the past could be very lengthy, and is very likely to include URLs that do not exist anymore.
 #
 # .. rubric:: Bugs
 #
@@ -521,7 +516,7 @@ function git_mirror_main()
 #
 # .. note::
 #
-#   :func:`git_mirror_repos` does not mirror all submodules that have ever been part of the repo, only those from a specific branch/SHA/tag you specify (master by default). This is because trying to mirror all submodules from the past could be very lengthy, and is very likely to include urls that do not exist anymore.
+#   :func:`git_mirror_repos` does not mirror all submodules that have ever been part of the repo, only those from a specific branch/SHA/tag you specify (master by default). This is because trying to mirror all submodules from the past could be very lengthy, and is very likely to include URLs that do not exist anymore.
 #
 # .. rubric:: Bugs
 #
@@ -752,6 +747,37 @@ function archive_mirrors()
   echo -n $'\e[0m'
 }
 
+#**
+# .. function:: _git_mirror_load_info
+#
+# Load the mapping between each repository and its mirror URL
+#
+# :Arguments: ``$1`` - A file specifying the mapping between each repository and its mirror URL
+# :Output: ``repo_paths`` - The array of (relative) paths from the root of the project repository to each submodule (recursively). (That is, a path as printed by ``echo . && git submodule foreach -q 'echo "$displaypath"'`` assuming the CWD is the root of the project repository)
+#          ``repo_urls`` - The corresponding URL of each repo_path
+#
+# .. rubric:: Example
+#
+# .. code-block:: bash
+#
+#    $ cat info.env
+#    repo_paths=(
+#      .
+#      docker/recipes
+#    )
+#    repo_urls=(
+#      https://git-server.com/foobar/vsi_common.git
+#      https://git-server.com/foobar/recipes.git
+#    )
+#
+# Or alternatively, using associative arrays:
+#
+# .. code-block:: bash
+#
+#    repos[.]=https://git-server.com/foobar/vsi_common.git
+#    repos[docker/recipes]=https://git-server.com/foobar/recipes.git
+#**
+
 function _git_mirror_load_info()
 {
   if [ "${bash_feature_associative_array}" = "0" ]; then
@@ -768,6 +794,17 @@ function _git_mirror_load_info()
     done
   fi
 }
+
+#**
+# .. function:: _git_mirror_get_url
+#
+# Return the URL for a given submodule
+#
+# :Arguments: ``$1`` - A path that can be found in ``repo_paths``
+# :Parameters: ``repo_paths`` - The array of (relative) paths from the root of the project repository to each submodule (recursively); see :func:`_git_mirror_load_info`
+#              ``repo_urls`` - The corresponding URL of each repo_path
+# :Output: The URL corresponding to ``$1``
+#**
 
 function _git_mirror_get_url()
 {
@@ -786,9 +823,9 @@ function _git_mirror_get_url()
 #
 # Clone recursively from the new mirror
 #
-# Once the repository has been mirrored to the new git server with :func:`git_push_main`, it can be cloned. However, because the .gitmodules file will point to different urls than the mirrors, and changing the .gitmodules file will change the repo, which we don't want to do, we need to make a shallow clone of the repository, init the submodules, modify the submodules' urls, and then finally update the submodules. And all of this has to be done recursively for each submodule. As you can tell, this is very tedious, so this script will do it all for you.
+# Once the repository has been mirrored to the new git server with :func:`git_push_main`, it can be cloned. However, because the .gitmodules file will point to different URLs than the mirrors, and changing the .gitmodules file will change the repo, which we don't want to do, we need to make a shallow clone of the repository, init the submodules, modify the submodules' URLs, and then finally update the submodules. And all of this has to be done recursively for each submodule. As you can tell, this is very tedious, so this script will do it all for you.
 #
-# :Arguments: ``$1`` - A file specifying the mapping between each repository's original url and its mirror url
+# :Arguments: ``$1`` - A file specifying the mapping between each repository and its mirror URL; see :func:`_git_mirror_load_info`
 #             [``$2``] - The directory in which to clone the repo
 #
 # .. rubric:: Example
@@ -830,15 +867,15 @@ function git_clone_main()
 #
 #   The mirrors must be initialized on the git server.
 #
-# However, because the urls for your mirrors will be different from the original repo urls in .gitmodules, and modifying the urls will change the git repo, which we do not want to do, you must create a file specifying the mapping between each repository's original url and its mirror url (remote). The main repo is referred to as ``.`` while the rest of the repos are referred to by the relative path with respect to the main repo (e.g. ``external/vsi_common``). These need to be stored in an associative array called ``repos``.
+# However, because the URLs for your mirrors will be different from the original repo URLs in .gitmodules, and modifying the URLs will change the git repo, which we do not want to do, you must create a file specifying the mapping between each repository and its mirror URL. The main repo is referred to as ``.`` while the rest of the repos are referred to by the relative path with respect to the main repo (e.g. ``external/vsi_common``). These need to be stored in an associative array called ``repos``.
 #
-# :Arguments: ``$1`` - A file specifying the mapping between each repository's original url and its mirror url
+# :Arguments: ``$1`` - A file specifying the mapping between each repository and its mirror URL; see :func:`_git_mirror_load_info`
 #             ``$2`` - The mirrored repositories (extracted from the archive) created by :func:`git_mirror_main`
 # :Parameters: [``GIT_MIRROR_FORCE_PUSH_REFS``] - A flag specifying whether to force push refs, should it be necessary. Default: 1 (force-push refs)
 #
 # .. rubric:: Example
 #
-# In this example, the main repo's mirror url is ``https://git-server.com/foobar/vsi_common.git``, and the submodule stored at ``./docker/recipes`` has the url ``https://git-server.com/foobar/recipes.git``. This file is also used by :func:`git_clone_main`. (Any valid git URL format can be used.)
+# In this example, the main repo's mirror URL is ``https://git-server.com/foobar/vsi_common.git``, and the submodule stored at ``./docker/recipes`` has the URL ``https://git-server.com/foobar/recipes.git``. This file is also used by :func:`git_clone_main`. (Any valid git URL format can be used.)
 #
 # .. code-block:: bash
 #
@@ -980,7 +1017,7 @@ function git_push_main()
 #
 # Before pushing the mirrored repository and all of its submodules to the new git server with :func:`git_push_main`, tag the refs so that if, during the **next** transfer, they become dereferenced (due to a force push, which is sometimes necessary), they are not lost. For a ref of the form refs/heads/master, this (annotated) tag takes the (long) form of refs/tags/just_git_mirror/{datetime}/heads/master
 #
-# :Arguments: ``$1`` - A file specifying the mapping between each repository's original url and its mirror url
+# :Arguments: ``$1`` - A file specifying the mapping between each repository and its mirror URL; see :func:`_git_mirror_load_info`
 #             ``$2`` - The mirrored repositories (extracted from the archive) created by :func:`git_mirror_main`
 # :Parameters: [``GIT_MIRROR_TAG_REFS_REGEX``] - An extended regular expression specifying which refs to tag. The refs should be matched in their long form, e.g., refs/heads/master or refs/tags/v1.0.0. Default: ^refs/heads/.+
 #

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -158,12 +158,12 @@ function git_mirror_has_lfs()
 #
 # Mirror a submodule and all of its submodules (recursively)
 #
-# This is a helper function to :func:`git_mirror_main`. Create a mirror of each submodule in a git repository, recursively. Each mirror is stored according to its full relative path in the project repository in a unique temporary directory created in the GIT_MIRROR_PREP_DIR. Submodules of a submodule are processed recursively in a depth-first fashion.
+# This is a helper function to :func:`git_mirror_main`. Create a mirror of each submodule in a git repository, recursively. Each mirror is stored according to its full relative path in the project repository in a unique temporary directory created in the ``GIT_MIRROR_PREP_DIR``. Submodules of a submodule are processed recursively in a depth-first fashion.
 #
 # WARNING: ``git submodule foreach`` runs commands via sh because git is weird; however I start bash and source this script for its vars and functions, so it's really bash again.
 #
-# :Arguments: ``GIT_MIRROR_PREP_DIR`` - The directory in which to mirror the repositories
-#             [``base_submodule_path``] - The (relative) path from the project repository to the submodule (i.e., ``git submodule foreach '$displaypath'`` assuming the CWD is the root of the project repository)
+# :Parameters: ``GIT_MIRROR_PREP_DIR`` - The directory in which to mirror the repositories
+#              [``base_submodule_path``] - The (relative) path from the project repository to a submodule (a repository itself) with, potentially, submodules of its own that need to be mirrored/updated (i.e., a path as printed by ``git submodule foreach -q 'echo "$displaypath"'`` assuming the CWD is the root of the project repository)
 #
 # :Output: A mirrored submodule located at ``GIT_MIRROR_PREP_DIR/{temp_dir}/base_submodule_path``
 #**
@@ -336,12 +336,14 @@ function clone_submodules()
 #
 # Clone a submodule and any of its submodules (recursively)
 #
-# This is a helper function to git_clone_main. Recursively clone a submodule mirrored with :func:`git_mirror_main`, and fixup the submodules' remote urls according to the mapping specified by ``$1``.
+# This is a helper function to :func:`git_clone_main`. Recursively clone a submodule mirrored with :func:`git_mirror_main`, and fixup the submodules' remote urls according to the mapping specified by ``$1``.
 #
 # WARNING: ``git submodule foreach`` runs commands via sh because git is weird; however I start bash and source this script for its vars and functions, so it's really bash again.
 #
 # :Arguments: ``$1`` - A file specifying the mapping between each repository's original url and its mirror url
-#             [``base_submodule_path``] - The (relative) path from the project repository to the submodule
+#              [``base_submodule_path``] - The (relative) path from the project repository to a submodule (a repository itself) with, potentially,  submodules of its own that need to be cloned/updated (i.e., a path as printed by ``git submodule foreach -q 'echo "$displaypath"'`` assuming the CWD is the root of the project repository)
+#              [``prefix``] - A variable set when calling ``git submodule foreach`` (and, by necessity, re-exported by this function) to the submodule path (sm_path) from the .gitmodules file. After git v1.8.3, ``prefix`` was replaced with ``displaypath``
+#              [``displaypath``] - A variable set when calling ``git submodule foreach`` (and, by necessity, re-exported by this function) to the relative path from the current working directory to the submodules root directory
 # :Output: The recursively cloned submodule
 #**
 
@@ -783,8 +785,7 @@ function git_clone_main()
 #
 # :Arguments: ``$1`` - A file specifying the mapping between each repository's original url and its mirror url
 #             ``$2`` - The mirrored repositories (extracted from the archive) created by :func:`git_mirror_main`
-#
-#              [``GIT_MIRROR_FORCE_PUSH_REFS``] - A flag specifying whether to force push refs, should it be necessary. Default: 1 (force-push refs)
+# :Parameters: [``GIT_MIRROR_FORCE_PUSH_REFS``] - A flag specifying whether to force push refs, should it be necessary. Default: 1 (force-push refs)
 #
 # .. rubric:: Example
 #
@@ -932,7 +933,6 @@ function git_push_main()
 #
 # :Arguments: ``$1`` - A file specifying the mapping between each repository's original url and its mirror url
 #             ``$2`` - The mirrored repositories (extracted from the archive) created by :func:`git_mirror_main`
-#
 # :Parameters: [``GIT_MIRROR_TAG_REFS_REGEX``] - An extended regular expression specifying which refs to tag. The refs should be matched in their long form, e.g., refs/heads/master or refs/tags/v1.0.0. Default: ^refs/heads/.+
 #
 # .. seealso::

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -263,7 +263,8 @@ function clone_submodules()
   # Could also add --recommend-shallow (introduced in git 2.10.0)
   # This flag gets translated to the --depth flag, which is ignored for local
   # clones
-  # RE This optimization does not seem worth it for a local clone
+  # RE Whether this optimization is worth it for a local clone depends on a lot
+  # of things, including the filesystem
   GIT_LFS_SKIP_SMUDGE=1 "${GIT}" submodule update
   # Restore the origin urls after update, so that relative URLs work
   "${GIT}" submodule sync
@@ -308,20 +309,18 @@ function clone_submodules()
   # to pass the prefix/displaypath variables from git into the called function,
   # so export them.
   #
-  # NOTE We already have the list of submodule names (via get_submodule_name),
-  # and their associated sm_paths (via git config). We could recurse through
-  # the submodules ourselves like just_git_functions:safe_git_submodule_update
-  # (which is called recursively via just_git_functions:_checkout_git_submodule)
-  # and just_git_airgap_repo.bsh:git_sync_submodules_recursively.
+  # NOTE We list submodules two ways in this function: at the beginning with
+  # get_config_submodule_names (which uses git config and works with init-only
+  # submodules) and, here, with git submodule foreach (which does not).
+  # RE With the submodule names we could get the associated submodule paths
+  # (via git config) and then recurse through the submodules ourselves like
+  # just_git_functions:safe_git_submodule_update (which is called recursively
+  # via just_git_functions:_checkout_git_submodule) and
+  # just_git_airgap_repo.bsh:git_sync_submodules_recursively.
   # This would avoid the complications involved with exporting the required
   # variables, keeping track of base_submodule_path, re-sourcing this file (and
   # the info.env in update_submodules), etc. needed because git submodule foreach
   # runs in an sh subshell
-  # RE We would first have to do a recursive clone, but we are effectively
-  # doing that here anyway, just manually
-  # NOTE We list submodules two ways in this function: at the beginning with
-  # get_config_submodule_names (which uses git config and works with init-only
-  # submodules) and, here, with git submodule foreach (which does not).
   # NOTE We could make a similar change in update_submodules
   GIT_MIRROR_PREP_DIR="${GIT_MIRROR_PREP_DIR}" base_submodule_path="${base_submodule_path}" \
       "${GIT}" submodule foreach --quiet \
@@ -346,6 +345,10 @@ function clone_submodules()
 # :Output: The recursively cloned submodule
 #**
 
+# NOTE This function could be refactored in the same manner as suggested in
+# clone_submodules
+# RE This would make it easier to support refactoring this into a non-recursive
+# submodule sync and recursive submodule update function
 function update_submodules()
 {
   # Arrays aren't exported, reload
@@ -548,7 +551,8 @@ function git_mirror_repos()
   # Could also add --depth 1 --branch "${BRANCH}" --no-recursive
   # RE --depth is ignored for local clones...could add
   # --single-branch --branch "${BRNACH}" --no-recursive
-  # RE This optimization does not seem worth it for a local clone
+  # RE Whether this optimization is worth it for a local clone depends on a lot
+  # of things, including the filesystem
   if tar_feature_incremental_backup; then
     # Clone without hardlinks because they mess up the incremental archive
     # (see clone_submodules)

--- a/linux/just_files/just_git_functions.bsh
+++ b/linux/just_files/just_git_functions.bsh
@@ -140,7 +140,7 @@ function _checkout_git_submodule()
 
   if ! "${GIT}" -c foo=bar version &> /dev/null || \
      ! git_feature_submodule_update_with_custom_command; then
-    # This is older than 1.8 so it doesn't support -c OR submodule.${1}.update
+    # This is older than v1.8 so it doesn't support -c OR submodule.${1}.update
     echo "${YELLOW}Warning:${NC} your version of git is too old. Doing normal submodule update" >&2
 
     local tracked_sha="$("${GIT}" submodule status --cached "${2}" | cut -c2- | awk '{print $1}')"
@@ -161,7 +161,7 @@ function _checkout_git_submodule()
       echo
     fi
   else
-    # Starting in git 2.8, 'git submodule update' fails if the commit tracked
+    # Starting in git v2.8, 'git submodule update' fails if the commit tracked
     # by the parent repository does not exist in the submodule (which can
     # happen if the submodule's URL changes and needs to be sync'd)
     if PATH="${VSI_COMMON_DIR}/linux:${PATH}" "${GIT}" -c "submodule.${1}.update"='!bash git_safe_update' submodule update --no-fetch "${2}"; then
@@ -402,7 +402,8 @@ function safe_git_submodule_update()
 
 git_reattach_heads()
 {
-  # git submodule foreach must be run from the top-level working tree in git 1.8
+  # git submodule foreach must be run from the top-level working tree in
+  # git v1.8.3
   pushd "$("${GIT}" rev-parse --show-cdup)" &> /dev/null
     local submodule_paths
     if [ $# -eq 0 ]; then

--- a/linux/just_git_airgap_repo.bsh
+++ b/linux/just_git_airgap_repo.bsh
@@ -1238,11 +1238,11 @@ function add_import-repo_just_project()
 #
 # Resolve a submodule's relative URL based on the parent URL. This function works by creating a dummy git repository and submodule and then running ``git submodule init`` (which runs a process similar to ``git submodule sync``), after which, the resolved URL can be queried with ``git config submodule.submod.url``. We do this to avoid modifying the existing repository's git configuration (e.g., ``git config submodule.docker/recipes.url``).
 #
-# :Arguments: * ``$1`` - URL of the parent repository; e.g., ``git config remote.origin.url``
-#             * ``$2`` - A relative submodule URL---typically from the .gitmodules file; e.g., ``git config -f .gitmodules submodule.docker/recipes.url``
+# :Arguments: * ``$1`` - URL of the parent repository; e.g., https://github.com/VisionSystemsInc/vsi_common.git per ``git config remote.origin.url``
+#             * ``$2`` - A relative submodule URL---typically from the .gitmodules file; e.g., ../../VisionSystemsInc/docker_recipes.git per ``git config -f .gitmodules submodule.docker/recipes.url``
 #             * [``$3``] - Up path: path from the submodule to the parent repository; e.g., ``../../``. Must have a trailing slash. (Not strictly necessary if ``$1`` is an absolute path)
 #
-# :Output: *stdout* - Resolved URL
+# :Output: *stdout* - Resolved URL; e.g., https://github.com/VisionSystemsInc/docker_recipes.git
 #
 # .. note::
 #
@@ -1275,8 +1275,9 @@ function submodule-helper-relative-url()
     # to say, it updates the value in .git/config as well as the value in
     # .git/modules/docker/recipes/config, which is a problem we've run into
     # before: issue #186
-    # RE In git v2.9.0, git submodule--helper resolve-relative-url, was
-    # added to do this, but relative URLs exist as far back as v1.8.3
+    # RE In git v2.9.0, git submodule--helper resolve-relative-url, was added
+    # to do this for an existing submodule, but relative URLs exist as far back
+    # as v1.8.3 and it does not support the third parameter, up_path
     # RE Actually, it seems the behavior of
     #   git submodule--helper resolve-relative-url
     # is less sophisticated than I expected (basically just a norm_path if

--- a/linux/just_git_airgap_repo.bsh
+++ b/linux/just_git_airgap_repo.bsh
@@ -668,7 +668,16 @@ function git_submodule_summary()
   for sm_key in ${submodule_keys[@]+"${submodule_keys[@]}"}; do
     local sm_path="$("${GIT}" config --file .gitmodules --get submodule."${sm_key}".path)"
 
-    # Cf. git submodule summary - doesn't show modified/staged content
+    # Cf. git submodule summary - doesn't show modified/staged content [1]
+    # The implementations are actually different
+    # While both can be used to list changes to the working tree,
+    # git diff --submodule=log SHA~1..SHA (or git log --patch --submodule=log SHA)
+    # can be used to list the changes (in commits) to a submodule; however in
+    # that case, it only lists merges (unfortunately) [2]:
+    # [1] https://github.com/git/git/blob/v2.24.1/git-submodule.sh#L777
+    # [2] https://github.com/git/git/blob/v2.24.1/diff.c#L3400 =>
+    #     https://github.com/git/git/blob/v2.24.1/submodule.c#L613-L640
+    #     https://github.com/git/git/blob/v2.24.1/submodule.c#L586-L592
     "${GIT}" diff --submodule=log "${sm_path}"
 
     if [ -n "${_recursive_summary:+set}" ]; then

--- a/linux/just_git_airgap_repo.bsh
+++ b/linux/just_git_airgap_repo.bsh
@@ -140,8 +140,8 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 # RE However, it would not update the submodules in a safe way...
 # RE RE Create a function git_mirror:sync_submodules (which would look almost
 # identical to update_submodules except without 'git submodule update'---we
-# can't just refactor that function because initially it must be done in a
-# breadth-first manner: first sync and then clone (aka update) the submodule).
+# can't just refactor that function because initially it must be done in an
+# interleaved manner: first sync and then clone (aka update) the submodule).
 # sync_submodules could be made to override the sync'ing functionality of
 # git_submodule-update, which is already part of just sync
 

--- a/linux/just_git_airgap_repo.bsh
+++ b/linux/just_git_airgap_repo.bsh
@@ -102,7 +102,7 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 # 6. ``source setup.env``
 # #. ``just git import-repo`` - Push the mirrored repository and all its submodules to the new git server as defined by repo_map.env
 #
-# 1. Subsequent updates can be pushed to the repositories using much the same process, although with a few variations:
+# Subsequent updates can be pushed to the repositories using much the same process, although with a few variations:
 #
 #   #. In step 1, when prompted, choose "Base the archive off an existing airgap mirror"; in this example, ``{output_dir}``.
 #

--- a/linux/just_git_airgap_repo.bsh
+++ b/linux/just_git_airgap_repo.bsh
@@ -294,11 +294,11 @@ function git_tracking_branches()
   # and upstream:track=[ahead 3] or [gone] if the remote-tracking branch has
   # been pruned. upstream:short is a blank space (' ') if upstream is unset,
   # i.e., there is no remote-tracking branch setup
-  # NOTE %(upstream:track) requires git >= 1.9.0
+  # NOTE %(upstream:track) requires git >= v1.9.0
   #
   # Alternatively: git branch -vv provides the same tracking information as
-  # upstream:track, even in git 1.8.3
-  # RE this is the only command to get this info in git 1.8.3; although it can
+  # upstream:track, even in git v1.8.3
+  # RE this is the only command to get this info in git v1.8.3; although it can
   # be calculated manually with git log --format='%H' branch..branch@{upstream}
   # for incoming commits and git log --format='%H' branch@{upstream}..branch
   # for outgoing (see log_outgoing_commits)
@@ -418,7 +418,7 @@ function convert_git_remote_http_to_git()
   # local foo="$(bar)" || rv=$? does not work as one line in bash 4.2 or older. Use two lines
   remote_git_url="$(_http_to_git_protocol "${remote_url}")" || remote_git_url_rv=$?
   if [ "${remote_git_url_rv}" == "0" ]; then
-    # NOTE since git 1.8, a remote (e.g., origin) can have multiple associated
+    # NOTE since git v1.8, a remote (e.g., origin) can have multiple associated
     # pushurls (see .git/config:remote)
     # RE providing the old url (remote_url) will update the correct url
     #"${GIT}" remote set-url "${remote_name}" --push "${remote_git_url}" "${remote_url}"
@@ -488,9 +488,9 @@ function is_submodule()
       # --show-prefix)
       prefix="${prefix:+"${prefix%/}/"}"
       pushd "${superlevel}" &> /dev/null
-        # In git 1.8.3, git submodule must be run in the toplevel of the
+        # In git v1.8.3, git submodule must be run in the toplevel of the
         # working tree
-        # git 1.8.3 does not support git -C
+        # git v1.8.3 does not support git -C
         #
         # Strip trailing / (this may be guaranteed by sm_path)
         # real_path may be necessary to ensure the grep succeeds
@@ -523,7 +523,7 @@ function is_submodule()
   # git rev-parse --show-prefix
   #   The relative path from the current repository/submodule work tree to the
   #   CWD
-  # git rev-parse --show-superproject-working-tree (available in git 2.13.7)
+  # git rev-parse --show-superproject-working-tree (available in git v2.13.7)
   #   The absolute path to the superproject work tree of the current submodule;
   #   e.g., from /src/vsi_common/docker/recipes/hooks, this command prints
   #   /src/vsi_common
@@ -690,7 +690,7 @@ function git_submodule_displaypaths_recursive()
 #
 # Get the displaypath to each submodule
 #
-# Get what git refers to as the displaypath of the submodule: the relative path from the current working directory to the root of the containing repository and then to each submodule. This path is defined by the git-specified environment variable, displaypath (or prefix depending on git version).
+# Get what git refers to as the displaypath of the submodule: the relative path from the current working directory to the root of the containing repository and then to each submodule. This path is defined by the git-specified environment variable, displaypath (or prefix in and before git v1.8.3).
 #
 # :Output: *stdout* - The displaypath to each submodule (recursively); e.g., docker/recipes
 #
@@ -729,8 +729,9 @@ function git_submodule_displaypaths()
 
   local submodule_foreach_rv=0
   pushd "${up_path}" &> /dev/null
-    # In git 1.8.3, git submodule must be run in the toplevel of the working tree
-    # git 1.8.3 does not support git -C
+    # In git v1.8.3, git submodule must be run in the toplevel of the working
+    # tree
+    # git v1.8.3 does not support git -C
     "${GIT}" submodule foreach '[ -n "${prefix+set}" ]' &> /dev/null || submodule_foreach_rv=$?
   popd &> /dev/null
 
@@ -740,8 +741,9 @@ function git_submodule_displaypaths()
   local submodule_paths
   if [ "${submodule_foreach_rv}" -eq 0 ]; then
     pushd "${up_path}" &> /dev/null
-      # In git 1.8.3, git submodule must be run in the toplevel of the working tree
-      # git 1.8.3 does not support git -C
+      # In git v1.8.3, git submodule must be run in the toplevel of the working
+      # tree
+      # git v1.8.3 does not support git -C
       submodule_paths=($(up_path="${up_path}" relative_cwd="${relative_cwd}" \
           "${GIT}" submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} \
               'export prefix
@@ -759,7 +761,7 @@ function git_submodule_displaypaths()
   IFS="${OLD_IFS}"
   local submodule_path
   for submodule_path in ${submodule_paths[@]+"${submodule_paths[@]}"}; do
-    # Remove trailing slashes because on some versions of git (1.8.3, 2.17.1),
+    # Remove trailing slashes because on some versions of git (v1.8.3, v2.17.1)
     # prefix has a trailing slash
     # RE It may be that prefix always has a trailing slash and displaypath does not
     echo "${submodule_path%/}"
@@ -807,7 +809,7 @@ function git_submodule_urls_recursive()
 #
 # Get all submodule URLs
 #
-# Get the (last) URL for each submodule (recursively) from its .git/\*\*/config file (e.g., .git/modules/docker/recipes/config) for the specified remote (origin by default). Note: Since git 1.8, a remote can have multiple associated URLs (and pushurls) (see .git/config).
+# Get the (last) URL for each submodule (recursively) from its .git/\*\*/config file (e.g., .git/modules/docker/recipes/config) for the specified remote (origin by default). Note: Since git v1.8, a remote can have multiple associated URLs (and pushurls) (see .git/config).
 #
 # :Arguments: [``$1``] - The name of a remote. Note: this same remote must exist in all submodules. Default: origin
 # :Output: *stdout* - The URL of each submodule (recursively); e.g., https://github.com/VisionSystemsInc/docker_recipes.git
@@ -838,7 +840,8 @@ function git_submodule_urls()
     recursive_flag=("--recursive")
   fi
 
-  # git submodule foreach must be run from the top-level working tree in git 1.8
+  # git submodule foreach must be run from the top-level working tree in
+  # git v1.8.3
   pushd "$("${GIT}" rev-parse --show-cdup)" &> /dev/null
     # Query the URL from the submodule's repository configuration
     # (e.g., .git/modules/docker/recipes/config)
@@ -922,7 +925,8 @@ function git_submodule_names()
     recursive_flag=("--recursive")
   fi
 
-  # git submodule foreach must be run from the top-level working tree in git 1.8
+  # git submodule foreach must be run from the top-level working tree in
+  # git v1.8.3
   pushd "$("${GIT}" rev-parse --show-cdup)" &> /dev/null
     "${GIT}" submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} 'echo "${name}"'
   popd &> /dev/null
@@ -933,7 +937,7 @@ function git_submodule_names()
   #       sed -e 's|.url$||' -e 's|^submodule.||'
   #
   # git submodule--helper name docker/recipes will also return the name of a
-  # submodule given an sm_path (available after git 2.7 at least)
+  # submodule given an sm_path (available at least after git v2.7)
   #
   # NOTE Updating a submodule's name (as recorded in the .gitmodules file) is
   # tricky to get right; git basically treats it as a new submodule
@@ -987,7 +991,8 @@ function git_submodule_toplevels()
     recursive_flag=("--recursive")
   fi
 
-  # git submodule foreach must be run from the top-level working tree in git 1.8
+  # git submodule foreach must be run from the top-level working tree in
+  # git v1.8.3
   pushd "$("${GIT}" rev-parse --show-cdup)" &> /dev/null
     "${GIT}" submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} 'echo "${toplevel}"'
   popd &> /dev/null
@@ -1152,7 +1157,7 @@ function orphan_commit_repo_map
       "${GIT}" checkout "${orphan_branch}" &> /dev/null
     else
       # If trying to clone a single branch from a bare repo that has only
-      # been initialized, git 1.8 segfaults, leaving behind an initialized
+      # been initialized, git v1.8.3 segfaults, leaving behind an initialized
       # .git directory
       rm -rf .git
       "${GIT}" init &> /dev/null
@@ -1246,7 +1251,7 @@ function add_import-repo_just_project()
 #
 # .. note::
 #
-#   This is essentially a bash port of the function `relative_url() <https://github.com/git/git/blob/v2.16.0/builtin/submodule--helper.c#L117>`_ (called from `resolve_relative_url() <https://github.com/git/git/blob/v2.16.0/builtin/submodule--helper.c#L180>`_, aka ``git submodule--helper resolve-relative-url``, which itself is called from `cmd_sync() <https://github.com/git/git/blob/v2.16.0/git-submodule.sh#L1014>`_, aka ``git submodule sync``. ``git submodule--helper resolve-relative-url``, which is available in git 2.9 and after, does not allow us to specify (directly) the remote URL from which to resolve a relative URL: it resolves relative URLs based on the remote URL, ``git config remote.${remote_name}.url``, where remote_name is the default remote of the current branch, if set; otherwise origin.
+#   This is essentially a bash port of the function `relative_url() <https://github.com/git/git/blob/v2.16.0/builtin/submodule--helper.c#L117>`_ (called from `resolve_relative_url() <https://github.com/git/git/blob/v2.16.0/builtin/submodule--helper.c#L180>`_, aka ``git submodule--helper resolve-relative-url``, which itself is called from `cmd_sync() <https://github.com/git/git/blob/v2.16.0/git-submodule.sh#L1014>`_, aka ``git submodule sync``. ``git submodule--helper resolve-relative-url``, which is available in git v2.9 and after, does not allow us to specify (directly) the remote URL from which to resolve a relative URL: it resolves relative URLs based on the remote URL, ``git config remote.${remote_name}.url``, where remote_name is the default remote of the current branch, if set; otherwise origin.
 #**
 
 function submodule-helper-relative-url()
@@ -1481,7 +1486,7 @@ function _git_submodule_sync()
 #
 # .. note::
 #
-#   Cf. ``git push --recurse-submodules=check`` (available since git 1.8.0) will check for unpushed commits in a submodule for its current committed state in the parent project. However, this only seems to work if it is used with a set of outgoing commits that contains a change to a submodule. And, despite its name, it does not seem to recurse into submodules.
+#   Cf. ``git push --recurse-submodules=check`` (available since git v1.8.0) will check for unpushed commits in a submodule for its current committed state in the parent project. However, this only seems to work if it is used with a set of outgoing commits that contains a change to a submodule. And, despite its name, it does not seem to recurse into submodules.
 #**
 
 function git_submodule_is_published_recursive()
@@ -1689,7 +1694,7 @@ function relocate_git_defaultify()
           IFS=$'\n'
           # List urls configured for git fetch (i.e., the urls in
           # .git/config:remote)
-          # NOTE Since git 1.8, a remote (e.g., origin) can have multiple
+          # NOTE Since git v1.8, a remote (e.g., origin) can have multiple
           # associated urls (and pushurls)
           #
           # Make the list unique, preserving order

--- a/linux/just_git_airgap_repo.bsh
+++ b/linux/just_git_airgap_repo.bsh
@@ -145,10 +145,9 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 # RE For now, we can just run git_airgap-submodule-update instead of
 # git_submodule-update in an airgap scenario in just sync
 # RE However, it would not update the submodules in a safe way...
-# RE RE Create a function, git_mirror:sync_submodules, (which would look
-# similar to update_submodules except without 'git submodule update' or the
-# recursion. Then, sync_submodules could be made to override the sync'ing
-# functionality of git_submodule-update, which is already part of just sync
+# RE RE Convert git_mirror:sync_submodules into sync_submodule. Then,
+# sync_submodule could be made to override the sync'ing functionality of
+# git_submodule-update, which is already part of just sync
 #
 # NOTE git_submodule-update, like sync_submodules, also runs sync and update
 # in an interleaved fashion, but that is to make that function more robust

--- a/linux/just_git_airgap_repo.bsh
+++ b/linux/just_git_airgap_repo.bsh
@@ -136,14 +136,24 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 #   :func:`git_mirror git_mirror_main`, :func:`git_mirror git_push_main`, and :func:`git_mirror git_clone_main`
 #**
 # REVIEW git_airgap-submodule-update target should be added to just sync;
-# currently it is part of the setup section of just sync
+# currently it is part of the setup section of just sync; git_submodule-update
+# is called in subsequent calls to just sync
+# RE FIXME There is actually a problem when running the git_submodule-update
+# target in an airgap'ed repo: it now runs git submodule sync before update,
+# which will put the submodule URLs back to what they are in the .gitmodules
+# file. In our case, this is wrong, leading the subsequent update to fail
+# RE For now, we can just run git_airgap-submodule-update instead of
+# git_submodule-update in an airgap scenario in just sync
 # RE However, it would not update the submodules in a safe way...
-# RE RE Create a function git_mirror:sync_submodules (which would look almost
-# identical to update_submodules except without 'git submodule update'---we
-# can't just refactor that function because initially it must be done in an
-# interleaved manner: first sync and then clone (aka update) the submodule).
-# sync_submodules could be made to override the sync'ing functionality of
-# git_submodule-update, which is already part of just sync
+# RE RE Create a function, git_mirror:sync_submodules, (which would look
+# similar to update_submodules except without 'git submodule update' or the
+# recursion. Then, sync_submodules could be made to override the sync'ing
+# functionality of git_submodule-update, which is already part of just sync
+#
+# NOTE git_submodule-update, like sync_submodules, also runs sync and update
+# in an interleaved fashion, but that is to make that function more robust
+# (albeit toward a scenario that git itself does not account for) not out of
+# necessity when first updating (aka cloning) the submodules
 
 #**
 # .. function:: log_unpushed_commits

--- a/tests/int/test-just_git_functions.bsh
+++ b/tests/int/test-just_git_functions.bsh
@@ -410,7 +410,7 @@ begin_test "Test safe-submodule-update"
 
   # Pull new changes
   pushd "${TEST_REPO}" &> /dev/null
-    # In git <=1.8.3, 'git fetch origin master' amazingly does not update the
+    # In git <= v1.8.3, 'git fetch origin master' amazingly does not update the
     # remote tracking branch: https://stackoverflow.com/a/20967347
     # RE git fetch origin master:refs/remotes/origin/master would have also
     # worked
@@ -419,7 +419,7 @@ begin_test "Test safe-submodule-update"
     git merge origin/master --no-edit
     # behind - HEAD is now behind the tracked commit
     # equal - HEAD is still equal to tracked commit
-    # ahead - HEAD is still ahead of the tracked commit (if git >1.8.3)
+    # ahead - HEAD is still ahead of the tracked commit (if git > v1.8.3)
     git push origin master
   popd &> /dev/null
 
@@ -508,7 +508,7 @@ begin_test "Test safe-submodule-update"
   # wasn't such a pain)
   cp -a "${PRETEND_URL}_behind" "${PRETEND_URL}_behind2"
   pushd "${BUILD_REPO}" &> /dev/null
-    # In git <=1.8.3, 'git fetch origin master' amazingly does not update the
+    # In git <= v1.8.3, 'git fetch origin master' amazingly does not update the
     # remote tracking branch: https://stackoverflow.com/a/20967347
     git fetch
     git merge origin/master
@@ -544,19 +544,19 @@ begin_test "Test safe-submodule-update"
     # the URL changed. safe_git_submodule_update will update just_upstream and
     # fetch from the new URL
     #
-    # In git 2.27, git pull began recommending a merge strategy
+    # In git v2.27, git pull began recommending a merge strategy
     # https://stackoverflow.com/a/62653694
     #
-    # In git <=1.8.3, 'git fetch origin master' amazingly does not update the
+    # In git <= v1.8.3, 'git fetch origin master' amazingly does not update the
     # remote tracking branch: https://stackoverflow.com/a/20967347
     #
-    # In git 2.21.0, 'git fetch' started failing if the commit of a submodule
+    # In git v2.21.0, 'git fetch' started failing if the commit of a submodule
     # as tracked by the parent repo couldn't be found (which can happen if the
     # submodule's URL changes and needs to be sync'd). That is, running
     # 'git fetch'  from within a parent repo fetches all branches (from either
     # the default remote of the current branch or, if not set, origin). Then,
     # git runs fetch in each submodule (assuming fetch.recurseSubmodules is
-    # enabled, which it is by default since at least git 1.8.3). Finally, git
+    # enabled, which it is by default since at least git v1.8.3). Finally, git
     # seems to inspect the submodule to ensure that each commit tracked by the
     # parent exists in the submodule, otherwise, it errors
     git fetch || :


### PR DESCRIPTION
Setup to eventually convert `git_mirror:sync_submodules` into `sync_submodule` (sync a single submodule). Then, sync_submodule could be made to override the sync'ing functionality of `just_git_functions:git_submodule-update`. That way, a safe git submodule update can be run in the airgap environment.