### PR TITLE
ci_load --other-repos

### DIFF
--- a/linux/ci_load.py
+++ b/linux/ci_load.py
@@ -113,7 +113,8 @@ class CiLoad:
         pull_file.write(yaml.dump(self.pull_dict))
         pull_file.flush()
 
-        pull_cmd = [self.docker_compose_exe, '-f', pull_file.name, 'pull']
+        pull_cmd = [self.docker_compose_exe, '-f', pull_file.name, 'pull',
+                    '--ignore-pull-failures']
         if self.quiet_pull:
           pull_cmd.append('-q')
 


### PR DESCRIPTION
`ci_load.py --other-repos <OTHER_REPO> ...` to optionally warm CI docker cache from more than one location.  This is useful if the cache is moved to a new dockerhub location, or for new "blueprint" docker patterns where default dockers stored in one dockerhub location are useful to warm a project-specific docker cache. 

Specific changes include:
- separate pull & push configurations, to allow pulling from multiple caches but push only to the main cache
- multiple cache locations - pull from multiple caches, `cache_from` with multiple caches
- add `--ignore-pull-failures` to pull, pulling what's available and ignoring what's not yet available 
- Note the push/pull yaml files are only briefly written to disk during push/pull operations; the class now stores push/pull dictionaries instead of references to yaml files