### PR TITLE
Cuda update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
 
   run_bash_and_os_tests:
     <<: *container_config
-    parallelism: 3
+    parallelism: 4
     steps:
       - checkout
       - submodule_checkout

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -80,9 +80,19 @@ source "${VSI_COMMON_DIR}/linux/versions.bsh"
 # .. seealso::
 #   :var:`CUDA_DEPRECATED`
 #
+# .. var:: CUDA_LTOS
+#
+# Starting in CUDA 11, NVIDIA introduced Link Time Optimizations (``lto_``) architectures in addition to the already existing ``sm_`` and ``compute_``
+#
+# Separately compiled code may not have as high of performance as whole program code because of the inability to inline code across files. A way to still get optimal performance is to use link-time optimization
+#
 # .. var:: CUDA_MINIMAL_DRIVER_VERSION
 #
 # Every version of CUDA has a minimal version of the NVIDIA graphics-card driver that must be installed in order to support that version of CUDA. This was largely undocumented until CUDA 10 came out, despite being obviously important. This variable is set to the minimum required version of the NVIDIA driver for the :var:`CUDA_VERSION` version of CUDA, as best as we've been able to determine.
+#
+# .. var:: CUDA_COMPATIBLE_DRIVER_VERSION
+#
+# Starting in CUDA 11, NVIDIA introduced a ``cuda-compat` package that can be installed on machines with older NVIDIA Drivers, for increased compatibility with these drivers. This is the minimum supported driver version that will handle the ``cuda-compat`` runtime.
 #
 # .. var:: CUDA_DEPRECATED
 #

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -342,247 +342,113 @@ function cuda_capabilities()
   CUDA_DEPRECATED=()
   CUDA_LTOS=()
 
-  # This seems to be updated regularly
-  # [1] https://stackoverflow.com/a/30820690/4166604
-  # [2] https://gist.github.com/ax3l/9489132
   case "${1}" in
-    1.0*)
+    1.*)
       CUDA_ARCHES=(10 11)
       CUDA_CODES=("${CUDA_ARCHES[@]}")
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=162.01 #~
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=100.14 #~
-      fi
       ;;
-    1.1*)
-      CUDA_ARCHES=(10 11)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
-      CUDA_MINIMAL_DRIVER_VERSION=169.01
-      ;;
-    2.0*)
+
+    2.*)
       CUDA_ARCHES=(10 11 12 13)
       CUDA_CODES=("${CUDA_ARCHES[@]}")
-      CUDA_MINIMAL_DRIVER_VERSION=177.70 #~
       ;;
-    2.1*)
-      CUDA_ARCHES=(10 11 12 13)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
-      CUDA_MINIMAL_DRIVER_VERSION=180.22 #~
-      ;;
-    2.2*)
-      CUDA_ARCHES=(10 11 12 13)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
-      CUDA_MINIMAL_DRIVER_VERSION=185.18.14 #~
-      ;;
-    2.3*)
-      CUDA_ARCHES=(10 11 12 13)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
-      CUDA_MINIMAL_DRIVER_VERSION=190.53 #~
-      ;;
+
     3.0*)
       CUDA_ARCHES=(10 11 12 13 20)
       CUDA_CODES=("${CUDA_ARCHES[@]}")
-      CUDA_MINIMAL_DRIVER_VERSION=195.36.15
       ;;
     3.1*)
       CUDA_ARCHES=(10 11 12 13 20 30)
       CUDA_CODES=(10 11 12 13 20 21 22 23 30)
-      CUDA_MINIMAL_DRIVER_VERSION=256.40
       ;;
-    3.2*) # CUDA .16
+    3.2*|4.1*) # In 4.1, 22 and 23 were removed
       CUDA_ARCHES=(10 11 12 13 20)
       CUDA_CODES=(10 11 12 13 20 21)
-      CUDA_MINIMAL_DRIVER_VERSION=260.19.26
       ;;
-    4.0*) # CUDA .17
+    4.0*)
       CUDA_ARCHES=(10 11 12 13 20)
       CUDA_CODES=(10 11 12 13 20 21 22 23)
-      CUDA_MINIMAL_DRIVER_VERSION=270.41.19
       ;;
-    4.1*) # CUDA .28
-      CUDA_ARCHES=(10 11 12 13 20)
-      CUDA_CODES=(10 11 12 13 20 21)
-      CUDA_MINIMAL_DRIVER_VERSION=285.05.33
-      ;;
-    4.2*) # CUDA .9
+    4.2*)
       CUDA_ARCHES=(10 11 12 13 20 30)
       CUDA_CODES=(10 11 12 13 20 21 30)
-      CUDA_MINIMAL_DRIVER_VERSION=295.41
       ;;
-    5.0*) # CUDA .35
+
+    5.*)
       CUDA_ARCHES=(10 11 12 13 20 30 35)
       CUDA_CODES=(10 11 12 13 20 21 30 35)
-      CUDA_MINIMAL_DRIVER_VERSION=304
       ;;
-    5.5*) # .0, CUDA .22
-      CUDA_ARCHES=(10 11 12 13 20 30 35)
-      CUDA_CODES=(10 11 12 13 20 21 30 35)
-      CUDA_MINIMAL_DRIVER_VERSION=319
-      ;;
-    6.0*) # .1, CUDA .37
+
+    6.0*)
       CUDA_ARCHES=(10 11 12 13 20 30 32 35 50)
       CUDA_CODES=(10 11 12 13 20 21 30 32 35 50)
-      CUDA_MINIMAL_DRIVER_VERSION=331
       CUDA_DEPRECATED=(10)
       ;;
-    6.5*) # .12, CUDA .14
+    6.5*)
       CUDA_ARCHES=(11 12 13 20 30 32 35 37 50 52)
       CUDA_CODES=(11 12 13 20 21 30 32 35 37 50 52)
-      CUDA_MINIMAL_DRIVER_VERSION=340
       CUDA_DEPRECATED=(11 12 13)
       ;;
-    7.0*) # .27, CUDA .28
+
+    7.*)
       CUDA_ARCHES=(20 30 32 35 37 50 52 53)
       CUDA_CODES=(20 21 30 32 35 37 50 52 53)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=347.62
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=346.46
-      fi
       ;;
-    7.5*) # .17, CUDA .18
-      CUDA_ARCHES=(20 30 32 35 37 50 52 53)
-      CUDA_CODES=(20 21 30 32 35 37 50 52 53)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=353.66
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=352.31
-      fi
-      ;;
-    8.0.44)
+
+    8.*)
       CUDA_ARCHES=(20 30 32 35 37 50 52 53 60 61 62)
       CUDA_CODES=(20 21 30 32 35 37 50 52 53 60 61 62)
       CUDA_DEPRECATED=(20 21)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=369.30
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=367.48
-      fi
       ;;
