### PR TITLE
Update docker images 2021

### DIFF
--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -72,6 +72,8 @@ RUN set -euxv; \
              diffutils \
              # nm for lwhich
              binutils \
+             # find and xargs
+             findutils \
              # xxd for unit tests
              vim \
              ${other} ca-certificates\

--- a/linux/common_source.sh
+++ b/linux/common_source.sh
@@ -457,12 +457,12 @@ if [ "${VSI_DISTRO_CORE-}" = "debian" ]; then
   VSI_DISTRO_VERSION_CORE="${VSI_DISTRO_VERSION_CORE%/sid}"
   # turn codenames to numbers
   case "${VSI_DISTRO_VERSION_CORE-}" in
-    squeeze)  VSI_DISTRO_VERSION_CORE=6  ;; # EOL Feb 29 2016
-    wheezy)   VSI_DISTRO_VERSION_CORE=7  ;; # EEOL Dec 31 2019
-    jessie)   VSI_DISTRO_VERSION_CORE=8  ;; # EEOL ~June 6 2022
-    stretch)  VSI_DISTRO_VERSION_CORE=9  ;; # EOL 2022
-    buster)   VSI_DISTRO_VERSION_CORE=10 ;; # EOL 2022
-    bullseye) VSI_DISTRO_VERSION_CORE=11 ;; # Release ?
+    squeeze)  VSI_DISTRO_VERSION_CORE=6  ;; # LTS Feb 29 2016
+    wheezy)   VSI_DISTRO_VERSION_CORE=7  ;; # ELTS ~2022-06-30
+    jessie)   VSI_DISTRO_VERSION_CORE=8  ;; # ELTS ~2022-06-30
+    stretch)  VSI_DISTRO_VERSION_CORE=9  ;; # EOL 2020-07-06 LTS 2022-06-30
+    buster)   VSI_DISTRO_VERSION_CORE=10 ;; # EOL 2022-08
+    bullseye) VSI_DISTRO_VERSION_CORE=11 ;; # Release 2021-08-14 EOL +3years?
     bookworm) VSI_DISTRO_VERSION_CORE=12 ;; # Release ?
     trixie)   VSI_DISTRO_VERSION_CORE=13 ;; # Release ?
   esac
@@ -486,9 +486,11 @@ if [ "${VSI_DISTRO_LIKE-}" = "ubuntu" ]; then
     cosmic)  VSI_DISTRO_VERSION_LIKE=18.10 ;; # EOL Jul 18, 2019
     disco)   VSI_DISTRO_VERSION_LIKE=19.04 ;; # EOL Jan 23, 2020
     eoan)    VSI_DISTRO_VERSION_LIKE=19.10 ;; # EOL Jul 17, 2020
-    focal)   VSI_DISTRO_VERSION_LIKE=20.04 ;; # EOL Apr 2030
-    groovy)  VSI_DISTRO_VERSION_LIKE=20.10 ;; # EOL Jul 2021
-    hirsute) VSI_DISTRO_VERSION_LIKE=21.04 ;; # Release April 22, 2021 : EOL ~Jan 2022
+    focal)   VSI_DISTRO_VERSION_LIKE=20.04 ;; # EOL April 2025, ESM Apr 2030
+    groovy)  VSI_DISTRO_VERSION_LIKE=20.10 ;; # EOL July 22, 2021
+    hirsute) VSI_DISTRO_VERSION_LIKE=21.04 ;; # EOL ~Jan 2022
+    impish)  VSI_DISTRO_VERSION_LIKE=21.10 ;; # Release October 14, 2021 EOL July 2022
+    #j)      VSI_DISTRO_VERSION_LIKE=22.04 ;; # Release April 21, 2022 EOL April 2027
   esac
 fi
 

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -577,7 +577,7 @@ function load_vsi_compat()
         __bash_feature_rcfile=1
       fi
     fi
-
+    rm "${tempfile}"
     return "${__bash_feature_rcfile}"
   }
 

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -32,7 +32,6 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 # .. envvar:: JUST_INSTALL_ACTIVATE_BASENAME
 #
 # File basename for utility activation. Users may source anactivation file to create useful environment variables and add the utility to $PATH.
