### PR TITLE
miniforge conda install

### DIFF
--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -167,11 +167,12 @@ function cmake-install()
 #**
 # .. function:: conda-install
 #
-# Install miniconda
+# Install miniconda/miniforge
 #
 # :Arguments: * [``--dir {dir}``] - conda install directory
 #             * [``--version {version}``] - conda version for install (default= ``${CONDA_VERSION:-latest}``)
-#             * [``--installer {INSTALLER}``] - Conda installer
+#             * [``--installer {INSTALLER}``] - Conda installer (default= ``${CONDA_INSTALLER:-}``)
+#             * [``--miniforge``] - Use miniforge installer (rather than miniconda)
 #
 # :Output: * conda_exe - conda executable
 #          * conda_version - conda version
@@ -183,12 +184,14 @@ function conda-install()
 {
   local conda_dir  # install directory
   local conda_ver="${CONDA_VERSION:-latest}"  # conda version
-  local CONDA_INSTALLER  # optional conda installer
+  local CONDA_INSTALLER="${CONDA_INSTALLER:-}"  # optional conda installer
+  local download_miniforge=0  # use miniforge (rather than miniconda)
 
   parse_args conda_extra_args \
       --dir conda_dir: \
       --version conda_ver: \
       --installer CONDA_INSTALLER: \
+      --miniforge download_miniforge \
       -- ${@+"${@}"}
 
   # directory check
@@ -199,22 +202,54 @@ function conda-install()
   fi
 
   # download conda installer to self-deleting temporary directory
-  if [ -z "${CONDA_INSTALL-}" ]; then
+  if [ -z "${CONDA_INSTALLER-}" ]; then
 
-    local conda_url="https://repo.anaconda.com/miniconda/"
-    if [ "${OS-}" = "Windows_NT" ]; then
-      conda_url+="Miniconda3-${conda_ver}-Windows-x86_64.exe"
-    elif [[ ${OSTYPE-} = darwin* ]]; then
-      if [ "${HOSTTYPE}" = "x86_64" ]; then
-        conda_url+="Miniconda3-${conda_ver}-MacOSX-x86_64.sh"
+    # miniforge url
+    if [ "${download_miniforge}" != "0" ]; then
+
+      local conda_url="https://github.com/conda-forge/miniforge/releases/"
+      local conda_ver_str
+      if [ "${conda_ver}" == "latest" ]; then
+        conda_ver_str="-"
+        conda_url+="latest/download/"
       else
-        conda_url+="Miniconda3-${conda_ver}-MacOSX-arm64.sh"
+        conda_ver_str="-${conda_ver}-"
+        conda_url+="download/${conda_ver}/"
       fi
-    else
-      conda_url+="Miniconda3-${conda_ver}-Linux-x86_64.sh"
-    fi
-    echo "Downloading miniconda <${conda_url}>..." >&2
 
+      if [ "${OS-}" = "Windows_NT" ]; then
+        conda_url+="Miniforge3${conda_ver_str}Windows-x86_64.exe"
+      elif [[ ${OSTYPE-} = darwin* ]]; then
+        if [ "${HOSTTYPE}" = "x86_64" ]; then
+          conda_url+="Miniforge3${conda_ver_str}MacOSX-x86_64.sh"
+        else
+          conda_url+="Miniforge3${conda_ver_str}MacOSX-arm64.sh"
+        fi
+      else
+        conda_url+="Miniforge3${conda_ver_str}Linux-x86_64.sh"
+      fi
+      echo "Downloading miniforge <${conda_url}>..." >&2
+
+    # miniconda url
+    else
+
+      local conda_url="https://repo.anaconda.com/miniconda/"
+      if [ "${OS-}" = "Windows_NT" ]; then
+        conda_url+="Miniconda3-${conda_ver}-Windows-x86_64.exe"
+      elif [[ ${OSTYPE-} = darwin* ]]; then
+        if [ "${HOSTTYPE}" = "x86_64" ]; then
+          conda_url+="Miniconda3-${conda_ver}-MacOSX-x86_64.sh"
+        else
+          conda_url+="Miniconda3-${conda_ver}-MacOSX-arm64.sh"
+        fi
+      else
+        conda_url+="Miniconda3-${conda_ver}-Linux-x86_64.sh"
+      fi
+      echo "Downloading miniconda <${conda_url}>..." >&2
+
+    fi
+
+    # download installer
     local conda_installer_dir
     make_temp_path conda_installer_dir -d
     CONDA_INSTALLER="${conda_installer_dir}/$(basename "${conda_url}")"
@@ -222,13 +257,13 @@ function conda-install()
   fi
 
   # install conda
-  echo "Installing miniconda..." >&2
+  echo "Installing conda using \"$(basename ${CONDA_INSTALLER})\"..." >&2
 
   # windows
   if [ "${OS-}" = "Windows_NT" ]; then
 
     # manual specification of NoRegistry, AddToPath, & RegisterPython
-    # ensure the temporary miniconda is not added to the system registry
+    # ensure the conda install is not added to the system registry
     # at <HKEY_CURRENT_USER\SOFTWARE\Python\PythonCore>
     MSYS2_ARG_CONV_EXCL="*" "${CONDA_INSTALLER}" \
         /NoRegistry=1 /AddToPath=0 /RegisterPython=0 \
@@ -239,7 +274,7 @@ function conda-install()
     CONDA="${conda_dir}/${conda_exe_footer}"
 
     # cleanup shortcuts
-    "${CONDA}" remove --offline -y -p "${conda_dir}" console_shortcut powershell_shortcut
+    "${CONDA}" remove --offline -y -p "${conda_dir}" *_shortcut
 
   # linux & darwin
   else
@@ -262,9 +297,10 @@ function conda-install()
   echo "Conda ${conda_version} installed at \"${conda_exe}\"" >&2
 
   # Make sure version meets request
-  # note we remove any any "py??_" prefix during version comparison
   if [ "${conda_ver}" != "latest" ]; then
-    if ! meet_requirements "${conda_version}" "==${conda_ver#*_}"; then
+    local conda_ver_match="${conda_ver#*_}"  # remove any "py??_" prefix
+    conda_ver_match="${conda_ver_match%-*}"  # remove any "-??" suffix (as in miniforge 4.3.10-1)
+    if ! meet_requirements "${conda_version}" "==${conda_ver_match}"; then
       echo "Conda version ${conda_version} is not the requested version ${conda_ver}" >&2
       local JUST_IGNORE_EXIT_CODES=1
       return 1

--- a/tests/int/test-just_install_functions.bsh
+++ b/tests/int/test-just_install_functions.bsh
@@ -70,18 +70,24 @@ function registry_to_stdout()
 }
 
 
