### PR TITLE
CI: ignore centos6, appveyor VS2019

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 image:
-- Visual Studio 2017
+- Visual Studio 2019
 # - Windows Server 2016 # Doesn't work, private Beta I think
 # - Visual Studio 2017 Preview # Doesn't have docker
 
@@ -30,21 +30,6 @@ install:
   # see https://www.appveyor.com/docs/how-to/private-git-sub-modules/
   - git submodule update --init --recursive
 
-  # Fix for https://github.com/msys2/MSYS2-packages/issues/1967
-  # Fix for https://github.com/msys2/MSYS2-packages/issues/1884#issuecomment-702878590
-  # https://stackoverflow.com/q/37627248/4166604
-  # https://www.msys2.org/news/#2020-05-31-update-fails-with-could-not-open-file
-  - >-
-    C:\msys64\usr\bin\bash -lc "
-    cd /tmp;
-    for server in $(grep $'\x5eServer' /etc/pacman.d/mirrorlist.msys | awk '{print $3}' | shuf | arch=x86_64 /usr/bin/envsubst); do
-    :;  echo Trying ${server};
-    :;  curl --connect-timeout 10 -LO ${server}msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz && break;
-    done"
-  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U --config <(echo) /tmp/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
-  # Hack for https://github.com/msys2/MSYS2-packages/issues/2300
-  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U https://repo.msys2.org/msys/x86_64/zstd-1.4.7-1-x86_64.pkg.tar.xz"
-  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U https://repo.msys2.org/msys/x86_64/pacman-5.2.2-5-x86_64.pkg.tar.xz"
   # Update the db and mirrors
   - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   # Update the db again, since we just got new mirrors, and then update pacman (again)

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -38,7 +38,6 @@ set_array_default VSI_COMMON_TEST_OSES \
   fedora:rawhide \
   centos:8 \
   centos:7 \
-  centos:6 \
   mstormo/suse:11.4 \
   opensuse/leap:15.2 \
   opensuse/tumbleweed \
@@ -61,7 +60,6 @@ set_array_default VSI_COMMON_TEST_OSES_ANS \
   "fedora - 34, fedora - 34, fedora - 34 0" \
   "centos - 8, rhel - 8, fedora - 28 0" \
   "centos - 7, rhel - 7, fedora - 19 0" \
-  "centos - 6.10, rhel - 6.10, fedora - 13 14 0" \
   "sles - 11.4, sles - 11.4, sles - 11.4 0" \
   "opensuse-leap - 15.2, opensuse - 15.2, suse - 15.2 0" \
   "opensuse-tumbleweed - 20200919, opensuse - 20200919, suse - 20200919 0" \


### PR DESCRIPTION
- update appveyor to use Visual Studio 2019 image, eliminating the need for several pacman workarounds
- stop testing centos6 as per https://github.com/VisionSystemsInc/vsi_common/pull/371#issuecomment-898593598