### PR TITLE
Other os fun

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -46,7 +46,7 @@ function caseify()
       local rv=$?
       if [ "${rv}" -ne "0" ]; then
         # This is needed for bash 3.2
-        return rv
+        return "${rv}"
       fi
       extra_args=$#
       ;;
@@ -170,7 +170,7 @@ function caseify()
       local rv=$?
       if [ "${rv}" -ne "0" ]; then
         # This is needed for bash 3.2
-        return rv
+        return "${rv}"
       fi
       extra_args=$#
       ;;

--- a/Justfile
+++ b/Justfile
@@ -43,6 +43,11 @@ function caseify()
         shift "${extra_args}"
         vsi_test_env "${VSI_COMMON_DIR}/tests/run_tests" ${@+"${@}"}
       )
+      local rv=$?
+      if [ "${rv}" -ne "0" ]; then
+        # This is needed for bash 3.2
+        return rv
+      fi
       extra_args=$#
       ;;
     test_int) # Run integration tests
@@ -162,6 +167,11 @@ function caseify()
         cd "${VSI_COMMON_DIR}"
         TESTLIB_PARALLEL=8 vsi_test_env darling shell ./tests/run_tests ${@+"${@}"}
       )
+      local rv=$?
+      if [ "${rv}" -ne "0" ]; then
+        # This is needed for bash 3.2
+        return rv
+      fi
       extra_args=$#
       ;;
     test_python) # Run python unit tests

--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -163,6 +163,7 @@ RUN shopt -s nullglob; for patch in /usr/local/share/just/container_build_patch/
 # in a container_build_patch, instead here, so that would mean conda only gets
 # added to the image in that case, right now its there 100% of the time, and only
 # used for a few images.
+# This is basically only needed for pre glibc 2.14
 RUN if ! docker-compose --version; then \
       rm /usr/local/bin/docker-compose; \
       # Handle symlink dirs, grrr
@@ -177,10 +178,8 @@ RUN if ! docker-compose --version; then \
       done; \
       # Patch for old linuxes
       ldd_version="$(ldd --version 2>/dev/null | awk '{print $NF; exit}')"; \
-      which python; \
-      if [ -n "${ldd_version}" ] && python -c "from distutils.version import LooseVersion as lv; exit(lv('${ldd_version') >= lv('2.24'))"; \
-        pip install cryptography==3.2; \
-      fi; \
+      # latest cryptography use abi packages that requrire glibc 2.24
+      pip install cryptography==3.2; \
       pip install docker-compose; \
       docker-compose --version; \
     fi

--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -175,6 +175,12 @@ RUN if ! docker-compose --version; then \
           cp -r "${d}" "/usr/local/"; \
         fi; \
       done; \
+      # Patch for old linuxes
+      ldd_version="$(ldd --version 2>/dev/null | awk '{print $NF; exit}')"; \
+      which python; \
+      if [ -n "${ldd_version}" ] && python -c "from distutils.version import LooseVersion as lv; exit(lv('${ldd_version') >= lv('2.24'))"; \
+        pip install cryptography==3.2; \
+      fi; \
       pip install docker-compose; \
       docker-compose --version; \
     fi

--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -177,8 +177,7 @@ RUN if ! docker-compose --version; then \
         fi; \
       done; \
       # Patch for old linuxes
-      ldd_version="$(ldd --version 2>/dev/null | awk '{print $NF; exit}')"; \
-      # latest cryptography use abi packages that requrire glibc 2.24
+      # latest cryptography use abi wheels requrire glibc 2.24, so use an older one
       pip install cryptography==3.2; \
       pip install docker-compose; \
       docker-compose --version; \

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -84,7 +84,8 @@ function load_vsi_compat()
   #
   #   sed "-${sed_flag_rE}" 's|foo(.*)|bar\1.|'
   #**
-  # Needed for CentOS 6 running sed 4.1.5
+  # We prefer r over E for older versions of GNU sed, e.g. 4.1.5
+  # Enhanced regex to find potental violations: sed.*-[^ ]*E([^}]|$)
   if [ "${VSI_SED_COMPAT-}" = "gnu" ]; then
     sed_flag_rE='r'
   else

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -85,7 +85,7 @@ function load_vsi_compat()
   #   sed "-${sed_flag_rE}" 's|foo(.*)|bar\1.|'
   #**
   # We prefer r over E for older versions of GNU sed, e.g. 4.1.5
-  # Enhanced regex to find potental violations: sed.*-[^ ]*E([^}]|$)
+  # Enhanced regex to find potential violations of this in source code files: sed.*-[^ ]*E([^}]|$)
   if [ "${VSI_SED_COMPAT-}" = "gnu" ]; then
     sed_flag_rE='r'
   else

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -477,6 +477,26 @@ function load_vsi_compat()
   #
   # :Value: * ``0`` Bash has the bug
   #         * ``1`` Unbound variables error as expected
