### PR TITLE
just_ci_functions arguments

### DIFF
--- a/linux/just_files/just_ci_functions.bsh
+++ b/linux/just_files/just_ci_functions.bsh
@@ -48,6 +48,18 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 : ${JUST_CI_CACHE_VERSION=}
 
 #**
+# .. envvar:: JUST_CI_CACHE_ARGS
+#
+# Additional `ci_load.py` arguments for CI service cache as a single string.
+#
+# .. seealso::
+#
+#   :cmd:`ci_load-services`
+#**
+
+: ${JUST_CI_CACHE_ARGS=}
+
+#**
 # .. envvar:: JUST_CI_RECIPE_REPO
 #
 # Dockerhub repository for CI recipe cache.
@@ -70,6 +82,18 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 #**
 
 : ${JUST_CI_RECIPE_VERSION=}
+
+#**
+# .. envvar:: JUST_CI_RECIPE_ARGS
+#
+# Additional `ci_load.py` arguments for CI recipe cache as a single string.
+#
+# .. seealso::
+#
+#   :cmd:`ci_load-services`
+#**
+
+: ${JUST_CI_RECIPE_ARGS="--no-push"}
 
 #**
 # .. command:: ci_load-recipes
@@ -105,7 +129,7 @@ function ci_defaultify()
             --recipe-repo "IGNORE" \
             ${JUST_CI_RECIPE_REPO:+ --cache-repo "${JUST_CI_RECIPE_REPO}"} \
             ${JUST_CI_RECIPE_VERSION:+ --cache-version "${JUST_CI_RECIPE_VERSION}"} \
-            --no-push \
+            ${JUST_CI_RECIPE_ARGS-} \
             "${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml" \
             "${recipe}"
       done
@@ -128,6 +152,7 @@ function ci_defaultify()
           --recipe-repo "IGNORE" \
           ${JUST_CI_CACHE_REPO:+ --cache-repo "${JUST_CI_CACHE_REPO}"} \
           ${JUST_CI_CACHE_VERSION:+ --cache-version "${JUST_CI_CACHE_VERSION}"} \
+          ${JUST_CI_CACHE_ARGS-} \
           ${@+"${@}"}
       extra_args=${#}
       ;;


### PR DESCRIPTION
`just_ci_functions.bsh` - add `JUST_CI_CACHE_ARGS` and `JUST_CI_RECIPE_ARGS` to allow environment variable of ci_load arguments for services and recipes.