### PR TITLE
cuda query

### DIFF
--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -232,6 +232,54 @@ function device_query_cuda_capability()
 }
 
 #**
+# .. function:: nvidia_smi_cuda_capability
+#
+# :Output: * :var:`cuda_info.bsh CUDA_CARD_FAMILIES`
+#          * :var:`cuda_info.bsh CUDA_CARD_ARCHES`
+#          * :var:`cuda_info.bsh CUDA_CARDS`
+#
+# :Parameters: * ``NVIDIA_SMI`` - Optional path to a specific ``nvidia-smi``. Default: ``nvidia-smi`` (using the system path)
+#
+# :Return Value: * ``0`` - No errors
+#                * Non-zero - If the output of ``nvidia-smi`` does not contain any CUDA cards, then something likely failed.
+#**
+function nvidia_smi_cuda_capability()
+{
+  local card_info
+  card_info="$(${NVIDIA_SMI-nvidia-smi} --query-gpu=gpu_name,compute_cap --format=csv,noheader)" || return ${?}
+
+  local IFS=$'\n'
+  CUDA_CARDS=( $(echo "${card_info}" | \awk -F', ' '{print $1}') )
+
+  # remove dots from nvidia-smi architectures (e.g., "7.5"->"75")
+  CUDA_CARD_ARCHES=( $(echo "${card_info}" | \awk -F', ' '{print $2}' | \sed 's/\.//g') )
+  cuda_arch_to_cuda_family
+}
+
+#**
+# .. function:: wmic_cuda_capability
+#
+# :Output: * :var:`cuda_info.bsh CUDA_CARDS`
+#
+# :Parameters: * ``WMIC`` - Optional path to a specific ``wmic``. Default: ``wmic.exe`` (using the system path)
+#
+# :Return Value: * ``0`` - No errors
+#                * Non-zero - If the output of ``wmic.exe`` does not contain any CUDA cards, then something likely failed.
+#**
+function wmic_cuda_capability()
+{
+  local card_info
+  card_info="$(${WMIC-wmic.exe} PATH win32_VideoController GET AdapterCompatibility,Name /format:csv)"  || return ${?}
+
+  # replace all /r with /n
+  card_info=$(echo "${card_info}" | sed 's/\r/\n/g')
+
+  # line format is "Node,AdapterCompatibility,Name", e.g., "DUMMY,NVIDIA,NVIDIA GeForce GTX 1650 Ti"
+  local IFS=$'\n'
+  CUDA_CARDS=( $(echo "${card_info}" | \awk -F',' '$2=="NVIDIA" {print $3}') )
+}
+
+#**
 # .. function:: nvidia_docker_plugin_cuda_capability
 #
 # The deprecated nvidia-docker v1 API actually hosted GPU information, which was useful for determining the CUDA Arches. This is rarely used now.

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -234,6 +234,8 @@ function device_query_cuda_capability()
 #**
 # .. function:: nvidia_smi_cuda_capability
 #
+# Starting at NVIDIA Driver version >500, ``nvidia-smi`` provides the ``compute_cap`` query property. This function can be used to parse that.
+#
 # :Output: * :var:`cuda_info.bsh CUDA_CARD_FAMILIES`
 #          * :var:`cuda_info.bsh CUDA_CARD_ARCHES`
 #          * :var:`cuda_info.bsh CUDA_CARDS`
@@ -364,14 +366,18 @@ function discover_cuda_info()
 
   CUDA_CARD_FAMILIES=()
 
+  # Attempt to use ``nvidia-smi --query-gpus=compute_cap ...``
+  if nvidia_smi_cuda_capability &> /dev/null; then
+    :
   # Attempt to use deviceQuery
-  if command -v "${DEVICE_QUERY-deviceQuery}" &> /dev/null && device_query_cuda_capability; then
+  elif command -v "${DEVICE_QUERY-deviceQuery}" &> /dev/null && device_query_cuda_capability; then
     :
   # Else attempt to use the nvidia-docker daemon
   elif __nvidia_docker_is_running nvidia-docker-plugin || declare -p NV_HOST &> /dev/null; then
     nvidia_docker_plugin_cuda_capability
   else