-#
 #**
 
 : ${JUST_INSTALL_ACTIVATE_BASENAME="just_activate.bsh"}
@@ -164,7 +163,6 @@ function cmake-install()
 #          * conda_version - conda version
 #          * conda_extra_args - number of arguments consumed
 #          * conda_activate - bash file to make conda available
-#
 #**
 
 function conda-install()
@@ -238,7 +236,9 @@ function conda-install()
 
   # output: executable & version
   conda_exe="${CONDA}"
-  conda_version="$("${CONDA}" --version | awk 'NR==1{print $2}')"
+  # Source conda.sh and use conda function to handle long paths (see No module
+  # named conda.cli error below)
+  conda_version="$(source "${conda_dir}/etc/profile.d/conda.sh"; conda --version | awk 'NR==1{print $2}')"
   echo "Conda ${conda_version} installed at \"${conda_exe}\"" >&2
 
   # Make sure version meets request
@@ -265,20 +265,13 @@ function conda-install()
           CONDA_VER=\"${conda_version}\"
           " >> "${conda_activate}"
 
-  if [ "${OS-}" = "Windows_NT" ]; then
-    uwecho '
-            # source conda.sh which contains the "conda" command as a function
-            # https://github.com/conda/conda/blob/master/CHANGELOG.md#440-2017-12-20
-            # This function will auto-update the path
-            CONDA_SH="${CONDA_DIR}/etc/profile.d/conda.sh"
-            . "${CONDA_SH}"
-            ' >> "${conda_activate}"
-  else
-    uwecho '
-            # update PATH
-            PATH="$(dirname "${CONDA_EXE}"):${PATH}"
-            ' >> "${conda_activate}"
-  fi
+  uwecho '
+          # source conda.sh which contains the "conda" command as a function
+          # https://github.com/conda/conda/blob/master/CHANGELOG.md#440-2017-12-20
+          # This function will auto-update the path
+          CONDA_SH="${CONDA_DIR}/etc/profile.d/conda.sh"
+          . "${CONDA_SH}"
+          ' >> "${conda_activate}"
 }
 
 
@@ -304,7 +297,6 @@ function conda-install()
 #          * python_version - Python version
 #          * conda_python_extra_args - number of arguments consumed
 #          * python_activate - Bash file to activate python environment
-#
 #**
 
 function conda-python-install()
@@ -315,6 +307,7 @@ function conda-python-install()
   local CONDA_INSTALLER  # conda installer
   local prefer_download=0  # prefer conda download if no CONDA|CONDA_INSTALLER
   local packages=()
+  local conda_activate
 
   parse_args conda_python_extra_args \
       --dir python_dir: \
@@ -356,7 +349,10 @@ function conda-python-install()
         --dir "${conda_temp_dir}/conda" \
         ${CONDA_INSTALLER:+ --installer "${CONDA_INSTALLER}"}
 
-    CONDA="${conda_exe}"
+    # Shebang can't be more than 128 often, so we need to source conda.sh and so
+    # and use the conda function, so the right python is found and used, else
+    # you will see "ImportError: No module named conda.cli"
+    CONDA="conda"
   fi
 
   # create output directory
@@ -365,7 +361,12 @@ function conda-python-install()
 
   # install python
   echo "Installing python..." >&2
-  "${CONDA}" create -y -p "${python_dir}" "python==${python_ver}" ${packages[@]+"${packages[@]}"}
+  (
+    if [ -r "${conda_activate-}" ]; then
+      source "${conda_activate}"
+    fi
+    "${CONDA}" create -y -p "${python_dir}" "python==${python_ver}" ${packages[@]+"${packages[@]}"}
+  )
   local python_exe_footer
   if [ "${OS-}" = "Windows_NT" ]; then
     python_exe_footer="python.exe"
@@ -430,7 +431,6 @@ function conda-python-install()
             PATH="${MORE_PATH}:${PATH}"
             ' >> "${python_activate}"
   fi