-    8.0*) # .61 GA2
-      CUDA_ARCHES=(20 30 32 35 37 50 52 53 60 61 62)
-      CUDA_CODES=(20 21 30 32 35 37 50 52 53 60 61 62)
-      CUDA_DEPRECATED=(20 21)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=376.51
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=375.26
-      fi
-      ;;
-    9.0*) # .76 and RC2 .103 and 0.176 and maybe RC .69 [2]
+
+    9.0*)
       CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70)
       CUDA_CODES=("${CUDA_ARCHES[@]}")
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=385.54
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=384.81
-      fi
-      #https://devtalk.nvidia.com/default/topic/1023719/cuda-setup-and-installation/-solved-cuda-9-0rc-and-nvidia-384-69-but-driver-version-is-insufficient-for-cuda-runtime-version/
       ;;
-    9.1*) # .85
+    9.1*|9.2*)
       CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70 72)
       CUDA_CODES=("${CUDA_ARCHES[@]}")
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=391.29
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=390.46
-      fi
-      # https://devtalk.nvidia.com/default/topic/1028802/cuda-setup-and-installation/problems-with-cuda-9-1-in-ubuntu-16-04/
       ;;
-    9.2.88)
-      CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70 72)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=397.44
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=396.26
-      fi
-      ;;
-    9.2*) # .148 Update 1
-      CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70 72)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=398.26
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=396.37
-      fi
-      ;;
-    10.0*) #.130
-      CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70 72 75)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=411.31
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=410.48
-      fi
-      ;;
-    10.1*) #.105/.168 U1/.243 U2
-      CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70 72 75)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=418.96
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=418.39
-      fi
-      ;;
-    10.2*) #.89
+
+    10.2*)
       CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70 72 75)
       CUDA_CODES=("${CUDA_ARCHES[@]}")
       CUDA_DEPRECATED=(30 32 35 37 50)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=441.22
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=440.33
-      fi
+      ;;
+    10.*)
+      CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70 72 75)
+      CUDA_CODES=("${CUDA_ARCHES[@]}")
       ;;
 
-    # 11.0.194|11.0.207|11.0.2) # docs .207, CUDA .2 GA
-    # 11.0.221|11.0.228|11.0.3) # docs .228, CUDA .3 Update 1
-    # 11.0.189) # also 11.0.1 RC, there were multiple RCs
-    # RC 11.0.167 technically allowed sm/compute 30, but that didn't make it to release
-    11.0*) # all of 11.0
+    11.0*)
       CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80)
       CUDA_CODES=("${CUDA_ARCHES[@]}")
       CUDA_DEPRECATED=(35 37 50)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=451.22 # Actual min may be lower
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=450.36.06 # Actual min may be lower
-      fi
       ;;
-
-    # 11.1.74|11.1.0) # CUDA .0 GA
-    # 11.1*) # .105, CUDA .1 Update 1
-    # 11.2.67|11.2.0) # CUDA .0
-    # 11.2.142|11.2.1) # CUDA .1 Update 1
-    # 11.2*) # .152, CUDA .2 Update 2
-    # 11.3.58|11.3.0|11.3.109|11.3.1)
-    11.1*|11.2*|11.3*) # Nothing changed between 11.1.0 and 11.3.1
+    11.1*|11.2*|11.3*)
       CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
       CUDA_CODES=("${CUDA_ARCHES[@]}")
       CUDA_DEPRECATED=(35 37 50)
-
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=452.39
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=450.80.02
-      fi
       ;;
-
-    11.4*|11.5*|11.6*) # Nothing has changed between 11.4.0 and 11.6
+    11.4*)
       CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 87 86) # Added undocumented sm_87
       CUDA_CODES=("${CUDA_ARCHES[@]}")
       CUDA_LTOS=("${CUDA_ARCHES[@]}")
       CUDA_DEPRECATED=(35 37 50)
-
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=452.39
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=450.80.02
-      fi
       ;;
-
+    11.5*|11.6*|11.7*)
+      CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86 87)
+      CUDA_CODES=("${CUDA_ARCHES[@]}")
+      CUDA_LTOS=("${CUDA_ARCHES[@]}")
+      CUDA_DEPRECATED=(35 37 50)
+      ;;
+    11.8*)
+      CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86 87)
+      CUDA_CODES=("${CUDA_ARCHES[@]}")
+      CUDA_LTOS=("${CUDA_ARCHES[@]}")
+      CUDA_DEPRECATED=(35 37 50)
+      ;;
+      ;;
     # 11.7*) ?
     #   # run "strings `which nvcc` | grep compute_" (ARCHES) and "sm_" (CODES) and you'll get a complete list
     #   # The strings output typically has a "are deprecated and may be removed in a future release" message
@@ -598,6 +464,190 @@ function cuda_capabilities()
     #   # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
     #   # https://docs.nvidia.com/deploy/cuda-compatibility/index.html also shows the actual minimal versions
     #
