### PR TITLE
Strip copy

### DIFF
--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -484,7 +484,7 @@ function relative_path()
 #
 # .. note:
 #
-#    ``cp`` will process files in a different order than ``tar --strip-components``. In case there are multiple files with the same name at a stripped depth,files may be overwritten differently than ``tar --strip-components`` would have. While ``tar`` keeps the first one in the archive order, ``cp`` will keep the last one in ``cp`` order. And as both order and behaviors are different, the result could be the same, or different.
+#    ``cp`` will process files in a different order than ``tar --strip-components``. In case there are multiple files with the same name at a stripped depth,files may be overwritten differently than ``tar --strip-components`` would have. While ``tar`` keeps the first one in the archive order, ``cp`` will keep the last one in ``cp`` order. Consequently, the order is not guaranteed as both order and behaviors are different.
 #**
 function strip_copy()
 {
@@ -494,12 +494,12 @@ function strip_copy()
 
   mkdir -p "${destination}"
 
-  # Technically the length of destination is not including in the xargs like
-  # formation internal the find command, however it turns out everyone's
-  # implementation of xargs/find adds such a large safety buffer that that
-  # discrepancy doesn't matter
+  # Technically, the length of the destination, DEST, is not included in the xargs
+  # line formation because it is internal the find command, however it turns out
+  # everyone's implementation of xargs/find adds such a large safety buffer that
+  # the discrepancy doesn't matter
   #
-  # Newer versions of cp refused to overwrite a file it copied in the same
+  # Newer versions of cp refuse to overwrite a file it copied in the same
   # command, "cp: will not overwrite just-created". However the behavior of
   # --strip-components doesn't care, so we won't either
   # This is slightly different from the tar behavior, where the first one is
@@ -511,6 +511,7 @@ function strip_copy()
                             -mindepth "${depth}" -maxdepth "${depth}" \
                             -exec sh -c 'cp -fa "${@}" "${DEST}/" || :' sh \{\} \+
 
+  # Kept for reference/posterity
   # if [ "${depth}" = "0" ]; then
   #   cp -a "${source_dir}" "${destination}/"
   #   return 0

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -10,6 +10,7 @@ fi
 
 source "${VSI_COMMON_DIR}/linux/signal_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
+source "${VSI_COMMON_DIR}/linux/real_path"
 
 #*# linux/dir_tools
 
@@ -479,11 +480,15 @@ function relative_path()
 #             * ``$2`` - The destination directory
 #             * ``$3`` - Strip this many leading components from file names on ``cp``
 #
-# Replicated the behavior of ``tar --strip-components``, but when applied to a ``cp`` scenario.
+# Replicates the behavior of ``tar --strip-components``, but when applied to a ``cp`` scenario.
+#
+# .. note:
+#
+#    ``cp`` will process files in a different order than ``tar --strip-components``. In case there are multiple files with the same name at a stripped depth,files may be overwritten differently than ``tar --strip-components`` would have. While ``tar`` keeps the first one in the archive order, ``cp`` will keep the last one in ``cp`` order. And as both order and behaviors are different, the result could be the same, or different.
 #**
 function strip_copy()
 {
-  local source_dir=$(normpath "${1}")
+  local source_dir=$(real_path "${1}")
   local destination=${2}
   local depth=${3}
 
@@ -493,9 +498,18 @@ function strip_copy()
   # formation internal the find command, however it turns out everyone's
   # implementation of xargs/find adds such a large safety buffer that that
   # discrepancy doesn't matter
+  #
+  # Newer versions of cp refused to overwrite a file it copied in the same
+  # command, "cp: will not overwrite just-created". However the behavior of
+  # --strip-components doesn't care, so we won't either
+  # This is slightly different from the tar behavior, where the first one is
+  # kept, while cp will override. But seeing as order isn't guaranteed to be
+  # maintained, this different in behavior hardly matters. Trying to disable
+  # this "error message" with --backup=none did not work, so just ignore cp
+  # exit code with || :
   DEST="${destination}" find "${source_dir}" \
                             -mindepth "${depth}" -maxdepth "${depth}" \
-                            -exec sh -c 'cp -fa "${@}" "${DEST}/"' sh \{\} \+
+                            -exec sh -c 'cp -fa "${@}" "${DEST}/" || :' sh \{\} \+
 
   # if [ "${depth}" = "0" ]; then
   #   cp -a "${source_dir}" "${destination}/"

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -471,3 +471,51 @@ function relative_path()
     echo "${ans[*]}"
   fi
 }
+
+#**
+# .. function:: strip_copy
+#
+# :Arguments: * ``$1`` - The source directory
+#             * ``$2`` - The destination directory
+#             * ``$3`` - Strip this many leading components from file names on ``cp``
+#
+# Replicated the behavior of ``tar --strip-components``, but when applied to a ``cp`` scenario.
+#**
+function strip_copy()
+{
+  local source_dir=$(normpath "${1}")
+  local destination=${2}
+  local depth=${3}
+
+  mkdir -p "${destination}"
+
+  # Technically the length of destination is not including in the xargs like
+  # formation internal the find command, however it turns out everyone's
+  # implementation of xargs/find adds such a large safety buffer that that
+  # discrepancy doesn't matter
+  DEST="${destination}" find "${source_dir}" \
+                            -mindepth "${depth}" -maxdepth "${depth}" \
+                            -exec sh -c 'cp -fa "${@}" "${DEST}/"' sh \{\} \+
+
+  # if [ "${depth}" = "0" ]; then
+  #   cp -a "${source_dir}" "${destination}/"
+  #   return 0
+  # elif [ "${depth}" -lt "0" ]; then
+  #   echo "Something went wrong" &> 2
+  #   return 1
+  # fi
+
+  # while IFS= read -r -d '' filename || [ -n "${filename}" ]; do
+  #   if [ -d "${filename}" ]; then
+  #     if [ "${depth}" = "1" ]; then
+  #       cp -a "${filename}" "${destination}/"
+  #     else
+  #       strip_copy "${filename}" "${destination}" $((depth-1))
+  #     fi
+  #   else
+  #     if [ "${depth}" = "1" ]; then
+  #       cp -a "${filename}" "${destination}/"
+  #     fi
+  #   fi
+  # done < <(find "${source_dir}" -mindepth 1 -maxdepth 1 -print0)
+}

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -505,11 +505,11 @@ function strip_copy()
   # command, "cp: will not overwrite just-created". However the behavior of
   # --strip-components doesn't care, so we won't either
   # This is slightly different from the tar behavior, where the first one is
-  # kept, while cp will override. This different in behavior hardly matters;
+  # kept, while cp will override. This difference in behavior hardly matters;
   # consequently, we are not guaranteeing order. Trying to disable this
   # "error message" with --backup=none did not work, so just ignore cp
-  # exit code with || : and ignore the "will not overwrite just-created" if the
-  # spew to the screen.
+  # exit code with || : and ignore the "cp: will not overwrite just-created"
+  # message if it is spewed to the screen.
   DEST="${destination}" find "${source_dir}" \
                             -mindepth "${depth}" -maxdepth "${depth}" \
                             -exec sh -c 'cp -fa "${@}" "${DEST}/" || :' sh \{\} \+

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -484,7 +484,7 @@ function relative_path()
 #
 # .. note:
 #
-#    ``cp`` will process files in a different order than ``tar --strip-components``. In the case where there are multiple files with the same name at a stripped depth, the file may be overwritten in a different order than ``tar --strip-components`` would have. While ``tar`` keeps the first one in the archive order, ``cp`` will keep the last one in ``cp`` order. Consequently, the order is not guaranteed as both order and behaviors are different.
+#    ``cp`` will process files in a different order than ``tar --strip-components``. In the case where there are multiple files with the same name at a stripped depth, the file may be overwritten in a different order than ``tar --strip-components`` would have. While ``tar`` keeps the first one in the archive order, ``cp`` will keep the last one in ``cp`` order. Consequently, the order is not guaranteed.
 #**
 function strip_copy()
 {

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -484,7 +484,7 @@ function relative_path()
 #
 # .. note:
 #
-#    ``cp`` will process files in a different order than ``tar --strip-components``. In case there are multiple files with the same name at a stripped depth,files may be overwritten differently than ``tar --strip-components`` would have. While ``tar`` keeps the first one in the archive order, ``cp`` will keep the last one in ``cp`` order. Consequently, the order is not guaranteed as both order and behaviors are different.
+#    ``cp`` will process files in a different order than ``tar --strip-components``. In the case where there are multiple files with the same name at a stripped depth, the file may be overwritten in a different order than ``tar --strip-components`` would have. While ``tar`` keeps the first one in the archive order, ``cp`` will keep the last one in ``cp`` order. Consequently, the order is not guaranteed as both order and behaviors are different.
 #**
 function strip_copy()
 {

--- a/linux/dir_tools.bsh
+++ b/linux/dir_tools.bsh
@@ -494,6 +494,8 @@ function strip_copy()
 
   mkdir -p "${destination}"
 
+  # Based on https://stackoverflow.com/a/47645560/4166604
+  #
   # Technically, the length of the destination, DEST, is not included in the xargs
   # line formation because it is internal the find command, however it turns out
   # everyone's implementation of xargs/find adds such a large safety buffer that
@@ -503,10 +505,11 @@ function strip_copy()
   # command, "cp: will not overwrite just-created". However the behavior of
   # --strip-components doesn't care, so we won't either
   # This is slightly different from the tar behavior, where the first one is
-  # kept, while cp will override. But seeing as order isn't guaranteed to be
-  # maintained, this different in behavior hardly matters. Trying to disable
-  # this "error message" with --backup=none did not work, so just ignore cp
-  # exit code with || :
+  # kept, while cp will override. This different in behavior hardly matters;
+  # consequently, we are not guaranteeing order. Trying to disable this
+  # "error message" with --backup=none did not work, so just ignore cp
+  # exit code with || : and ignore the "will not overwrite just-created" if the
+  # spew to the screen.
   DEST="${destination}" find "${source_dir}" \
                             -mindepth "${depth}" -maxdepth "${depth}" \
                             -exec sh -c 'cp -fa "${@}" "${DEST}/" || :' sh \{\} \+

--- a/tests/test-dir_tools.bsh
+++ b/tests/test-dir_tools.bsh
@@ -331,3 +331,39 @@ begin_test "relaive path"
   relpath_check "/a/b" "/a/b" '.'
 )
 end_test
+
+begin_test "Strip copy"
+(
+  setup_test
+
+  mkdir -p "${TESTDIR}/foo/dir1/dir12"
+  mkdir -p "${TESTDIR}/foo/dir1/dir11"
+  touch "${TESTDIR}/foo/dir1/file11"
+  touch "${TESTDIR}/foo/dir1/file12"
+
+  mkdir -p "${TESTDIR}/foo/dir1/dir_common"
+  mkdir -p "${TESTDIR}/foo/dir1/dir_common/dirc"
+  echo 111 > "${TESTDIR}/foo/dir1/file_common"
+  touch "${TESTDIR}/foo/dir1/dir_common/filec1"
+
+  mkdir -p "${TESTDIR}/foo/dir2/dir21"
+  mkdir -p "${TESTDIR}/foo/dir2/dir22"
+  touch "${TESTDIR}/foo/dir2/file21"
+
+  mkdir -p "${TESTDIR}/foo/dir2/dir_common"
+  mkdir -p "${TESTDIR}/foo/dir2/dir_common/dirc"
+  echo 222 > "${TESTDIR}/foo/dir2/file_common"
+
+  touch "${TESTDIR}/foo/file1"
+  touch "${TESTDIR}/foo/file2"
+
+  mkdir "${TESTDIR}/bar1"
+
+  strip_copy "${TESTDIR}/foo" "${TESTDIR}/bar0" 0
+  strip_copy "${TESTDIR}/foo" "${TESTDIR}/bar1" 1
+  cd "${TESTDIR}/foo"
+  strip_copy . "${TESTDIR}/bar2" 2
+
+  [ -d "${TESTDIR}/bar0/foo" ]
+)
+end_test

--- a/tests/test-dir_tools.bsh
+++ b/tests/test-dir_tools.bsh
@@ -342,7 +342,6 @@ begin_test "Strip copy"
   touch "${TESTDIR}/foo/dir1/file12"
 
   mkdir -p "${TESTDIR}/foo/dir1/dir_common"
-  mkdir -p "${TESTDIR}/foo/dir1/dir_common/dirc"
   echo 111 > "${TESTDIR}/foo/dir1/file_common"
   touch "${TESTDIR}/foo/dir1/dir_common/filec1"
 
@@ -351,7 +350,7 @@ begin_test "Strip copy"
   touch "${TESTDIR}/foo/dir2/file21"
 
   mkdir -p "${TESTDIR}/foo/dir2/dir_common"
-  mkdir -p "${TESTDIR}/foo/dir2/dir_common/dirc"
+  mkdir -p "${TESTDIR}/foo/dir2/dir_common/dir2"
   echo 222 > "${TESTDIR}/foo/dir2/file_common"
 
   touch "${TESTDIR}/foo/file1"
@@ -359,11 +358,49 @@ begin_test "Strip copy"
 
   mkdir "${TESTDIR}/bar1"
 
-  strip_copy "${TESTDIR}/foo" "${TESTDIR}/bar0" 0
-  strip_copy "${TESTDIR}/foo" "${TESTDIR}/bar1" 1
-  cd "${TESTDIR}/foo"
-  strip_copy . "${TESTDIR}/bar2" 2
+  strip_copy "${TESTDIR}/foo" "${TESTDIR}/bar0a" 0
+  pushd "${TESTDIR}/foo" &> /dev/null
+  strip_copy . "${TESTDIR}/bar0b" 0
+  strip_copy . "${TESTDIR}/bar1" 1
+  popd  &> /dev/null
+  strip_copy "${TESTDIR}/foo" "${TESTDIR}/bar2" 2
 
-  [ -d "${TESTDIR}/bar0/foo" ]
+  # Verify no stripping works (level 0) and level 1 stripping
+  for d in bar0a/foo bar0b/foo bar1; do
+    [ -f "${TESTDIR}/${d}/file1" ]
+    [ -f "${TESTDIR}/${d}/file2" ]
+
+    [ -d "${TESTDIR}/${d}/dir1/dir11" ]
+    [ -d "${TESTDIR}/${d}/dir1/dir12" ]
+    [ -f "${TESTDIR}/${d}/dir1/file11" ]
+    [ -f "${TESTDIR}/${d}/dir1/file12" ]
+
+    [ -d "${TESTDIR}/${d}/dir2/dir21" ]
+    [ -d "${TESTDIR}/${d}/dir2/dir22" ]
+    [ -f "${TESTDIR}/${d}/dir2/file21" ]
+
+
+    [ -f "${TESTDIR}/${d}/dir1/dir_common/filec1" ]
+    [ -d "${TESTDIR}/${d}/dir2/dir_common/dir2" ]
+
+    [ "$(cat "${TESTDIR}/${d}/dir1/file_common")" == "111" ]
+    [ "$(cat "${TESTDIR}/${d}/dir2/file_common")" == "222" ]
+  done
+
+  # Verify Collision case at level 2
+  [ -d "${TESTDIR}/bar2/dir11" ]
+  [ -d "${TESTDIR}/bar2/dir12" ]
+  [ -f "${TESTDIR}/bar2/file11" ]
+  [ -f "${TESTDIR}/bar2/file12" ]
+
+  [ -d "${TESTDIR}/bar2/dir21" ]
+  [ -d "${TESTDIR}/bar2/dir22" ]
+  [ -f "${TESTDIR}/bar2/file21" ]
+
+  [ -f "${TESTDIR}/bar2/dir_common/filec1" ]
+  [ -d "${TESTDIR}/bar2/dir_common/dir2" ]
+
+  contents="$(cat "${TESTDIR}/bar2/file_common")"
+  [ "${contents}" = "111" ] || [ "${contents}" = "222" ]
 )
 end_test


### PR DESCRIPTION
Adds a way to reproduce `--strip-components` from `tar`, during `cp`