-
 }
 
 
@@ -450,7 +450,6 @@ function conda-python-install()
 #          * pipenv_version - Pipenv version
 #          * pipenv_extra_args - number of arguments consumed
 #          * pipenv_activate - Bash file to activate pipenv environment
-#
 #**
 
 function pipenv-install()
@@ -590,7 +589,6 @@ function pipenv-install()
 # .. seealso::
 #
 #   :func:`pipenv-install`
-#
 
 #**
 

--- a/tests/int/test-just_install_functions.bsh
+++ b/tests/int/test-just_install_functions.bsh
@@ -118,13 +118,17 @@ begin_test "conda-install"
   # output version (removing the py38_ prefix)
   [ "${conda_version}" = "${CONDA_VER#*_}" ]
 
+  # This catches some rare scenario when the conda exe without the executable
+  # didn't report the right version. However, if the shebang is longer than 127
+  # characters, then conda will not start without the right python interpreter
+  # So a blank RESULT represent this case, and should be ignored
   # executable version
-  RESULT="$("${conda_exe}" --version)"
-  [ "$RESULT" = "${CONDA_VER_FULL}" ]
+  RESULT="$("${conda_exe}" --version || :)"
+  [ "${RESULT}" = "" ] || [ "${RESULT}" = "${CONDA_VER_FULL}" ]
 
   # activate version