+
+    *)
+      echo "CUDA Version ${CUDA_VERSION} is not programmed in here yet..." >&2
+      CUDA_ARCHES=()
+      CUDA_CODES=()
+      ;;
+  esac
+
+
+  # This seems to be updated regularly
+  # [1] https://stackoverflow.com/a/30820690/4166604
+  # [2] https://gist.github.com/ax3l/9489132
+  case "${1}" in
+    1.0*)
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=162.01 #~
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=100.14 #~
+      fi
+      ;;
+    1.1*)
+      CUDA_MINIMAL_DRIVER_VERSION=169.01
+      ;;
+    2.0*)
+      CUDA_MINIMAL_DRIVER_VERSION=177.70 #~
+      ;;
+    2.1*)
+      CUDA_MINIMAL_DRIVER_VERSION=180.22 #~
+      ;;
+    2.2*)
+      CUDA_MINIMAL_DRIVER_VERSION=185.18.14 #~
+      ;;
+    2.3*)
+      CUDA_MINIMAL_DRIVER_VERSION=190.53 #~
+      ;;
+    3.0*)
+      CUDA_MINIMAL_DRIVER_VERSION=195.36.15
+      ;;
+    3.1*)
+      CUDA_MINIMAL_DRIVER_VERSION=256.40
+      ;;
+    3.2*) # CUDA .16
+      CUDA_MINIMAL_DRIVER_VERSION=260.19.26
+      ;;
+    4.0*) # CUDA .17
+      CUDA_MINIMAL_DRIVER_VERSION=270.41.19
+      ;;
+    4.1*) # CUDA .28
+      CUDA_MINIMAL_DRIVER_VERSION=285.05.33
+      ;;
+    4.2*) # CUDA .9
+      CUDA_MINIMAL_DRIVER_VERSION=295.41
+      ;;
+    5.0*) # CUDA .35
+      CUDA_MINIMAL_DRIVER_VERSION=304
+      ;;
+    5.5*) # .0, CUDA .22
+      CUDA_MINIMAL_DRIVER_VERSION=319
+      ;;
+    6.0*) # .1, CUDA .37
+      CUDA_MINIMAL_DRIVER_VERSION=331
+      ;;
+    6.5*) # .12, CUDA .14
+      CUDA_MINIMAL_DRIVER_VERSION=340
+      ;;
+    7.0*) # .27, CUDA .28
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=347.62
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=346.46
+      fi
+      ;;
+    7.5*) # .17, CUDA .18
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=353.66
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=352.31
+      fi
+      ;;
+    8.0.44)
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=369.30
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=367.48
+      fi
+      ;;
+    8.0*) # .61 GA2
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=376.51
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=375.26
+      fi
+      ;;
+    9.0*) # .76 and RC2 .103 and 0.176 and maybe RC .69 [2]
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=385.54
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=384.81
+      fi
+      #https://devtalk.nvidia.com/default/topic/1023719/cuda-setup-and-installation/-solved-cuda-9-0rc-and-nvidia-384-69-but-driver-version-is-insufficient-for-cuda-runtime-version/
+      ;;
+    9.1*) # .85
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=391.29
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=390.46
+      fi
+      # https://devtalk.nvidia.com/default/topic/1028802/cuda-setup-and-installation/problems-with-cuda-9-1-in-ubuntu-16-04/
+      ;;
+    9.2.88)
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=397.44
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=396.26
+      fi
+      ;;
+    9.2*) # .148 Update 1
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=398.26
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=396.37
+      fi
+      ;;
+    10.0*) #.130
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=411.31
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=410.48
+      fi
+      ;;
+    10.1*) #.105/.168 U1/.243 U2
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=418.96
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=418.39
+      fi
+      ;;
+    10.2*) #.89
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=441.22
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=440.33
+      fi
+      ;;
+
+    # 11.0.194|11.0.207|11.0.2) # docs .207, CUDA .2 GA
+    # 11.0.221|11.0.228|11.0.3) # docs .228, CUDA .3 Update 1
+    # 11.0.189) # also 11.0.1 RC, there were multiple RCs
+    # RC 11.0.167 technically allowed sm/compute 30, but that didn't make it to release
+    11.0*)
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=451.22 # Actual min may be lower
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=450.36.06 # Actual min may be lower
+      fi
+      ;;
+
+    # 11.1.74|11.1.0) # CUDA .0 GA
+    # 11.1*) # .105, CUDA .1 Update 1
+    # 11.2.67|11.2.0) # CUDA .0
+    # 11.2.142|11.2.1) # CUDA .1 Update 1
+    # 11.2*) # .152, CUDA .2 Update 2
+    # 11.3.58|11.3.0|11.3.109|11.3.1)
+    11.1*|11.2*|11.3*)
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=452.39
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=450.80.02
+      fi
+      ;;
+
+    11.4*|11.5*|11.6*)
+      if [ "${OS-}" == "Windows_NT" ]; then
+        CUDA_MINIMAL_DRIVER_VERSION=452.39
+      else
+        CUDA_MINIMAL_DRIVER_VERSION=450.80.02
+      fi
+      ;;
+
+    # 11.7.1
+    # 11.7.0
+    # 11.8.0
+
+    # 11.7*) ?
     #   if [ "${OS-}" == "Windows_NT" ]; then
     #     CUDA_MINIMAL_DRIVER_VERSION=?
     #   else
@@ -607,8 +657,6 @@ function cuda_capabilities()
 
     *)
       echo "CUDA Version ${CUDA_VERSION} is not programmed in here yet..." >&2
-      CUDA_ARCHES=()
-      CUDA_CODES=()
       CUDA_MINIMAL_DRIVER_VERSION=0
       ;;
   esac

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -326,7 +326,9 @@ function discover_cuda_info()
 #
 # :Output: * :var:`cuda_info.bsh CUDA_ARCHES`
 #          * :var:`cuda_info.bsh CUDA_CODES`
-#          * :var:`cuda_info.bsh CUDA_MINIMAL_DRIVER_VERSION`
+#          * :var:`cuda_info.bsh CUDA_LTOS` - Starting in CUDA 11, Link Time Optimization architectures were added
+#          * :var:`cuda_info.bsh CUDA_MINIMAL_DRIVER_VERSION` - Minimal required Nvidia Driver needed to run this version of CUDA
+#          * :var:`cuda_info.bsh CUDA_COMPATIBLE_DRIVER_VERSION` - Starting in CUDA 10, you can install a ``cuda-compat`` packages to run a different CUDA library that runs on older drivers up to this version
 #          * :var:`cuda_info.bsh CUDA_DEPRECATED`
 #
 # Determine compiler capabilities for specific CDK
@@ -341,21 +343,19 @@ function cuda_capabilities()
 
   CUDA_DEPRECATED=()
   CUDA_LTOS=()
+  CUDA_CODES=()
 
   case "${1}" in
     1.*)
       CUDA_ARCHES=(10 11)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
       ;;
 
     2.*)
       CUDA_ARCHES=(10 11 12 13)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
       ;;
 
     3.0*)
       CUDA_ARCHES=(10 11 12 13 20)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
       ;;
     3.1*)
       CUDA_ARCHES=(10 11 12 13 20 30)
@@ -403,67 +403,54 @@ function cuda_capabilities()
 
     9.0*)
       CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
       ;;
-    9.1*|9.2*)
+    9.[1-2]*)
       CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70 72)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
       ;;
 
     10.2*)
       CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70 72 75)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
       CUDA_DEPRECATED=(30 32 35 37 50)
       ;;
     10.*)
       CUDA_ARCHES=(30 32 35 37 50 52 53 60 61 62 70 72 75)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
       ;;
 
+    # RC 11.0.167 technically allowed sm/compute 30, but that didn't make it to release
     11.0*)
       CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
       CUDA_DEPRECATED=(35 37 50)
       ;;
-    11.1*|11.2*|11.3*)
+    11.[1-3].*|11.[1-3]) # Do it this way in case there is 11.10
       CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
       CUDA_DEPRECATED=(35 37 50)
       ;;
     11.4*)
       CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 87 86) # Added undocumented sm_87
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
-      CUDA_LTOS=("${CUDA_ARCHES[@]}")
       CUDA_DEPRECATED=(35 37 50)
       ;;
-    11.5*|11.6*|11.7*)
+    11.[5-7]*)
       CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86 87)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