+  #
+  # .. var  :: bash_bug_uncaught_error_compound_subshell
+  #
+  # There is a bug in bash 3.2, where ``set -e`` will not trigger an error in the parent process when a subshell command fails. The subshell does trigger the error as expected, but it is not propogated to the parent, even though the return code is.
+  #
+  # :Value: * ``0`` Bash has the bug
+  #         * ``1`` Error from subshell statements are thrown as expected
+  #
+  # .. rubric:: Example
+  #
+  # .. code-block:: bash
+  #
+  #    set -e
+  #    echo hi
+  #    (
+  #      echo inner
+  #      false
+  #      echo "you won't see this"
+  #    )
+  #    echo "You will only see this on bash 3.2: $?"
   #**
   if [ "${bash_major_version}" -ge "4" ]; then
     bash_feature_associative_array=0
@@ -484,12 +504,14 @@ function load_vsi_compat()
     bash_feature_bashpid=0
     bash_bug_unassigned_variable_set_to_null=1
     bash_bug_uncaught_unbound_on_exit_trap=1
+    bash_bug_uncaught_error_compound_subshell=1
   else
     bash_feature_associative_array=1
     bash_feature_case_modification=1
     bash_feature_bashpid=1
     bash_bug_unassigned_variable_set_to_null=0
     bash_bug_uncaught_unbound_on_exit_trap=0
+    bash_bug_uncaught_error_compound_subshell=0
   fi
 
   #**

--- a/linux/signal_tools.bsh
+++ b/linux/signal_tools.bsh
@@ -41,7 +41,7 @@ function set_bashpid()
       # A source means we need the grandparent
       if [ "${f}" == "source" ]; then
         if [ -d /proc ]; then
-          BASHPID="$(bash -c "sed -E 's|.*\) [^ ]* ([^ ]*) .*|\1|' /proc/\${PPID}/stat")"
+          BASHPID="$(bash -c "sed -${sed_flag_rE} 's|.*\) [^ ]* ([^ ]*) .*|\1|' /proc/\${PPID}/stat")"
           return
         else
           # Not all ps's support -fp, but this should work on macOS where these is no /proc

--- a/linux/versions.bsh
+++ b/linux/versions.bsh
@@ -83,6 +83,49 @@ function bash_version()
 }
 
 #**
+# .. function:: glibc_version
+#
+# Retrieves the version number of glibc currently uses by the OS
+#
+# :Parameters: [``LDD``] - The ``ldd`` executable that will be called to determine glibc version. Can be overwritten to call a different executable. Defaults to ``/usr/glibc-compat/bin/ldd`` or ``ldd``.
+# :Output: *stdout* - The glibc version number. Blank if it failed, which probably means glibc is not the default on this operating system.
+#**
+function glibc_version()
+{
+  local default_ldd=ldd
+
+  # Compatibility for alpine with glibc installed
+  if [ -x /usr/glibc-compat/bin/ldd ]; then
+    default_ldd=/usr/glibc-compat/bin/ldd
+  fi
+
+  # Alpine ldd prints to stderr, so the result will be blank
+  ${LDD-${default_ldd}} --version 2>/dev/null | awk '{print $NF; exit}'
+}
+
+#**
+# .. function:: glibc_version_manual
+#
+# Retrieves the version number of a speific glibc library
+#
+# :Arguments: * ``$1`` - Path to glibc, usually something like `/lib64/libc.so.6`
+# :Output: *stdout* - The glibc version number.
+#
+# .. rubric:: Example
+#
+# .. code-block:: bash
+#
+#    libc_filename="$(ldconfig -p 2>/dev/null| \grep '^\s*libc\.so' | awk '{print $NF; exit}')"
+#    echo "The glibc version is: $(glibc_version_manual "${libc_filename}")"
+#**
+function glibc_version_manual()
+{
+  local version="$("${1}" | sed -n${sed_flag_rE} '/version/{s|.*version ([^, ]*).*|\1|; p; q}')"
+  # Remove potential trailing period
+  echo "${version%.}"
+}
+
+#**
 # .. function:: tar_version_info
 #
 # Sets the vendor and version number of ``tar``.

--- a/python/vsi/test/test_vdb.py
+++ b/python/vsi/test/test_vdb.py
@@ -1,7 +1,13 @@
 import unittest
 
+import warnings
+
 class GlobTest(unittest.TestCase):
   def test_import(self):
