### PR TITLE
ci_load --push

### DIFF
--- a/linux/ci_load.py
+++ b/linux/ci_load.py
@@ -322,12 +322,26 @@ class CiLoad:
                             "docker/recipes/docker-compose.yml"),
        help='Recipe compose file')
 
-    aa('--no-push', dest='push', action='store_false',
-       default=True, help='Disable pushing images')
-    aa('--no-pull', dest='pull', action='store_false',
-       default=True, help='Disable pulling images')
-    aa('--no-build', dest='build', action='store_false',
-       default=True, help='Disable building images')
+    group = self.parser.add_mutually_exclusive_group()
+    group.add_argument('--pull', dest='pull', action='store_true',
+                       help='Enable pulling images (default)')
+    group.add_argument('--no-pull', dest='pull', action='store_false',
+                       help='Disable pulling images')
+    self.parser.set_defaults(pull=True)
+
+    group = self.parser.add_mutually_exclusive_group()
+    group.add_argument('--build', dest='build', action='store_true',
+                       help='Enable building images (default)')
+    group.add_argument('--no-build', dest='build', action='store_false',
+                       help='Disable building images')
+    self.parser.set_defaults(build=True)
+
+    group = self.parser.add_mutually_exclusive_group()
+    group.add_argument('--push', dest='push', action='store_true',
+                       help='Enable pushing images')
+    group.add_argument('--no-push', dest='push', action='store_false',
+                       help='Disable pushing images (default)')
+    self.parser.set_defaults(push=False)
 
     aa('--quiet-pull', dest='quiet_pull', action='store_true',
        default=False, help='Quiet pull (no progress bars)')

--- a/linux/just_files/just_ci_functions.bsh
+++ b/linux/just_files/just_ci_functions.bsh
@@ -124,7 +124,7 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 #
 # :Arguments: [``$1``]... - Recipe names to load
 #
-# Runs `ci_load.py` for specified docker recipes. Handles loading of both single and multi-stage recipes. Note recipes are not pushed back to the recipe cache (``ci_load.py --no-push ...``).
+# Runs `ci_load.py` for specified docker recipes. Handles loading of both single and multi-stage recipes.
 #
 # .. command:: ci_load-recipes-auto
 #
@@ -161,7 +161,6 @@ function ci_defaultify()
             --recipe-repo "IGNORE" \
             ${JUST_CI_RECIPE_REPO:+ --cache-repo "${JUST_CI_RECIPE_REPO}"} \
             ${JUST_CI_RECIPE_VERSION:+ --cache-version "${JUST_CI_RECIPE_VERSION}"} \
-            --no-push \
             ${JUST_CI_RECIPE_ARGS-} \
             "${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml" \
             "${recipe}"


### PR DESCRIPTION
`ci_load.py` do not push by default
- mutually exclusive options for `--pull`/`--no-pull`, `--build`/`--no-build`, `--push`/`--no-push`
- do not push by default
- other defaults remain the same - pull & build by default

Additional update for `just ci load-recipes` as forced `--no-push` is no longer necessary