-      CUDA_LTOS=("${CUDA_ARCHES[@]}")
       CUDA_DEPRECATED=(35 37 50)
       ;;
     11.8*)
-      CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86 87)
-      CUDA_CODES=("${CUDA_ARCHES[@]}")
-      CUDA_LTOS=("${CUDA_ARCHES[@]}")
+      CUDA_ARCHES=(35 37 50 52 53 60 61 62 70 72 75 80 86 87 89 90)
       CUDA_DEPRECATED=(35 37 50)
       ;;
-      ;;
-    # 11.7*) ?
+
+    # 11.9*) ?
     #   # run "strings `which nvcc` | grep compute_" (ARCHES) and "sm_" (CODES) and you'll get a complete list
     #   # The strings output typically has a "are deprecated and may be removed in a future release" message
     #   #
     #   # strings `command -v nvcc` | \grep '^sm_' | sed 's|sm_||' | tr '\n' ' '; echo
     #   # strings `command -v nvcc` | \grep '^compute_' | sed 's|compute_||' | tr '\n' ' '; echo
+    #   # strings `command -v nvcc` | \grep '^lto_' | sed 's|compute_||' | tr '\n' ' '; echo
     #
     #   CUDA_ARCHES=(?)
-    #   CUDA_CODES=("${CUDA_ARCHES}")
+    #   CUDA_CODES=(?) # only if different, else skip this
+    #   CUDA_LTOS=(?) # only if different, else skip this
     #   # strings `command -v nvcc` | \grep '\(sm\|compute\).*deprecate'
     #   CUDA_DEPRECATED=(?)
-    #
-    #   # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
-    #   # https://docs.nvidia.com/deploy/cuda-compatibility/index.html also shows the actual minimal versions
-    #
 
     *)
       echo "CUDA Version ${CUDA_VERSION} is not programmed in here yet..." >&2
@@ -472,194 +459,219 @@ function cuda_capabilities()
       ;;
   esac
 
+  if [ "${#CUDA_CODES[@]}" = "0" ]; then
+    CUDA_CODES=("${CUDA_ARCHES[@]}")
+  fi
 
-  # This seems to be updated regularly
-  # [1] https://stackoverflow.com/a/30820690/4166604
-  # [2] https://gist.github.com/ax3l/9489132
+  # Starting in 11.0, lto architectures were added
+  if [[ ${1} = 11.* ]] && [ "${#CUDA_LTOS[@]}" = "0" ]; then
+    CUDA_LTOS=("${CUDA_ARCHES[@]}")
+  fi
+
+  local versions
+
   case "${1}" in
     1.0*)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=162.01 #~
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=100.14 #~
-      fi
+      versions=(100.14 162.01) #~
       ;;
     1.1*)
-      CUDA_MINIMAL_DRIVER_VERSION=169.01
+      versions=(169.01 169.01)
       ;;
     2.0*)
-      CUDA_MINIMAL_DRIVER_VERSION=177.70 #~
+      versions=(177.70 177.70) #~
       ;;
     2.1*)
-      CUDA_MINIMAL_DRIVER_VERSION=180.22 #~
+      versions=(180.22 180.22) #~
       ;;
     2.2*)
-      CUDA_MINIMAL_DRIVER_VERSION=185.18.14 #~
+      versions=(185.18.14 185.18.14) #~
       ;;
     2.3*)
-      CUDA_MINIMAL_DRIVER_VERSION=190.53 #~
+      versions=(190.53 190.53) #~
       ;;
     3.0*)
-      CUDA_MINIMAL_DRIVER_VERSION=195.36.15
+      versions=(195.36.15 195.36.15)
       ;;
     3.1*)
-      CUDA_MINIMAL_DRIVER_VERSION=256.40
+      versions=(256.40 256.40)
       ;;
     3.2*) # CUDA .16
-      CUDA_MINIMAL_DRIVER_VERSION=260.19.26
+      versions=(260.19.26 260.19.26)
       ;;
     4.0*) # CUDA .17
-      CUDA_MINIMAL_DRIVER_VERSION=270.41.19
+      versions=(270.41.19 270.41.19)
       ;;
     4.1*) # CUDA .28
-      CUDA_MINIMAL_DRIVER_VERSION=285.05.33
+      versions=(285.05.33 285.05.33)
       ;;
     4.2*) # CUDA .9
-      CUDA_MINIMAL_DRIVER_VERSION=295.41
+      versions=(295.41 295.41)
       ;;
     5.0*) # CUDA .35
-      CUDA_MINIMAL_DRIVER_VERSION=304
+      versions=(304 304)
       ;;
     5.5*) # .0, CUDA .22
-      CUDA_MINIMAL_DRIVER_VERSION=319
+      versions=(319 319)
       ;;
     6.0*) # .1, CUDA .37
-      CUDA_MINIMAL_DRIVER_VERSION=331
+      versions=(331 331)
       ;;
     6.5*) # .12, CUDA .14
-      CUDA_MINIMAL_DRIVER_VERSION=340
+      versions=(340 340)
       ;;
     7.0*) # .27, CUDA .28
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=347.62
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=346.46
-      fi
+      versions=(346.46 347.62)
       ;;
     7.5*) # .17, CUDA .18
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=353.66
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=352.31
-      fi
+      versions=(352.31 353.66)
       ;;
     8.0.44)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=369.30
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=367.48
-      fi
+      versions=(367.48 369.30)
       ;;
     8.0*) # .61 GA2
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=376.51
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=375.26
-      fi
+      versions=(375.26 376.51)
       ;;
     9.0*) # .76 and RC2 .103 and 0.176 and maybe RC .69 [2]
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=385.54
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=384.81
-      fi
+      versions=(384.81 385.54)
       #https://devtalk.nvidia.com/default/topic/1023719/cuda-setup-and-installation/-solved-cuda-9-0rc-and-nvidia-384-69-but-driver-version-is-insufficient-for-cuda-runtime-version/
       ;;
     9.1*) # .85
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=391.29
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=390.46
-      fi
+      versions=(390.46 391.29)
       # https://devtalk.nvidia.com/default/topic/1028802/cuda-setup-and-installation/problems-with-cuda-9-1-in-ubuntu-16-04/
       ;;
     9.2.88)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=397.44
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=396.26
-      fi
+      versions=(396.26 397.44)
       ;;
     9.2*) # .148 Update 1
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=398.26
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=396.37
-      fi
+      versions=(396.37 398.26)
       ;;
     10.0*) #.130
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=411.31
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=410.48
-      fi
+      versions=(410.48 411.31)
       ;;
     10.1*) #.105/.168 U1/.243 U2
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=418.96
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=418.39
-      fi
+      versions=(418.39 418.96)
       ;;
     10.2*) #.89
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=441.22
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=440.33
-      fi
+      versions=(440.33 441.22)
       ;;
 