-    echo "deviceQuery not found and nvidia-docker v1 plugin not running"
+    echo "nvidia-smi not available or does not have 'compute_cap' query, "
+    echo "deviceQuery not found, and nvidia-docker v1 plugin not running."
     echo "deviceQuery can be downloaded from https://www.vsi-ri.com/bin/deviceQuery"
     echo "or https://goo.gl/equvX3"
     echo "(Use https://www.vsi-ri.com/bin/deviceQuery.exe for Windows)"

--- a/tests/test-cuda_info.bsh
+++ b/tests/test-cuda_info.bsh
@@ -488,6 +488,7 @@ begin_test "Discover cuda info"
 (
   setup_test
 
+  NVIDIA_SMI=--error
   DEVICE_QUERY=--error
 
   function __nvidia_docker_is_running()
@@ -495,7 +496,7 @@ begin_test "Discover cuda info"
     return 1
   }
 
-  ans="deviceQuery not found and nvidia-docker v1 plugin not running"
+  ans="nvidia-smi not available or does not have"
   [[ $(discover_cuda_info) = ${ans}* ]] || false
 
   function __nvidia_docker_is_running()

--- a/tests/test-cuda_info.bsh
+++ b/tests/test-cuda_info.bsh
@@ -151,6 +151,12 @@ nvidia_smi_new='Wed Mar 17 19:10:41 2021
 |                               |                      |                  N/A |
 +-------------------------------+----------------------+----------------------+'
 
+# ``nvidia-smi --query-gpu=gpu_name,compute_cap --format=csv,noheader``
+nvidia_smi_query_string=$'TITAN X (Pascal), 6.1\nTITAN X (Pascal), 6.1\nNVIDIA GeForce GTX 1650 Ti, 7.5'
+
+# ``wmic.exe PATH win32_VideoController GET AdapterCompatibility,Name /format:csv``
+wmic_query_string=$'\r\r\nNode,AdapterCompatibility,Name\r\r\DUMMY,Intel Corporation,Intel(R) UHD Graphics\r\r\DUMMY,NVIDIA,NVIDIA GeForce GTX 1650 Ti\r\r'
+
 nvidia_docker_gpu_info='
 Driver version:          455.28
 Supported CUDA version:  11.1
@@ -376,6 +382,39 @@ begin_test "Use deviceQuery to get cuda version"
 
   assert_array_values CUDA_CARD_ARCHES 61 61 30
   assert_array_values CUDA_CARDS "TITAN X (Pascal)" "TITAN X (Pascal)" "Quadro K600"
+)
+end_test
+
+begin_test "Use nvidia-smi to get cuda capabilities"
+(
+  setup_test
+
+  function nvidia-smi() { return 1; }
+  not nvidia_smi_cuda_capability
+
+  function nvidia-smi2()
+  {
+    echo "${nvidia_smi_query_string}"
+  }
+  NVIDIA_SMI=nvidia-smi2 nvidia_smi_cuda_capability
+  assert_array_values CUDA_CARD_ARCHES 61 61 75
+  assert_array_values CUDA_CARDS "TITAN X (Pascal)" "TITAN X (Pascal)" "NVIDIA GeForce GTX 1650 Ti"
+)
+end_test
+
+begin_test "Use wmic to get cuda capabilities"
+(
+  setup_test
+
+  function wmic.exe() { return 1; }
+  not wmic_cuda_capability
+
+  function wmic2()
+  {
+    echo "${wmic_query_string}"
+  }
+  WMIC=wmic2 wmic_cuda_capability
+  assert_array_values CUDA_CARDS "NVIDIA GeForce GTX 1650 Ti"
 )
 end_test
 


### PR DESCRIPTION
CUDA card info (`CUDA_CARDS`, `CUDA_CARD_ARCHES`, & `CUDA_CARD_FAMILIES`) from `nvidia-smi` using the command
```
nvidia-smi --query-gpu=gpu_name,compute_cap --format=csv,noheader
```

CUDA card info (`CUDA_CARDS` only) from `wmic.exe` using the command
```
wmic.exe PATH win32_VideoController GET AdapterCompatibility,Name /format:csv
```