### PR TITLE
ci_load blueprint

### DIFF
--- a/linux/just_files/just_ci_functions.bsh
+++ b/linux/just_files/just_ci_functions.bsh
@@ -93,7 +93,7 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 #   :cmd:`ci_load-services`
 #**
 
-: ${JUST_CI_RECIPE_ARGS="--no-push"}
+: ${JUST_CI_RECIPE_ARGS=}
 
 #**
 # .. envvar:: JUST_CI_BLUEPRINT_REPO
@@ -161,6 +161,7 @@ function ci_defaultify()
             --recipe-repo "IGNORE" \
             ${JUST_CI_RECIPE_REPO:+ --cache-repo "${JUST_CI_RECIPE_REPO}"} \
             ${JUST_CI_RECIPE_VERSION:+ --cache-version "${JUST_CI_RECIPE_VERSION}"} \
+            --no-push \
             ${JUST_CI_RECIPE_ARGS-} \
             "${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml" \
             "${recipe}"

--- a/linux/just_files/just_ci_functions.bsh
+++ b/linux/just_files/just_ci_functions.bsh
@@ -96,6 +96,30 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 : ${JUST_CI_RECIPE_ARGS="--no-push"}
 
 #**
+# .. envvar:: JUST_CI_BLUEPRINT_REPO
+#
+# Dockerhub repository for CI blueprint cache.
+#
+# .. seealso::
+#
+#   :cmd:`ci_load-blueprint`
+#**
+
+: ${JUST_CI_BLUEPRINT_REPO="vsiri/ci_cache_blueprints"}
+
+#**
+# .. envvar:: JUST_CI_BLUEPRINT_VERSION
+#
+# Version for CI blueprint cache.
+#
+# .. seealso::
+#
+#   :cmd:`ci_load-blueprint`
+#**
+
+: ${JUST_CI_BLUEPRINT_VERSION=}
+
+#**
 # .. command:: ci_load-recipes
 #
 # :Arguments: [``$1``]... - Recipe names to load
@@ -107,6 +131,14 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 # :Arguments: ``$1``... - Dockerfiles to parse
 #
 # Scans Dockerfiles for ``vsiri/recipe:`` images, and calls :cmd:`ci_load-recipes` on the recipes discovered. Accepts multiple files and ``-`` for stdin
+#
+# .. command:: ci_load-blueprint
+#
+# :Arguments: ``$1`` - Project docker compose yaml file
+#             ``$2`` - Project blueprint service (e.g., ``project_gdal````)
+#             [``$3``] - Blueprint service name in ``$JUST_CI_BLUEPRINT_CACHE``, if different from project blueprint service
+#
+# Runs `ci_load.py` for specified docker blueprint.  Blueprint is saved to the project cache ``$JUST_CI_CACHE_REPO``, warmed from the blueprint cache at ``$JUST_CI_BLUEPRINT_CACHE``.
 #
 # .. command:: ci_load-services
 #
@@ -145,6 +177,27 @@ function ci_defaultify()
       fi
       local recipes=($(get_docker_recipes ${@+"${@}"}))
       justify ci_load-recipes "${recipes[@]}"
+      extra_args=${#}
+      ;;
+    ci_load-blueprint) # Load one blueprint from dockerhub cache
+
+      # inputs
+      local _project_compose_file="$1"
+      local _project_service="$2"
+      local _blueprint_name="${3:-$2}"
+
+      # blueprint repo for cache warming
+      local _blueprint_version=${JUST_CI_BLUEPRINT_VERSION:+"${JUST_CI_BLUEPRINT_VERSION}_"}
+      local _other_repo="${JUST_CI_BLUEPRINT_REPO}:${_blueprint_version}${_blueprint_name}"
+
+      # ci_load blueprint service
+      python3 "${VSI_COMMON_DIR}/linux/ci_load.py" \
+          ${JUST_CI_BLUEPRINT_REPO:+ --other-repos "${_other_repo}"} \
+          --recipe-repo "IGNORE" \
+          ${JUST_CI_CACHE_REPO:+ --cache-repo "${JUST_CI_CACHE_REPO}"} \
+          ${JUST_CI_CACHE_VERSION:+ --cache-version "${JUST_CI_CACHE_VERSION}"} \
+          ${JUST_CI_CACHE_ARGS-} \
+          "${_project_compose_file}" "${_project_service}"
       extra_args=${#}
       ;;
     ci_load-services) # Load services from dockerhub cache


### PR DESCRIPTION
`just ci load-blueprint` to run `ci_load.py` for a single blueprint.  The result is saved to the project cache at `$JUST_CI_CACHE_REPO`, warmed from the blueprint cache at `$JUST_CI_BLUEPRINT_REPO`.

Additionally force `just ci load-recipes` to always include the `--no-push` flag, as `docker_recipes` is the only repo that should ever push to the recipe CI cache.