-    # 11.0.194|11.0.207|11.0.2) # docs .207, CUDA .2 GA
-    # 11.0.221|11.0.228|11.0.3) # docs .228, CUDA .3 Update 1
-    # 11.0.189) # also 11.0.1 RC, there were multiple RCs
-    # RC 11.0.167 technically allowed sm/compute 30, but that didn't make it to release
-    11.0*)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=451.22 # Actual min may be lower
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=450.36.06 # Actual min may be lower
-      fi
+    11.0.189|11.0.1) # there were multiple RCs, don't have all the info
+      versions=(450.36.06 451.22)
+      ;;
+    11.0.194|11.0.207|11.0.2) # docs .207, CUDA .2 GA
+      versions=(450.51.05 451.48)
+      ;;
+    11.0*) # .221, docs .228, CUDA .3 Update 1 + catch all for 11.0
+      versions=(450.51.06 451.82)
       ;;
 
-    # 11.1.74|11.1.0) # CUDA .0 GA
-    # 11.1*) # .105, CUDA .1 Update 1
-    # 11.2.67|11.2.0) # CUDA .0
-    # 11.2.142|11.2.1) # CUDA .1 Update 1
-    # 11.2*) # .152, CUDA .2 Update 2
-    # 11.3.58|11.3.0|11.3.109|11.3.1)
-    11.1*|11.2*|11.3*)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=452.39
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=450.80.02
-      fi
+    11.1.74|11.1.0) # CUDA .0 GA
+      versions=(455.23 456.38)
+      ;;
+    11.1*) # .105, CUDA .1 Update 1 + catch all
+      versions=(455.32 456.81)
       ;;
 
-    11.4*|11.5*|11.6*)
-      if [ "${OS-}" == "Windows_NT" ]; then
-        CUDA_MINIMAL_DRIVER_VERSION=452.39
-      else
-        CUDA_MINIMAL_DRIVER_VERSION=450.80.02
-      fi
+    11.2.67|11.2.0) # CUDA .0
+      versions=(460.27.03 460.82)
+      ;;
+    11.2.142|11.2.1) # CUDA .1 Update 1
+      versions=(460.32.03 461.09)
+      ;;
+    11.2*) # .152, CUDA .2 Update 2
+      versions=(460.32.03 461.33)
       ;;
 
-    # 11.7.1
-    # 11.7.0
-    # 11.8.0
+    # 11.3.58|11.3.0) # GA
+    # 11.3.109|11.3.1) # Update 1
+    11.3*)
+      versions=(465.19.0 465.89)
+      ;;
 
-    # 11.7*) ?
-    #   if [ "${OS-}" == "Windows_NT" ]; then
-    #     CUDA_MINIMAL_DRIVER_VERSION=?
-    #   else
-    #     CUDA_MINIMAL_DRIVER_VERSION=?
-    #   fi
+    11.4.0|11.4.48)
+      versions=(470.42.01 471.11)
+      ;;
+    11.4.1|11.4.100|11.4.2|11.4.120)
+      versions=(470.57.02 471.41)
+      ;;
+    # 11.4.3|11.4.152)
+    # 11.4.4|11.4.152)
+    11.4*)
+      versions=(470.57.2 472.50)
+      ;;
+
+    11.5.0|11.5.50)
+      versions=(495.29.05 496.04)
+      ;;
+    # 11.5.1|11.5.119)
+    # 11.5.2|11.5.119)
+    11.5*)
+      versions=(495.29.05 496.13)
+      ;;
+
+    11.6.0|11.6.55)
+      versions=(510.39.01 511.23)
+      ;;
+    # 11.6.1|11.6.112)
+    # 11.6.2|11.6.124)
+    11.6*)
+      versions=(510.47.03 511.65)
+      ;;
+
+    11.7.0|11.7.64)
+      versions=(515.43.04 516.01)
+      ;;
+    # 11.7.1|11.7.99)
+    11.7*)
+      versions=(515.48.07 516.31)
+      ;;
+
+    # 11.8.0|11.8.89)
+    11.8*)
+      versions=(520.61.05 522.06)
+      ;;
+
+    # 11.9*)
+    #   versions=(linux windows)
     #   ;;
+
+    # These seem to be updated regularly
+    # - https://stackoverflow.com/a/30820690/4166604
+    # - https://gist.github.com/ax3l/9489132
+    # - https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
+    # - https://docs.nvidia.com/deploy/cuda-compatibility/index.html also shows the minimal compatible versions
 
     *)
       echo "CUDA Version ${CUDA_VERSION} is not programmed in here yet..." >&2
-      CUDA_MINIMAL_DRIVER_VERSION=0
+      versions=(0 0)
       ;;
   esac
+
+  if [ "${OS-}" == "Windows_NT" ]; then
+    CUDA_MINIMAL_DRIVER_VERSION="${versions[1]}"
+  else
+    CUDA_MINIMAL_DRIVER_VERSION="${versions[0]}"
+  fi
+
+  versions=()
+
+  case "${1}" in
+    11.0*)
+      versions=(450.36.06 451.22) # Actual min may be lower
+      ;;
+    11.*) # 11.1-11.8
+      versions=(450.80.02 452.39)
+      ;;
+    # 12.*)
+  esac
+
+  if [ "${#versions[@]}" = "2" ]; then
+    if [ "${OS-}" == "Windows_NT" ]; then
+      CUDA_COMPATIBLE_DRIVER_VERSION="${versions[1]}"
+    else
+      CUDA_COMPATIBLE_DRIVER_VERSION="${versions[0]}"
+    fi
+  fi
 }
 
 #**

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -84,7 +84,7 @@ source "${VSI_COMMON_DIR}/linux/versions.bsh"
 #
 # Starting in CUDA 11, NVIDIA introduced Link Time Optimizations (``lto_``) architectures in addition to the already existing ``sm_`` and ``compute_``
 #
-# Separately compiled code may not have as high of performance as whole program code because of the inability to inline code across files. A way to still get optimal performance is to use link-time optimization
+# Separately compiled kernels may not have as high of performance as if they were compiled together with the rest of the executable code because of the inability to inline code across files. Link-time optimization is a way to recover that improved performance
 #
 # .. var:: CUDA_MINIMAL_DRIVER_VERSION
 #
@@ -92,7 +92,7 @@ source "${VSI_COMMON_DIR}/linux/versions.bsh"
 #
 # .. var:: CUDA_COMPATIBLE_DRIVER_VERSION
 #