-# test conda-install
-if [ "${VSI_OS}" = "linux" ] && [ -z "${VSI_FORCE_INSTALL_FUNCTIONS_TEST+set}" ]; then
-  # alpine musl won't run the miniconda executable, nor will really old GLIBCs
-  if [ "${VSI_MUSL}" = "1" ] || meet_requirements "$(glibc_version)" "<2.17"; then
+# helper function: check if conda-based test should be skipped
+function check_skip_conda_test()
+{
+  if [ "${VSI_OS}" = "linux" ] && [ -z "${VSI_FORCE_INSTALL_FUNCTIONS_TEST+set}" ]; then
+    # alpine musl won't run the miniconda executable, nor will really old GLIBCs
+    if [ "${VSI_MUSL}" = "1" ] || meet_requirements "$(glibc_version)" "<2.17"; then
+      skip_next_test
+    fi
+  fi
+  if [ -n "${TRASHDIR+set}" ] && [[ ! ${TRASHDIR} =~ ^${does_not_needs_quote_escape_regex}$ ]]; then
+    # Conda is sad https://superuser.com/a/1495827/352118
     skip_next_test
   fi
-fi
-if [ -n "${TRASHDIR+set}" ] && [[ ! ${TRASHDIR} =~ ^${does_not_needs_quote_escape_regex}$ ]]; then
-  # Conda is sad https://superuser.com/a/1495827/352118
-  skip_next_test
-fi
+}
 
