### PR TITLE
remove '-it'

### DIFF
--- a/linux/just_files/just_singularity_functions.bsh
+++ b/linux/just_files/just_singularity_functions.bsh
@@ -61,7 +61,7 @@ function singular_defaultify()
         custom_script=(--mount source="${SINGULARITY_CUSTOM_IMPORT_SCRIPT}",destination=/custom/tosingularity,type=bind,readonly=true)
       fi
 
-      Docker run -it --rm --privileged \
+      Docker run --rm --privileged \
           ${docker_socket[@]+"${docker_socket[@]}"} \
           --mount source="$(pwd)",destination=/output,type=bind \
           -e DOCKER_UID="${DOCKER_UID-$(id -u)}" -e DOCKER_GID="${DOCKER_GID-$(id -g)}" \


### PR DESCRIPTION
`just_singularity_functions` remove `-it` from docker call in `singularity_import`.  Interactive mode & tty do not appear necessary for this function.