-    import vsi.tools.vdb
-    import vsi.tools.vdb_rpdb2
-    import vsi.tools.vdb_rpdb
+    with warnings.catch_warnings():
+      warnings.filterwarnings("ignore", category=DeprecationWarning,
+                              module='rpdb2')
+
+      import vsi.tools.vdb
+      import vsi.tools.vdb_rpdb2
+      import vsi.tools.vdb_rpdb

--- a/python/vsi/tools/dir_util.py
+++ b/python/vsi/tools/dir_util.py
@@ -6,7 +6,7 @@ from tempfile import mkdtemp as mkdtemp_orig, gettempdir
 
 from shutil import Error, copy2, copystat, rmtree
 
-def is_subdir(path, base_dir):
+def is_subdir(path, base_dir, dereference_symlinks=True):
   ''' Determines if the path is in the base_dir
 
   Parameters
@@ -22,19 +22,20 @@ def is_subdir(path, base_dir):
       containing (True/False, and remainder (relative) of path)
 
   str
-      Remainder - Windows - If the paths are on two different drives, entire
-      path is returned
+      Remainder, the relative different between the two paths. If on Windows
+      and the paths are on two different drives, the entire path is returned
 
   Note
   ----
-  This will NOT work with Junctions in Windows... I'm not sure what else
-
+  This will NOT work with Junctions in Windows.
   '''
 
-  path = os.path.normcase(os.path.normpath(os.path.abspath(os.path.realpath(
-      path))))
-  base_dir = os.path.normcase(os.path.normpath(os.path.abspath(
-      os.path.realpath(base_dir))))
+  if dereference_symlinks:
+    path = os.path.realpath(path)
+    base_dir = os.path.realpath(base_dir)
+
+  path = os.path.normcase(os.path.normpath(os.path.abspath(path)))
+  base_dir = os.path.normcase(os.path.normpath(os.path.abspath(base_dir)))
 
   try:
     relative = os.path.relpath(path, base_dir)

--- a/tests/int/test-just_install_functions.bsh
+++ b/tests/int/test-just_install_functions.bsh
@@ -13,6 +13,8 @@ fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${VSI_COMMON_DIR}/linux/common_source.sh"
+source "${VSI_COMMON_DIR}/linux/versions.bsh"
+source "${VSI_COMMON_DIR}/linux/requirements.bsh"
 source "${VSI_COMMON_DIR}/linux/just_files/just_install_functions.bsh"
 
 
@@ -66,8 +68,12 @@ function registry_to_stdout()
 
 
 # test conda-install