-# Starting in CUDA 11, NVIDIA introduced a ``cuda-compat` package that can be installed on machines with older NVIDIA Drivers, for increased compatibility with these drivers. This is the minimum supported driver version that will handle the ``cuda-compat`` runtime.
+# Starting in CUDA 11, NVIDIA introduced a ``cuda-compat` package that can be installed on machines with older NVIDIA Drivers for increased compatibility with these drivers. This is the minimum supported driver version that will handle the ``cuda-compat`` runtime.
 #
 # .. var:: CUDA_DEPRECATED
 #
@@ -324,8 +324,9 @@ function discover_cuda_info()
     nvidia_docker_plugin_cuda_capability
   else
     echo "deviceQuery not found and nvidia-docker v1 plugin not running"
-    echo "deviceQuery can be downloaded from https://www.vsi-ri.com/bin/deviceQuery60"
+    echo "deviceQuery can be downloaded from https://www.vsi-ri.com/bin/deviceQuery"
     echo "or https://goo.gl/equvX3"
+    echo "(Use https://www.vsi-ri.com/bin/deviceQuery.exe for Windows)"
   fi
 }
 
@@ -336,9 +337,9 @@ function discover_cuda_info()
 #
 # :Output: * :var:`cuda_info.bsh CUDA_ARCHES`
 #          * :var:`cuda_info.bsh CUDA_CODES`
-#          * :var:`cuda_info.bsh CUDA_LTOS` - Starting in CUDA 11, Link Time Optimization architectures were added
-#          * :var:`cuda_info.bsh CUDA_MINIMAL_DRIVER_VERSION` - Minimal required Nvidia Driver needed to run this version of CUDA
-#          * :var:`cuda_info.bsh CUDA_COMPATIBLE_DRIVER_VERSION` - Starting in CUDA 10, you can install a ``cuda-compat`` packages to run a different CUDA library that runs on older drivers up to this version
+#          * :var:`cuda_info.bsh CUDA_LTOS` - Starting in CUDA 11, Link-Time Optimization architectures were added
+#          * :var:`cuda_info.bsh CUDA_MINIMAL_DRIVER_VERSION` - Minimal required NVIDIA Driver needed to run this version of CUDA
+#          * :var:`cuda_info.bsh CUDA_COMPATIBLE_DRIVER_VERSION` - Starting in CUDA 10, you can install a ``cuda-compat`` package that supports a different version of the CUDA library that runs on older drivers up to that version
 #          * :var:`cuda_info.bsh CUDA_DEPRECATED`
 #
 # Determine compiler capabilities for specific CDK
@@ -505,95 +506,104 @@ function cuda_capabilities()
     3.1*)
       versions=(256.40 256.40)
       ;;
-    3.2*) # CUDA .16
+    3.2*) # Package Version 3.2.16
       versions=(260.19.26 260.19.26)
       ;;
-    4.0*) # CUDA .17
+    4.0*) # Package Version 4.0.17
       versions=(270.41.19 270.41.19)
       ;;
-    4.1*) # CUDA .28
+    4.1*) # Package Version 4.1.28
       versions=(285.05.33 285.05.33)
       ;;
-    4.2*) # CUDA .9
+    4.2*) # Package Version 4.2.9
       versions=(295.41 295.41)
       ;;
-    5.0*) # CUDA .35
+    5.0*) # Package Version 5.0.35
       versions=(304 304)
       ;;
-    5.5*) # .0, CUDA .22
+    5.5*) # CUDA Version 5.5.0, Package Version 5.5.22
       versions=(319 319)
       ;;
-    6.0*) # .1, CUDA .37
+    6.0*) # CUDA Version 6.0.1, Package Version 6.0.37
       versions=(331 331)
       ;;
-    6.5*) # .12, CUDA .14
+    6.5*) # CUDA Version 6.5.12, Package Version 6.5.14
       versions=(340 340)
       ;;
-    7.0*) # .27, CUDA .28
+    7.0*) # CUDA Version 7.0.27, Package Version 7.0.28
       versions=(346.46 347.62)
       ;;
-    7.5*) # .17, CUDA .18
+    7.5*) # CUDA Version 7.5.17, Package Version 7.5.18
       versions=(352.31 353.66)
       ;;
     8.0.44)
       versions=(367.48 369.30)
       ;;
-    8.0*) # .61 GA2
+    8.0*) # 8.0.61 GA2
       versions=(375.26 376.51)
       ;;
-    9.0*) # .76 and RC2 .103 and 0.176 and maybe RC .69 [2]
+    9.0*) # 9.0.76 and RC2 9.0.103 and 9.0.176 and maybe RC 9.0.69 [2]
       versions=(384.81 385.54)
-      #https://devtalk.nvidia.com/default/topic/1023719/cuda-setup-and-installation/-solved-cuda-9-0rc-and-nvidia-384-69-but-driver-version-is-insufficient-for-cuda-runtime-version/
+      # https://devtalk.nvidia.com/default/topic/1023719/cuda-setup-and-installation/-solved-cuda-9-0rc-and-nvidia-384-69-but-driver-version-is-insufficient-for-cuda-runtime-version/
       ;;
-    9.1*) # .85
+    9.1*) # 9.1.85
       versions=(390.46 391.29)
       # https://devtalk.nvidia.com/default/topic/1028802/cuda-setup-and-installation/problems-with-cuda-9-1-in-ubuntu-16-04/
       ;;
     9.2.88)
       versions=(396.26 397.44)
       ;;
-    9.2*) # .148 Update 1
+    9.2*) # 9.2.148 Update 1
       versions=(396.37 398.26)
       ;;
-    10.0*) #.130
+    10.0*) #10.0.130
       versions=(410.48 411.31)
       ;;
-    10.1*) #.105/.168 U1/.243 U2
+    10.1*) #10.1.105/10.1.168 U1/10.1.243 U2
       versions=(418.39 418.96)
       ;;
-    10.2*) #.89
+    10.2*) #10.2.89
       versions=(440.33 441.22)
       ;;
 
-    11.0.189|11.0.1) # there were multiple RCs, don't have all the info
+    # Starting in CUDA 11, the "CUDA Version" and the component versions are no
+    # longer the same, so that each component no longer needs to be updated when
+    # nothing changes. However, this now means it's more complicated to match
+    # the version number coming out of nvcc with the version of CUDA.
+    # In General these case targets are "CUDA Version|nvcc version)"
+
+    11.0.1|11.0.189) # there were multiple RCs, don't have all the info
       versions=(450.36.06 451.22)
       ;;
-    11.0.194|11.0.207|11.0.2) # docs .207, CUDA .2 GA
+    11.0.2|11.0.194|11.0.207) # GA, docs inconsistently say 11.0.207
       versions=(450.51.05 451.48)
       ;;
