### PR TITLE
Add docker compose timeout by default

### DIFF
--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -261,6 +261,8 @@ function write_project_env()
 
             : ${TZ=/usr/share/zoneinfo/UTC}
 
+            : ${COMPOSE_HTTP_TIMEOUT=600}
+
             # Use this to add the user name to the docker-compose project name. This is
             # important when multiple users are using this docker-compose project on a
             # single host. This way all of the docker resources are prefixed with a unique


### PR DESCRIPTION
This is a common enough problem, and I don't see a significant side effect to not justify making this the default.

## Explanation

A few docker operations take an undefined amount of time while not communicating between the docker client (`docker-compose`) and docker daemon, e.g. during docker container creation, a large volume initialization can take longer than the default timeout of 30 seconds. 