### PR TITLE
terra_dsm CI fixes

### DIFF
--- a/docker/vsi_common/docker-compose.yml
+++ b/docker/vsi_common/docker-compose.yml
@@ -29,10 +29,10 @@ services:
         source: ${VSI_COMMON_DIR}
         target: /vsi
       - type: bind
-        source: ${DOCS_SOURCE_DIR_HOST-}
+        source: ${DOCS_SOURCE_DIR_HOST-.}
         target: /src
       - type: bind
-        source: ${DOCS_DIR_HOST-}
+        source: ${DOCS_DIR_HOST-./docs}
         target: /docs
   bashcov:
     build:
@@ -46,7 +46,7 @@ services:
     volumes:
       - <<: *vsi_common_volume
       - type: bind
-        source: ${BASH_COV_SOURCE_DIR-}
+        source: ${BASH_COV_SOURCE_DIR-.}
         target: /src
   makeself:
     build:
@@ -62,10 +62,10 @@ services:
     volumes:
       - <<: *vsi_common_volume
       - type: bind
-        source: ${MAKESELF_SOURCE_DIR-}
+        source: ${MAKESELF_SOURCE_DIR-.}
         target: /src
       - type: bind
-        source: ${MAKESELF_DIST_DIR-}
+        source: ${MAKESELF_DIST_DIR-./dist}
         target: /dist
     # platform: linux
   # pyinstaller:
@@ -81,10 +81,10 @@ services:
   #   volumes:
   #     - <<: *vsi_common_volume
   #     - type: bind
-  #       source: ${PYINSTALLER_SOURCE_DIR-}
+  #       source: ${PYINSTALLER_SOURCE_DIR-.}
   #       target: /src
   #     - type: bind
-  #       source: ${PYINSTALLER_DIST_DIR-}
+  #       source: ${PYINSTALLER_DIST_DIR-./dist}
   #       target: /dist
   #     - type: volume
   #       source: pyinstaller-build

--- a/linux/ci_load.py
+++ b/linux/ci_load.py
@@ -46,7 +46,7 @@ class CiLoad:
     output = pid.communicate()[0]
 
     self.compose_yaml = yaml.load(output, Loader=yaml.Loader)
-    self.compose_version = self.compose_yaml['version']
+    self.compose_version = self.compose_yaml.get('version', None)
 
     # Get dockerfile name
     build = self.compose_yaml['services'][self.main_service]['build']


### PR DESCRIPTION
Fixes derived from terra_dsm circleci failures, which is using a more recent docker and docker-compose in the CircleCI cimg/python image.  Specific fixes:
- Add default source locations for sphinx bind-mounts
- ci_load optional compose_version