-    11.0*) # .221, docs .228, CUDA .3 Update 1 + catch all for 11.0
+    # 11.0.3|11.0.221|11.0.228) # Update 1, docs say 11.0.228
+    11.0*)
       versions=(450.51.06 451.82)
       ;;
 
-    11.1.74|11.1.0) # CUDA .0 GA
+    11.1.0|11.1.74) # GA
       versions=(455.23 456.38)
       ;;
-    11.1*) # .105, CUDA .1 Update 1 + catch all
+    # 11.1.1|11.1.105) Update 1
+    11.1.*|11.1)
       versions=(455.32 456.81)
       ;;
 
-    11.2.67|11.2.0) # CUDA .0
+    11.2.0|11.2.67)
       versions=(460.27.03 460.82)
       ;;
-    11.2.142|11.2.1) # CUDA .1 Update 1
+    11.2.1|11.2.142) # Update 1
       versions=(460.32.03 461.09)
       ;;
-    11.2*) # .152, CUDA .2 Update 2
+    # 11.2.2|11.2.152) # Update 2
+    11.2*)
       versions=(460.32.03 461.33)
       ;;
 
-    # 11.3.58|11.3.0) # GA
-    # 11.3.109|11.3.1) # Update 1
+    # 11.3.0|11.3.58) # GA
+    # 11.3.1|11.3.109) # Update 1
     11.3*)
       versions=(465.19.0 465.89)
       ;;

--- a/linux/just_files/just_functions.bsh
+++ b/linux/just_files/just_functions.bsh
@@ -790,7 +790,7 @@ function is_powershell()
 #
 # Check to see if a tty is missing. Normal tty checks do not work in mintty, as the pts appears to be a tty to native apps, but external apps will see a pipe. Checking to see if stdin has a name of "None" will tell us if we don't have a piped stdin.
 #
-# Calling this function is an expensive operation, and takes roughtly 1-2 seconds (to call a new powershell). Setting JUST_IS_TTY to 1 will cause the function to return false instantly.
+# Calling this function is an expensive operation, and takes roughly 1-2 seconds (to call a new powershell). Setting JUST_IS_TTY to 1 will cause the function to return false instantly.
 #
 # :Parameters: [``JUST_IS_TTY``] - If set to `1``, need_tty automatically returns 1. If set to ``0``, then :func:`need_tty` will automatically returns 0 once.
 #
@@ -800,7 +800,7 @@ function is_powershell()
 #
 #     : ${JUST_IS_TTY=0}
 #
-# This way it is triggered only once, instead of everytime ``local.env`` is source, which can be quite frequently.
+# This way it is triggered only once, instead of every time ``local.env`` is source, which can be quite frequently.
 #
 # One use case for this is "ssh from linux into windows, start git bash, . setup.env, and then run python". This will detect a fake tty name, because it is piped. However, you still need a tty because in python up and down will not work. I do not know why in this case...
 #

--- a/tests/test-cuda_info.bsh
+++ b/tests/test-cuda_info.bsh
@@ -310,8 +310,8 @@ begin_test "Cuda 11.8 test"
   assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0 9.0+PTX"
 
   if [ "${OS-}" = "Windows_NT" ]; then
-    assert_str_eq "${CUDA_MINIMAL_DRIVER_VERSION}" 452.39
-    assert_str_eq "${CUDA_COMPATIBLE_DRIVER_VERSION}" 522.06
+    assert_str_eq "${CUDA_MINIMAL_DRIVER_VERSION}" 522.06
+    assert_str_eq "${CUDA_COMPATIBLE_DRIVER_VERSION}" 452.39
   else
     assert_str_eq "${CUDA_MINIMAL_DRIVER_VERSION}" 520.61.05
     assert_str_eq "${CUDA_COMPATIBLE_DRIVER_VERSION}" 450.80.02

--- a/tests/test-cuda_info.bsh
+++ b/tests/test-cuda_info.bsh
@@ -236,10 +236,18 @@ begin_test "Cuda 7.5 test"
   # Test it
   assert_array_values CUDA_ARCHES 20 30 32 35 37 50 52 53
   assert_array_values CUDA_CODES 20 21 30 32 35 37 50 52 53
-  [ "${CUDA_VERSION}" = "7.5.01" ]
+  assert_str_eq "${CUDA_VERSION}" "7.5.01"
   assert_array_values CUDA_SUGGESTED_ARCHES 30 35 52
   assert_array_values CUDA_SUGGESTED_CODES 30 35 52
-  [ "$(cmake_cuda_flags)" = "3.0 3.5 5.2 5.3+PTX" ]
+  assert_str_eq "$(cmake_cuda_flags)" "3.0 3.5 5.2 5.3+PTX"
+
+  if [ "${OS-}" = "Windows_NT" ]; then
+    assert_str_eq "${CUDA_MINIMAL_DRIVER_VERSION}" 353.66
+  else
+    assert_str_eq "${CUDA_MINIMAL_DRIVER_VERSION}" 352.31
+  fi
+
+  assert_unset CUDA_COMPATIBLE_DRIVER_VERSION
 )
 end_test
 
@@ -258,14 +266,56 @@ begin_test "Cuda 9 test"
   # Test it
   assert_array_values CUDA_ARCHES 30 32 35 37 50 52 53 60 61 62 70
   assert_array_values CUDA_CODES 30 32 35 37 50 52 53 60 61 62 70
-  [ "${CUDA_VERSION}" = "9.0.01" ]
+  assert_str_eq "${CUDA_VERSION}" "9.0.01"
   assert_array_values CUDA_SUGGESTED_ARCHES 37 52 70
   assert_array_values CUDA_SUGGESTED_CODES 37 52 70
-  [ "$(cmake_cuda_flags)" = "3.7 5.2 7.0" ]
+  assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0"
 
   # Test the future flag
   CUDA_SUGGESTED_PTX+=(${CUDA_SUGGESTED_PTX+"${CUDA_SUGGESTED_PTX[@]}"} "${CUDA_FORWARD_PTX}")