+
+# test conda-install
+check_skip_conda_test
 begin_test "conda-install"
 (
   setup_test
@@ -159,17 +165,7 @@ end_test
 
 
 # test conda-python-install & pipenv-install: test in sequence according to typical usage - install python then pipenv
-# test conda-install
-if [ "${VSI_OS}" = "linux" ] && [ -z "${VSI_FORCE_INSTALL_FUNCTIONS_TEST+set}" ]; then
-  # alpine musl won't run the miniconda executable, nor will really old GLIBCs
-  if [ "${VSI_MUSL}" = "1" ] || meet_requirements "$(glibc_version)" "<2.17"; then
-    skip_next_test
-  fi
-fi
-if [ -n "${TRASHDIR+set}" ] && [[ ! ${TRASHDIR} =~ ^${does_not_needs_quote_escape_regex}$ ]]; then
-  # Conda is sad https://superuser.com/a/1495827/352118
-  skip_next_test
-fi
+check_skip_conda_test
 begin_test "conda-python-install and pipenv-install"
 (
   setup_test

--- a/tests/int/test-just_install_functions.bsh
+++ b/tests/int/test-just_install_functions.bsh
@@ -86,82 +86,104 @@ function check_skip_conda_test()
 }
 
 
-# test conda-install
-check_skip_conda_test
-begin_test "conda-install"
-(
-  setup_test
-
-  # redirect mktemp commands to $TESTDIR (does not work on a mac)
-  [ "${VSI_OS}" != "darwin" ] && export TMPDIR="${TESTDIR}"
-
-  # environment
-  export JUST_INSTALL_ACTIVATE_BASENAME="test_just_activate.bsh"
-
-  # for windows, perform additional test if possible confirming no change to windows registry.
-  # For example, when misconfigured conda may add an unwanted entry to <HKEY_CURRENT_USER\SOFTWARE\Python>
-  if [ "${VSI_OS}" = "windows" ]; then
-
-    # registry keys for comparison
-    REGISTRY_KEYS=( "HKEY_CURRENT_USER\SOFTWARE\Python" )
-
-    # before/after registry files
-    REGISTRY_BEFORE="${TESTDIR}/before.reg"
-    REGISTRY_AFTER="${TESTDIR}/after.reg"
-
-    # registry comparison requires "reg" and "cmp" commands
-    ENABLE_REGISTRY_TEST="$( command -v reg &> /dev/null && \
-                             command -v cmp &> /dev/null && \
-                             echo "1" )"
-  fi
-
-  # store registry
-  if [ "${ENABLE_REGISTRY_TEST-}" = "1" ]; then
-    registry_to_stdout "${REGISTRY_KEYS[@]}" > "${REGISTRY_BEFORE}"
-  fi
-
-  # version info
-  CONDA_VER="py38_4.10.3"
-  CONDA_VER_FULL="conda 4.10.3"
-
-  # install
-  conda-install \
-      --dir "${TESTDIR}/conda" \
-      --version "${CONDA_VER}"
-
-  # output version (removing the py38_ prefix)
-  [ "${conda_version}" = "${CONDA_VER#*_}" ]
-
-  # This catches some rare scenario when the conda exe without the executable
-  # didn't report the right version. However, if the shebang is longer than 127
-  # characters, then conda will not start without the right python interpreter
-  # So a blank RESULT represent this case, and should be ignored
-  # executable version
-  RESULT="$("${conda_exe}" --version || :)"
-  [ "${RESULT}" = "" ] || [ "${RESULT}" = "${CONDA_VER_FULL}" ]
-
-  # activate version
-  RESULT="$(source "${conda_activate}"; conda --version)"
-  [ "${RESULT}" = "${CONDA_VER_FULL}" ]
-
-  # registry test
-  if [ "${ENABLE_REGISTRY_TEST-}" = "1" ]; then
-    registry_to_stdout "${REGISTRY_KEYS[@]}" > "${REGISTRY_AFTER}"
-
-    # echo to stderr for debugging
-    { echo "Registry comparison of [${REGISTRY_KEYS[@]}]" ;
-      echo "Initial state:" ;
-      cat "${REGISTRY_BEFORE}" ;
-      echo "Final state:" ;
-      cat "${REGISTRY_AFTER}" ;
-      echo ; } >&2
-
-    # compare
-    cmp "${REGISTRY_BEFORE}" "${REGISTRY_AFTER}"
-  fi
-
+# test conda-install with different options
+CONDA_TEST_ID_ARRAY=(
+    "miniconda"
+    "miniforge"
 )
-end_test
+CONDA_EXTRA_ARGS_ARRAY=(
+    "--version py38_4.10.3"
+    "--miniforge --version 4.11.0-4"
+)
+CONDA_VER_FULL_ARRAY=(
+    "conda 4.10.3"
+    "conda 4.11.0"
+)
+CONDA_VER_SHORT_ARRAY=(
+    "4.10.3"
+    "4.11.0"
+)
+
+for i in "${!CONDA_EXTRA_ARGS_ARRAY[@]}"; do
+
+  # test options
+  CONDA_TEST_ID="${CONDA_TEST_ID_ARRAY[$i]}"
+  CONDA_EXTRA_ARGS="${CONDA_EXTRA_ARGS_ARRAY[$i]}"
+  CONDA_VER_FULL="${CONDA_VER_FULL_ARRAY[$i]}"
+  CONDA_VER_SHORT="${CONDA_VER_SHORT_ARRAY[$i]}"
+
+  # run test
+  check_skip_conda_test
+  begin_test "conda-install ${CONDA_TEST_ID}"
+  (
+    setup_test
+
+    # redirect mktemp commands to $TESTDIR (does not work on a mac)
+    [ "${VSI_OS}" != "darwin" ] && export TMPDIR="${TESTDIR}"
+
+    # environment
+    export JUST_INSTALL_ACTIVATE_BASENAME="test_just_activate.bsh"
+
+    # for windows, perform additional test if possible confirming no change to windows registry.
+    # For example, when misconfigured conda may add an unwanted entry to <HKEY_CURRENT_USER\SOFTWARE\Python>
+    if [ "${VSI_OS}" = "windows" ]; then
+
+      # registry keys for comparison
+      REGISTRY_KEYS=( "HKEY_CURRENT_USER\SOFTWARE\Python" )
+
+      # before/after registry files
+      REGISTRY_BEFORE="${TESTDIR}/before.reg"
+      REGISTRY_AFTER="${TESTDIR}/after.reg"
+
+      # registry comparison requires "reg" and "cmp" commands
+      ENABLE_REGISTRY_TEST="$( command -v reg &> /dev/null && \
+                              command -v cmp &> /dev/null && \
+                              echo "1" )"
+    fi
+
+    # store registry
+    if [ "${ENABLE_REGISTRY_TEST-}" = "1" ]; then
+      registry_to_stdout "${REGISTRY_KEYS[@]}" > "${REGISTRY_BEFORE}"
+    fi
+
+    # install
+    conda-install --dir "${TESTDIR}/conda" ${CONDA_EXTRA_ARGS}
+
+    # output version
+    [ "${conda_version}" = "${CONDA_VER_SHORT}" ]
+
+    # This catches some rare scenario when the conda exe without the executable
+    # didn't report the right version. However, if the shebang is longer than 127
+    # characters, then conda will not start without the right python interpreter
+    # So a blank RESULT represent this case, and should be ignored
+    # executable version
+    RESULT="$("${conda_exe}" --version || :)"
+    [ "${RESULT}" = "" ] || [ "${RESULT}" = "${CONDA_VER_FULL}" ]
+
+    # activate version
+    RESULT="$(source "${conda_activate}"; conda --version)"
+    [ "${RESULT}" = "${CONDA_VER_FULL}" ]
+
+    # registry test
+    if [ "${ENABLE_REGISTRY_TEST-}" = "1" ]; then
+      registry_to_stdout "${REGISTRY_KEYS[@]}" > "${REGISTRY_AFTER}"
+
+      # echo to stderr for debugging
+      { echo "Registry comparison of [${REGISTRY_KEYS[@]}]" ;
+        echo "Initial state:" ;
+        cat "${REGISTRY_BEFORE}" ;
+        echo "Final state:" ;
+        cat "${REGISTRY_AFTER}" ;
+        echo ; } >&2
+
+      # compare
+      cmp "${REGISTRY_BEFORE}" "${REGISTRY_AFTER}"
+    fi
+
+  )
+  end_test
+
+done # test conda-install
 
 
 # test conda-python-install & pipenv-install: test in sequence according to typical usage - install python then pipenv


### PR DESCRIPTION
Allow conda install using miniforge (rather than miniconda).  Update conda install tests to try both miniconda and miniforge.