### PR TITLE
Fix incompatibility with docker-compose 2.x

### DIFF
--- a/linux/just_files/docker_functions.bsh
+++ b/linux/just_files/docker_functions.bsh
@@ -667,6 +667,9 @@ function parse-docker-compose-volumes()
                /^    volumes:/b volumes
                # Search all of the service entry
                /^    /b found
+               # Ignore blank lines, these can be caused by multiline commands
+               # in docker 2.x  or newer.
+               /^$/b found               
                # Volumes were not found, give up
                d
                :volumes

--- a/linux/just_files/docker_functions.bsh
+++ b/linux/just_files/docker_functions.bsh
@@ -669,7 +669,7 @@ function parse-docker-compose-volumes()
                /^    /b found
                # Ignore blank lines, these can be caused by multiline commands
                # in docker 2.x  or newer.
-               /^$/b found               
+               /^$/b found
                # Volumes were not found, give up
                d
                :volumes


### PR DESCRIPTION
The new docker-compose outputs `config` yaml differently than the old config. Instead of printing a multiline string in escaped form:

```yaml
  redis-commander:
    command: "sh -c '\n  echo -n '\"'\"'{\n    \"connections\":[\n      {\n      \
      \  \"password\": \"'\"'\"' > /redis-commander/config/local-production.json\n\
      \  cat \"/run/secrets/redis_password\" | sed '\"'\"'s|\\\\|\\\\\\\\|g;s|\"|\\\
      \\\"|g'\"'\"' >> /redis-commander/config/local-production.json\n  echo -n '\"\
      '\"'\",\n        \"host\": \"terra-redis\",\n        \"label\": \"terra\",\n\
      \        \"dbIndex\": 0,\n        \"connectionName\": \"redis-commander\",\n\
      \        \"port\": \"6379\"\n      }\n    ],\n    \"server\": {\n      \"address\"\
      : \"0.0.0.0\",\n      \"port\": \"4567\",\n      \"httpAuth\": {\n        \"\
      username\": \"admin\",\n        \"passwordHash\": \"'\"'\"'>> /redis-commander/config/local-production.json\n\
      \    cat \"/run/secrets/redis_commander_password\" | sed '\"'\"'s|\\\\|\\\\\\\
      \\|g;s|\"|\\\\\"|g'\"'\"' >> /redis-commander/config/local-production.json\n\
      \    echo '\"'\"'\"\n      }\n    }\n  }'\"'\"' >> /redis-commander/config/local-production.json\n\
      \  /redis-commander/docker/entrypoint.sh'\n"
```

it is now unescaped

```yaml
  redis-commander:
    command:
    - sh
    - -c
    - |2-

        echo -n '{
          "connections":[
            {
              "password": "' > /redis-commander/config/local-production.json
        cat "/run/secrets/redis_password" | sed 's|\\|\\\\|g;s|"|\\"|g' >> /redis-commander/config/local-production.json
        echo -n '",
              "host": "terra-redis",
              "label": "terra",
              "dbIndex": 0,
              "connectionName": "redis-commander",
              "port": "6379"
            }
          ],
          "server": {
            "address": "0.0.0.0",
            "port": "4567",
            "httpAuth": {
              "username": "admin",
              "passwordHash": "'>> /redis-commander/config/local-production.json
          cat "/run/secrets/redis_commander_password" | sed 's|\\|\\\\|g;s|"|\\"|g' >> /redis-commander/config/local-production.json
          echo '"
            }
          }
        }' >> /redis-commander/config/local-production.json
        /redis-commander/docker/entrypoint.sh
```

This means when before there was no way for there to be a "blank" line before, there now is. Since part of the sed logic is to give up if a "less indented" section is found, a blank line triggers this, ending the search. So an exception is made to ignore blank lines specifically and should not harm the search.