### PR TITLE
ci_load verbosity

### DIFF
--- a/linux/ci_load.py
+++ b/linux/ci_load.py
@@ -218,6 +218,10 @@ class CiLoad:
                              Loader=yaml.Loader)
     main_image = self.compose_yaml['services'][self.main_service].get('image')
 
+    if self.print_build:
+      print('BUILD CONFIGURATION:')
+      print(yaml.dump(yaml_content))
+
     def build_stage(stage_name):
       build = yaml_content['services'][f'{stage_name}']['build']
       image_name = yaml_content['services'][f'{stage_name}']['image']
@@ -299,6 +303,8 @@ class CiLoad:
 
     aa('--print-push-pull', dest='print_push_pull', action='store_true',
        default=False, help='Print push/pull configuration')
+    aa('--print-build', dest='print_build', action='store_true',
+       default=False, help='Print build configuration')
 
     aa('compose', type=str, help='Docker compose yaml file')
     aa('main_service', type=str, help='Main docker-compose service')
@@ -323,6 +329,7 @@ class CiLoad:
 
     self.quiet_pull = args.quiet_pull
     self.print_push_pull = args.print_push_pull
+    self.print_build = args.print_build
 
     if args.project_dir is None:
       self.project_dir = os.path.dirname(self.compose)

--- a/linux/ci_load.py
+++ b/linux/ci_load.py
@@ -104,6 +104,10 @@ class CiLoad:
     self.push_pull_file.write(yaml.dump(doc))
     self.push_pull_file.flush()
 
+    if self.print_push_pull:
+      print('PUSH/PULL CONFIGURATION:')
+      print(yaml.dump(doc))
+
   # 2 docker-compose pull
   def pull_images(self):
     if self.pull:
@@ -293,6 +297,9 @@ class CiLoad:
     aa('--quiet-pull', dest='quiet_pull', action='store_true',
        default=False, help='Quiet pull (no progress bars)')
 
+    aa('--print-push-pull', dest='print_push_pull', action='store_true',
+       default=False, help='Print push/pull configuration')
+
     aa('compose', type=str, help='Docker compose yaml file')
     aa('main_service', type=str, help='Main docker-compose service')
     aa('services', type=str, nargs='*',
@@ -315,6 +322,7 @@ class CiLoad:
     self.build = args.build
 
     self.quiet_pull = args.quiet_pull
+    self.print_push_pull = args.print_push_pull
 
     if args.project_dir is None:
       self.project_dir = os.path.dirname(self.compose)

--- a/linux/ci_load.py
+++ b/linux/ci_load.py
@@ -110,6 +110,10 @@ class CiLoad:
       pull_cmd = [self.docker_compose_exe,
                   '-f', self.push_pull_file.name,
                   'pull']
+      if self.quiet_pull:
+        print("Pulling images...")
+        pull_cmd.append('-q')
+
       try:
         Popen2(pull_cmd)
       except AssertionError:
@@ -286,6 +290,9 @@ class CiLoad:
     aa('--no-build', dest='build', action='store_false',
        default=True, help='Disable building images')
 
+    aa('--quiet-pull', dest='quiet_pull', action='store_true',
+       default=False, help='Quiet pull (no progress bars)')
+
     aa('compose', type=str, help='Docker compose yaml file')
     aa('main_service', type=str, help='Main docker-compose service')
     aa('services', type=str, nargs='*',
@@ -306,6 +313,8 @@ class CiLoad:
     self.push = args.push
     self.pull = args.pull
     self.build = args.build
+
+    self.quiet_pull = args.quiet_pull
 
     if args.project_dir is None:
       self.project_dir = os.path.dirname(self.compose)


### PR DESCRIPTION
control ci_load verbosity:
- `--quiet-pull` to eliminate progress bars during dockerhub image pull (progress bars can make CI output very hard to read)
- `--print-push-pull` to print push/pull configuration file (view services & cached images) 
- `--print-build` to print build configuration file (view services & cache_from values)