-  RESULT="$(source "${conda_activate}"; "${CONDA_EXE}" --version)"
-  [ "$RESULT" = "${CONDA_VER_FULL}" ]
+  RESULT="$(source "${conda_activate}"; conda --version)"
+  [ "${RESULT}" = "${CONDA_VER_FULL}" ]
 
   # registry test
   if [ "${ENABLE_REGISTRY_TEST-}" = "1" ]; then

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -267,6 +267,18 @@ atexit ()
 {
   test_status=$?
 
+  if [ "${TESTLIB_KEEP_TEMP_DIRS-}" != "1" ]; then
+    # Only works if stdin is connected, aka only one test file on run_tests
+    if [ "${failures}" != "0" -a "${TESTLIB_KEEP_PAUSE_AFTER_ERROR-0}" = "1" ]; then
+      read -rsn1 -p "Press any key to continue..." x
+    fi
+    rm -rf "$TRASHDIR"
+  fi
+
+  if [ "${tests}" -ne 0 ] && [ "${tracking_touched_files-}" = "1" ]; then
+    cleanup_touched_files
+  fi
+
   if [ "${__testlib_setup_started-1}" = "0" ]; then
     echo "Calling setup() ${TESTLIB_BAD_COLOR}failed${TESTLIB_RESET_COLOR}!!!" >&2
     # TODO: Add trace/stderr/stdout printout here
@@ -282,10 +294,6 @@ atexit ()
   fi
   unset test_status
 
-  if [ "${tests}" -ne 0 ] && [ "${tracking_touched_files-}" = "1" ]; then
-    cleanup_touched_files
-  fi
-
   if [ "${__testlib_ran_a_test-}" = "1" ] && \
      type -t teardown &> /dev/null && \
      [ "$(command -v teardown)" == "teardown" ]; then
@@ -296,14 +304,6 @@ atexit ()
     fi
 
     teardown
-  fi
-
-  if [ "${TESTLIB_KEEP_TEMP_DIRS-}" != "1" ]; then
-    # Only works if stdin is connected, aka only one test file on run_tests
-    if [ "${failures}" != "0" -a "${TESTLIB_KEEP_PAUSE_AFTER_ERROR-0}" = "1" ]; then
-      read -rsn1 -p "Press any key to continue..." x
-    fi
-    rm -rf "$TRASHDIR"
   fi
 
   local BOLD_COLOR

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -30,41 +30,48 @@ set_array_default VSI_COMMON_OS_VOLUMES "${VSI_COMMON_DOCKER_HOST}":/var/run/doc
 set_array_default VSI_COMMON_TEST_OSES \
   clearlinux:latest \
   amazonlinux:latest \
-  debian:9 \
   debian:10 \
+  debian:11 \
   ubuntu:14.04 \
   ubuntu:20.04 \
-  fedora:31 \
+  fedora:33 \
   fedora:rawhide \
-  centos:8 \
   centos:7 \
-  mstormo/suse:11.4 \
+  quay.io/centos/centos:stream8 \
   opensuse/leap:15.2 \
-  opensuse/tumbleweed \
+  opensuse/tumbleweed:latest@sha256:aeb62bae53022901b5da5d78d8de6ca07f5b3992e147e4c9723e0378ac0463ca \
   vbatts/slackware:latest \
-  gentoo/stage3-amd64:latest \
+  gentoo/stage3:latest \
   binhex/arch-base:latest
 
+# Debian 9 LTSS ends June 30, 2022, however ca-certificates hasn't been updates
+#   since June 2020, so it is now useless
+# Debian 10: EOL ~2022-08 LTS ?
+# Debian 11: EOL ? LTS ?
+# Ubuntu 14.04: LTS April 2024
+# Ubuntu 20.04: LTS April 2030
+# Fedora 33: EOL ~Nov 2021
+# Centos 7: EOL June 30, 2024
+# Centos Steram 8: ???
 # SLES 11.4 LTSS Support ends: 31 Mar 2022
 # SLES 15.2 LTSS Support ends: 31 Jul 2031
 # opensus Leap 15.2 - expected EOL December 2021
 
 set_array_default VSI_COMMON_TEST_OSES_ANS \
-  "clear-linux-os - 35030, clear-linux-os - 35030, clear-linux-os - 35030 0" \
+  "clear-linux-os - 35070, clear-linux-os - 35070, clear-linux-os - 35070 0" \
   "amzn - 2, centos - 2, rhel fedora - 2 0" \
-  "debian - 9, debian - 9, debian - 9 0" \
   "debian - 10, debian - 10, debian - 10 0" \
+  "debian - 11, debian - 11, debian - 11 0" \
   "ubuntu - 14.04, debian - 8, debian - 8 0" \
   "ubuntu - 20.04, debian - 11, debian - 11 0" \
-  "fedora - 31, fedora - 31, fedora - 31 0" \
-  "fedora - 34, fedora - 34, fedora - 34 0" \
-  "centos - 8, rhel - 8, fedora - 28 0" \
+  "fedora - 33, fedora - 33, fedora - 33 0" \
+  "fedora - 35, fedora - 35, fedora - 35 0" \
   "centos - 7, rhel - 7, fedora - 19 0" \
-  "sles - 11.4, sles - 11.4, sles - 11.4 0" \
+  "centos - 8, rhel - 8, fedora - 28 0" \
   "opensuse-leap - 15.2, opensuse - 15.2, suse - 15.2 0" \
-  "opensuse-tumbleweed - 20200919, opensuse - 20200919, suse - 20200919 0" \
+  "opensuse-tumbleweed - 20210916, opensuse - 20210916, suse - 20210916 0" \
   "slackware - 14.2, slackware - 14.2, slackware - 14.2 0" \
-  "gentoo - 2.6, gentoo - 2.6, gentoo - 2.6 0" \
+  "gentoo - 2.7, gentoo - 2.7, gentoo - 2.7 0" \
   "arch - , arch - , arch - 0" # Arch, like gentoo is a rolling release
 
 
@@ -75,6 +82,7 @@ set_array_default VSI_COMMON_TEST_OSES_ANS \
   # Something is going wrong with the lwhich tests on: busybox:latest \
 
   # Unnecessary:
+  # mstormo/suse:11.4 glibc too old, LTSS 31 Mar 2022. We are just abandoning it early
   # opensuse/leap:42.3 EOL 2019
   # linuxmintd/mint18-amd64
   # linuxmintd/mint19-amd64


### PR DESCRIPTION
- Update docker images, mainly to get ISRG Root X1
- Fix how we use conda to use their long path fix
- Fix mac failing tests
- Clean up temp testlib directories sooner, so they aren't left behind on accident on rare failures.