-  [ "$(cmake_cuda_flags)" = "3.7 5.2 7.0 7.0+PTX" ]
+  assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0 7.0+PTX"
+
+  if [ "${OS-}" = "Windows_NT" ]; then
+    assert_str_eq "${CUDA_MINIMAL_DRIVER_VERSION}" 385.54
+  else
+    assert_str_eq "${CUDA_MINIMAL_DRIVER_VERSION}" 384.81
+  fi
+
+  assert_unset CUDA_COMPATIBLE_DRIVER_VERSION
+)
+end_test
+
+begin_test "Cuda 11.8 test"
+(
+  setup_test
+
+  # Setup
+  CUDA_VERSION=11.8.89
+  CUDA_CARD_ARCHES=(37 52 70)
+
+  # Run code
+  cuda_capabilities "${CUDA_VERSION}"
+  suggested_architectures
+
+  # Test it
+  assert_array_values CUDA_ARCHES 35 37 50 52 53 60 61 62 70 72 75 80 86 87 89 90
+  assert_array_values CUDA_CODES 35 37 50 52 53 60 61 62 70 72 75 80 86 87 89 90
+  assert_str_eq "${CUDA_VERSION}" "11.8.89"
+  assert_array_values CUDA_SUGGESTED_ARCHES 37 52 70
+  assert_array_values CUDA_SUGGESTED_CODES 37 52 70
+  assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0"
+
+  # Test the future flag
+  CUDA_SUGGESTED_PTX+=(${CUDA_SUGGESTED_PTX+"${CUDA_SUGGESTED_PTX[@]}"} "${CUDA_FORWARD_PTX}")
+  assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0 9.0+PTX"
+
+  if [ "${OS-}" = "Windows_NT" ]; then
+    assert_str_eq "${CUDA_MINIMAL_DRIVER_VERSION}" 452.39
+    assert_str_eq "${CUDA_COMPATIBLE_DRIVER_VERSION}" 522.06
+  else
+    assert_str_eq "${CUDA_MINIMAL_DRIVER_VERSION}" 520.61.05
+    assert_str_eq "${CUDA_COMPATIBLE_DRIVER_VERSION}" 450.80.02
+  fi
 )
 end_test
 

--- a/tests/test-test_utils.bsh
+++ b/tests/test-test_utils.bsh
@@ -299,6 +299,79 @@ begin_test "Test associative array eq"
 )
 end_test
 
+begin_test "Test set/unset"
+(
+  setup_test
+
+  assert_unset foobar_not_defined
+  not assert_set foobar_not_defined
+
+  declare x=0
+  declare z=
+  declare y
+
+  assert_set x
+  assert_set z
+  assert_unset y
+  assert_unset w
+
+  not assert_unset x
+  if [ "${bash_bug_unassigned_variable_set_to_null}" = "1" ]; then
+    not assert_unset z
+    not assert_set y
+  fi
+  not assert_set w
+
+  a=(1 2 3)
+  assert_set a
+  assert_set a[0]
+  assert_set a[@]
+  not assert_unset a
+  not assert_unset a[0]
+  not assert_unset a[@]
+
+  a=("" 2 3)
+  assert_set a
+  assert_set a[0]
+  assert_set a[@]
+  if [ "${bash_bug_unassigned_variable_set_to_null}" = "1" ]; then
+    not assert_unset a
+    not assert_unset a[0]
+  fi
+  not assert_unset a[@]
+
+  unset a[0]
+  assert_unset a[0]
+  assert_set a[@]
+  not assert_set a[0]
+  not assert_unset a[@]
+
+  declare -a b
+  assert_unset b
+  assert_unset b[@]
+  not assert_set b
+  if [ "${bash_bug_unassigned_variable_set_to_null}" = "1" ]; then
+    not assert_set b[@]
+  fi
+
+  if [ "${bash_feature_associative_array}" = "0" ]; then
+    declare -A c=([a]=15)
+    assert_set c[a]
+    assert_unset c[b]
+    assert_set c[@]
+    not assert_unset c[a]
+    not assert_set c[b]
+    not assert_unset c[@]
+
+    declare -A d
+    assert_unset d
+    assert_unset d[@]
+    not assert_set d
+    not assert_set d[@]
+  fi
+)
+end_test
+
 begin_test "Test not"
 (
   setup_test

--- a/tests/test_utils.bsh
+++ b/tests/test_utils.bsh
@@ -3,6 +3,7 @@
 #*# tests/test_utils
 
 source "${VSI_COMMON_DIR}/linux/string_tools.bsh"
+source "${VSI_COMMON_DIR}/linux/compat.bsh"
 
 #**
 # ==============
@@ -408,6 +409,77 @@ function assert_regex_eq()
     echo "${ERR_C}ASSERT ERROR: regex eq${NC}" >&2
     echo         "======================" >&2
     echo "${INFO_C}FAILED:${NC} [[ ${1} =~ ${2} ]]" >&2
+    set -xv
+    return 1
+  fi
+}
+
+#**
+# .. function:: assert_set
+#
+# Asserts that a variable is set
+#
+# :Arguments: * ``$1`` - The variable name being checked
+#
+# .. rubric:: Example
+#
+# .. code-block:: bash
+#
+#   assert_unset a
+#   a=15
+#   assert_set a
+#   a =(11 22 33)
+#   assert_set a[0]
+#   assert_set a[@]
+#   unset a[0]
+#   assert_unset a[0]
+#   assert_set a[@]
+#
+# .. note::
+#   Checking ``assert_set a`` on an array is the same as ``a[0]``. So you should use ``a[@]`` instead
+#**
+function assert_set()
+{
+  set +xv
+  if [ " ""${!1+set}" != " " ]; then
+    set -xv
+    return 0
+  else
+    echo "${ERR_C}ASSERT ERROR: set${NC}" >&2
+    echo         "=================" >&2
+    echo "${INFO_C}FAILED:${NC} ${1} is not set" >&2
+    set -xv
+    return 1
+  fi
+}
+
+#**
+# .. function:: assert_unset
+#
+# Asserts that a variable is unset
+#
+# :Arguments: * ``$1`` - The variable name being checked
+#
+# .. note::
+#   On bash 3.2, an empty variable is indistinguishable from a null variable, so ``assert_unset`` will return true when it is null.
+#**
+function assert_unset()
+{
+  set +xv
+  # Handled [@] notation
+  if [ " ""${!1+set}" = " " ]; then
+    set -xv
+    return 0
+  # Even though this will allow for "assert_set" and "assert_unset" to be true
+  # at the same time, it's for the sake of bash 3.2 compatibility, and will
+  # only behave that way on bash 3.2
+  elif [ "${bash_bug_unassigned_variable_set_to_null}" = "0" -a "${!1-}" = "" ]; then
+    set -xv
+    return 0
+  else
+    echo "${ERR_C}ASSERT ERROR: unset${NC}" >&2
+    echo         "===================" >&2
+    echo "${INFO_C}FAILED:${NC} ${1} is set" >&2
     set -xv
     return 1
   fi


### PR DESCRIPTION
- Added up to CUDA 11.8
- Compatible and minimum drivers were mixed up for CUDA 11, they are now separated
- Refactored most of the cuda_info code to repeat the same information less, because CUDA is releasing new versions so frequently
- Added an assert_set and assert_unset to test_utils