-# alpine musl won't run the miniconda executable
-[ "${VSI_OS}" = "linux" ] && [ "${VSI_MUSL}" = "1" ] && [ -z "${VSI_FORCE_INSTALL_FUNCTIONS_TEST+set}" ] && skip_next_test
+if [ "${VSI_OS}" = "linux" ] && [ -z "${VSI_FORCE_INSTALL_FUNCTIONS_TEST+set}" ]; then
+  # alpine musl won't run the miniconda executable, nor will really old GLIBCs
+  if [ "${VSI_MUSL}" = "1" ] || meet_requirements "$(glibc_version)" "<2.17"; then
+    skip_next_test
+  fi
+fi
 begin_test "conda-install"
 (
   setup_test
@@ -141,8 +147,13 @@ end_test
 
 
 # test conda-python-install & pipenv-install: test in sequence according to typical usage - install python then pipenv
-# alpine musl won't run the miniconda executable
-[ "${VSI_OS}" = "linux" ] && [ "${VSI_MUSL}" = "1" ] && [ -z "${VSI_FORCE_INSTALL_FUNCTIONS_TEST+set}" ] && skip_next_test
+# test conda-install
+if [ "${VSI_OS}" = "linux" ] && [ -z "${VSI_FORCE_INSTALL_FUNCTIONS_TEST+set}" ]; then
+  # alpine musl won't run the miniconda executable, nor will really old GLIBCs
+  if [ "${VSI_MUSL}" = "1" ] || meet_requirements "$(glibc_version)" "<2.17"; then
+    skip_next_test
+  fi
+fi
 begin_test "conda-python-install and pipenv-install"
 (
   setup_test

--- a/tests/test-compat.bsh
+++ b/tests/test-compat.bsh
@@ -513,6 +513,25 @@ fi
 )
 end_test
 
+if [ "${bash_bug_uncaught_error_compound_subshell}" = "0" ]; then
+  begin_test "Bash bug uncaught subshell error"
+else
+  begin_required_fail_test "Bash bug uncaught subshell error"
+fi
+(
+  setup_test
+
+  begin_fail_zone
+
+  (
+    true
+    false
+  )
+
+  echo "Only bash 3.2 gets to this line, the the last line did have return code $?"
+)
+end_test
+
 begin_test "Tar flags"
 (
   setup_test

--- a/tests/test-versions.bsh
+++ b/tests/test-versions.bsh
@@ -1041,6 +1041,8 @@ end_test
 
 begin_test "glibc Version"
 (
+  setup_test
+
   function glibc_mock()
   {
     echo "${libc_version}"

--- a/tests/test-versions.bsh
+++ b/tests/test-versions.bsh
@@ -934,6 +934,68 @@ versions_txt_ans=(7.5.18
 versions_json=("${version1121}" "${version1122}" "${version1130}" "${version1131}")
 versions_json_ans=(11.2.142 11.2.152 11.3.58 11.3.109)
 
+ldd_2113="ldd (GNU libc) 2.11.3
+Copyright (C) 2009 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+Written by Roland McGrath and Ulrich Drepper."
+
+glibc_2113="GNU C Library stable release version 2.11.3 (20110527), by Roland McGrath et al.
+Copyright (C) 2009 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.
+There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
+Configured for x86_64-suse-linux.
+Compiled by GNU CC version 4.3.4 [gcc-4_3-branch revision 152973].
+Compiled on a Linux 2.6.32 system on 2015-07-29.
+Available extensions:
+        crypt add-on version 2.1 by Michael Glad and others
+        GNU Libidn by Simon Josefsson
+        Native POSIX Threads Library by Ulrich Drepper et al
+        BIND-8.2.3-T5B
+For bug reporting instructions, please see:
+<http://www.gnu.org/software/libc/bugs.html>."
+
+ldd_217="ldd (GNU libc) 2.17
+Copyright (C) 2012 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+Written by Roland McGrath and Ulrich Drepper."
+
+glibc_217="GNU C Library (GNU libc) stable release version 2.17, by Roland McGrath et al.
+Copyright (C) 2012 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.
+There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
+Compiled by GNU CC version 4.8.5 20150623 (Red Hat 4.8.5-44).
+Compiled on a Linux 3.10.0 system on 2021-02-08.
+Available extensions:
+        The C stubs add-on version 2.1.2.
+        crypt add-on version 2.1 by Michael Glad and others
+        GNU Libidn by Simon Josefsson
+        Native POSIX Threads Library by Ulrich Drepper et al
+        BIND-8.2.3-T5B
+        RT using linux kernel aio
+libc ABIs: UNIQUE IFUNC
+For bug reporting instructions, please see:
+<http://www.gnu.org/software/libc/bugs.html>."
+
+ldd_2339="ldd (GNU libc) 2.33.9000
+Copyright (C) 2021 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+Written by Roland McGrath and Ulrich Drepper."
+
+glibc_2339="GNU C Library (GNU libc) development release version 2.33.9000.
+Copyright (C) 2021 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.
+There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
+Compiled by GNU CC version 11.1.1 20210623 (Red Hat 11.1.1-6).
+libc ABIs: UNIQUE IFUNC ABSOLUTE
+For bug reporting instructions, please see:
+<https://www.gnu.org/software/libc/bugs.html>."
+
 begin_test "program versions"
 (
   setup_test
@@ -974,6 +1036,25 @@ begin_test "program versions"
   [ "$(git_version)" = "2.24.1" ]
   [ "$(docker_version)" = "19.03.5" ]
   [ "$(DOCKER_COMPOSE=docker_compose docker_compose_version)" = "1.24.0" ]
+)
+end_test
+
+begin_test "glibc Version"
+(
+  function glibc_mock()
+  {
+    echo "${libc_version}"
+  }
+  ldd_versions=("${ldd_2113}" "${ldd_217}" "${ldd_2339}")
+  glibc_versions=("${glibc_2113}" "${glibc_217}" "${glibc_2339}")
+  anses=(2.11.3 2.17 2.33.9000)
+
+  for i in "${!anses[@]}"; do
+    libc_version="${ldd_versions[i]}"
+    [ "$(LDD=glibc_mock glibc_version)" = "${anses[i]}" ]
+    libc_version="${glibc_versions[i]}"
+    [ "$(glibc_version_manual glibc_mock)" = "${anses[i]}" ]
+  done
 )
 end_test
 


### PR DESCRIPTION
- Fix bug causing every test to fail to even start properly on SLES 11.4  (in signal_tools)
- Fixes bug where failing tests on bash 3.2 didn't propagate the error code correctly (and added compat flag documenting this scenario)
- Fix could no longer build docker images on OSes pre-glibc 2.24
- Added `is_subdir` flag to skip dereferencing symlinks, so we can check is_subdir and ignore smylinks.