### PR TITLE
Improve a few things in new_just

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,8 +2,6 @@ name: macOS tests
 
 # This is required
 on:
-  pull_request:
-    types: [opened, reopened]
   push:
 
 jobs:

--- a/linux/just_files/just_functions.bsh
+++ b/linux/just_files/just_functions.bsh
@@ -386,6 +386,7 @@ function create_local_settings_file()
     if [ "${perm}" = "$(id -u)" ]; then
       echo "# Put local setting in this file" 2>/dev/null > "${JUST_LOCAL_SETTINGS}" &&
       {
+        echo "#!/usr/bin/env false bash" >> "${JUST_LOCAL_SETTINGS}"
         echo "# You should edit this file and not \"${project_file}\"" >> "${JUST_LOCAL_SETTINGS}"
         echo "# to customize setting just for your setup/computer" >> "${JUST_LOCAL_SETTINGS}"
         echo >> "${JUST_LOCAL_SETTINGS}"

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -210,7 +210,9 @@ function write_project_env()
 {
   exists "${1}" && return 0
 
-  uwecho   'JUST_PROJECT_PREFIX='"${PROJECT_PREFIX}"'
+  uwecho   '#!/usr/bin/env false bash
+
+            JUST_PROJECT_PREFIX='"${PROJECT_PREFIX}"'
             JUST_VERSION="'"${JUST_VERSION-JUST_VERSION unset in ${1}}"'"
             if [ -z "${'"${PROJECT_PREFIX}"'_CWD+set}" ]; then
               '"${PROJECT_PREFIX}"'_CWD="$(\cd "$(\dirname "${BASH_SOURCE[0]}")"; \pwd)"
@@ -442,6 +444,8 @@ function write_pipfile()
           [dev-packages]
 
           [packages]
+          #T# # Uncomment for GDAL
+          #T# gdal = "==3.2.3" # or whatever GDAL_VERSION is installed by the recipe
           ' >> "${1}"
 }
 
@@ -545,10 +549,10 @@ function write_dockerfile()
             FROM dep_stage as pipenv_cache
 
             # Install your build dependencies for python packages here
-            #T# RUN apt-get update; \
-            #T#     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            #T#       libxml-devel; \
-            #T#     rm -r /var/lib/apt/lists/*
+            RUN apt-get update; \
+                DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+                  python3-dev; \
+                rm -r /var/lib/apt/lists/*
 
             ADD Pipfile Pipfile.lock /src/
             #T# Simple packages can be added as dependencies to your project by:
@@ -577,6 +581,8 @@ function write_dockerfile()
             #T#    Note: the version of the pypi GDAL and C GDAL should match as closely as
             #T#    possible
             #T# 4) just sync # (optionally updates the docker image)
+            #T# 5) just shell
+            #T# 6) python -c "import osgeo.gdal_array" # Should not create an error message
 
 
             RUN \


### PR DESCRIPTION
- After setting up a new project, I noticed a few issues/bugs
- `local.env` had no shebang
- `project.env` had no shebang
- There was no GDAL in the tutorial in Pipfile
- The libxml-devel was a bad example in the pipenv cache stage
  - python3-dev is the right name on debian, and actually useful
- Added some steps in the comments no one reads on how to test that gdal
  is properly working with numpy integration

Signed-off-by: Andy Neff <andy@visionsystemsinc.com>