### PR TITLE
docker-compose nvidia gpus

### DIFF
--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -140,7 +140,7 @@ function _env_echo()
 #     * GPUs are identified via ``${1}_NVIDIA_DEVICE_INDICES``, a space-delimited string of GPU indices
 #     * GPU index ordering is as reported by ``nvidia-smi --list-gpus``
 #     * An empty or unset ``${1}_NVIDIA_DEVICE_INDICES`` results in no GPU support
-#     * Default indices can be obtained using :func:`nvidia_tools nvidia_device_indices`
+#     * Default indices can be obtained using :func:`nvidia_tools.bsh nvidia_device_indices`
 #
 # .. var:: COMPOSE_VERSION
 #

--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -137,9 +137,10 @@ function _env_echo()
 #   * NVIDIA GPU support can be added to the services listed in ``$2``...
 #
 #     * GPU support in docker-compose is specified in https://docs.docker.com/compose/gpu-support/
-#     * GPUs are identified via ``${1}_NVIDIA_INDICES``, a space-delimited string of GPU indices
+#     * GPUs are identified via ``${1}_NVIDIA_DEVICE_INDICES``, a space-delimited string of GPU indices
 #     * GPU index ordering is as reported by ``nvidia-smi --list-gpus``
-#     * An empty or unset ``${1}_NVIDIA_INDICES`` results in no GPU support
+#     * An empty or unset ``${1}_NVIDIA_DEVICE_INDICES`` results in no GPU support
+#     * Default indices can be obtained using :func:`nvidia_tools nvidia_device_indices`
 #
 # .. var:: COMPOSE_VERSION
 #
@@ -264,7 +265,7 @@ function generate_docker_compose_override()
   indirect_all="${volumes_name_all}[@]"
 
   # parse GPU info
-  nvidia_name="${JUST_PROJECT_PREFIX}_NVIDIA_INDICES"
+  nvidia_name="${JUST_PROJECT_PREFIX}_NVIDIA_DEVICE_INDICES"
   nvidia_indices="${!nvidia_name-}"
 
   echo "version: '${COMPOSE_VERSION-3.2}'"

--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -132,6 +132,15 @@ function _env_echo()
 #       * ``${1}_.*_DOCKER`` is copied exactly as is
 #       * ``${1}_.*`` is copied exactly as is if it exists
 #
+# * NVIDIA GPU features:
+#
+#   * NVIDIA GPU support can be added to the services listed in ``$2``...
+#
+#     * GPU support in docker-compose is specified in https://docs.docker.com/compose/gpu-support/
+#     * GPUs are identified via ``${1}_NVIDIA_INDICES``, a space-delimited string of GPU indices
+#     * GPU index ordering is as reported by ``nvidia-smi --list-gpus``
+#     * An empty or unset ``${1}_NVIDIA_INDICES`` results in no GPU support
+#
 # .. var:: COMPOSE_VERSION
 #
 #   :Default: ``3.2``
@@ -199,6 +208,10 @@ function generate_docker_compose_override()
   local enumerated_volumes
   local -i i=1
 
+  # nvidia gpu
+  local nvidia_name
+  local nvidia_indices
+
   # misc
   local host_mount_point
   local volume_host
@@ -249,6 +262,10 @@ function generate_docker_compose_override()
   # Indirect fun
   volumes_name_all="${JUST_PROJECT_PREFIX}_VOLUMES"
   indirect_all="${volumes_name_all}[@]"
+
+  # parse GPU info
+  nvidia_name="${JUST_PROJECT_PREFIX}_NVIDIA_INDICES"
+  nvidia_indices="${!nvidia_name-}"
 
   echo "version: '${COMPOSE_VERSION-3.2}'"
   echo "services:"
@@ -392,6 +409,20 @@ function generate_docker_compose_override()
     fi
 
     container_environment_override _env_echo
+
+    # GPU indices
+    # https://docs.docker.com/compose/gpu-support/
+    if [ -n "${nvidia_indices:+set}" ]; then
+      echo "    deploy:"
+      echo "      resources:"
+      echo "        reservations:"
+      echo "          devices:"
+      echo "            - capabilities: [gpu]"
+      echo "              driver: \"nvidia\""
+      echo "              device_ids:"
+      echo "              - \"${nvidia_indices// /, }\""
+    fi
+
   done
 
   ###################

--- a/linux/nvidia_tools.bsh
+++ b/linux/nvidia_tools.bsh
@@ -13,7 +13,7 @@ source "${VSI_COMMON_DIR}/linux/compat.bsh"
 source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 source "${VSI_COMMON_DIR}/linux/versions.bsh"
 
-#*# linux/cuda_info
+#*# linux/nvidia_tools
 
 #**
 # ============

--- a/tests/test-docker_compose_override.bsh
+++ b/tests/test-docker_compose_override.bsh
@@ -228,15 +228,16 @@ begin_test "Just docker compose dynamic nvidia"
   override="$(generate_docker_compose_override TEST test1)"
   assert_str_eq "${override}" "${ans}"
 
-  # TEST_NVIDIA_INDICES
+  # TEST_NVIDIA_DEVICE_INDICES
   indices="0 1 2 3"
   ans+=$(nvidia "${indices}")
-  override="$(TEST_NVIDIA_INDICES="${indices}" \
+  override="$(TEST_NVIDIA_DEVICE_INDICES="${indices}" \
               generate_docker_compose_override TEST test1)"
   assert_str_eq "${override}" "${ans}"
 
   # Ignores non-project variables
-  override="$(TEST_NVIDIA_INDICES="${indices}" TEST2_NVIDIA_INDICES="0 1" \
+  override="$(TEST_NVIDIA_DEVICE_INDICES="${indices}" \
+              TEST2_NVIDIA_DEVICE_INDICES="0 1" \
               generate_docker_compose_override TEST test1)"
   assert_str_eq "${override}" "${ans}"
 )
@@ -268,7 +269,7 @@ begin_test "Generate docker-compose override"
   TEST_VOLUMES+=("vol1:/test1")
   TEST_VOLUMES+=("vol2:/test2")
   TEST_VOLUMES+=("vol3:/test3:ro")
-  TEST_NVIDIA_INDICES="0 1 2 3"
+  TEST_NVIDIA_DEVICE_INDICES="0 1 2 3"
 
   override="$(generate_docker_compose_override TEST test1)"
 
@@ -287,7 +288,7 @@ begin_test "Generate docker-compose override"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
-  ans+="$(nvidia "${TEST_NVIDIA_INDICES}")"
+  ans+="$(nvidia "${TEST_NVIDIA_DEVICE_INDICES}")"
   ans+=$'\nvolumes:'
   ans+=$'\n  vol1:'
   ans+=$'\n  vol2:'
@@ -326,7 +327,7 @@ begin_test "Generate docker-compose override on nfs"
   TEST_VOLUMES+=("${TESTDIR}/a/c:/this is  a   test")
   TEST_VOLUMES+=("${TESTDIR}/a/d:/this is  a   test/subdir")
   TEST_VOLUMES+=("${TESTDIR}/b/a:/foo/bar")
-  TEST_NVIDIA_INDICES="0 1 2 3"
+  TEST_NVIDIA_DEVICE_INDICES="0 1 2 3"
 
   override="$(generate_docker_compose_override TEST test1)"
 
@@ -349,7 +350,7 @@ begin_test "Generate docker-compose override on nfs"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
-  ans+="$(nvidia "${TEST_NVIDIA_INDICES}")"
+  ans+="$(nvidia "${TEST_NVIDIA_DEVICE_INDICES}")"
 
   assert_str_eq "${override}" "${ans}"
 )

--- a/tests/test-docker_compose_override.bsh
+++ b/tests/test-docker_compose_override.bsh
@@ -43,6 +43,18 @@ function envi()
   echo $'\n'"      - ${1}"
 }
 
+function nvidia()
+{
+  echo $'\n'"    deploy:"
+  echo "      resources:"
+  echo "        reservations:"
+  echo "          devices:"
+  echo "            - capabilities: [gpu]"
+  echo "              driver: \"nvidia\""
+  echo "              device_ids:"
+  echo "              - \"${1// /, }\""
+}
+
 begin_test "Docker compose override variable substitution"
 (
   setup_test
@@ -207,6 +219,29 @@ begin_test "Just docker compose dynamic environment"
 )
 end_test
 
+begin_test "Just docker compose dynamic nvidia"
+(
+  setup_test
+
+  # Basic test
+  ans="$(head)$(service test1)"
+  override="$(generate_docker_compose_override TEST test1)"
+  assert_str_eq "${override}" "${ans}"
+
+  # TEST_NVIDIA_INDICES
+  indices="0 1 2 3"
+  ans+=$(nvidia "${indices}")
+  override="$(TEST_NVIDIA_INDICES="${indices}" \
+              generate_docker_compose_override TEST test1)"
+  assert_str_eq "${override}" "${ans}"
+
+  # Ignores non-project variables
+  override="$(TEST_NVIDIA_INDICES="${indices}" TEST2_NVIDIA_INDICES="0 1" \
+              generate_docker_compose_override TEST test1)"
+  assert_str_eq "${override}" "${ans}"
+)
+end_test
+
 linux_nfs="\
 Filesystem                       1K-blocks        Used   Available Use% Mounted on
 filetodata-2:/volume1/projects 23320723712 22239875584  1080729344  96%"
@@ -233,6 +268,7 @@ begin_test "Generate docker-compose override"
   TEST_VOLUMES+=("vol1:/test1")
   TEST_VOLUMES+=("vol2:/test2")
   TEST_VOLUMES+=("vol3:/test3:ro")
+  TEST_NVIDIA_INDICES="0 1 2 3"
 
   override="$(generate_docker_compose_override TEST test1)"
 
@@ -251,6 +287,7 @@ begin_test "Generate docker-compose override"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
+  ans+="$(nvidia "${TEST_NVIDIA_INDICES}")"
   ans+=$'\nvolumes:'
   ans+=$'\n  vol1:'
   ans+=$'\n  vol2:'
@@ -289,6 +326,7 @@ begin_test "Generate docker-compose override on nfs"
   TEST_VOLUMES+=("${TESTDIR}/a/c:/this is  a   test")
   TEST_VOLUMES+=("${TESTDIR}/a/d:/this is  a   test/subdir")
   TEST_VOLUMES+=("${TESTDIR}/b/a:/foo/bar")
+  TEST_NVIDIA_INDICES="0 1 2 3"
 
   override="$(generate_docker_compose_override TEST test1)"
 
@@ -311,6 +349,7 @@ begin_test "Generate docker-compose override on nfs"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
+  ans+="$(nvidia "${TEST_NVIDIA_INDICES}")"
 
   assert_str_eq "${override}" "${ans}"
 )


### PR DESCRIPTION
Add the `${JUST_PROJECT_PREFIX}_NVIDIA_DEVICE_INDICES` environment variable to auto-add NVIDIA GPU capabilities to a docker container via `docker_compose_override`.

- GPU support in docker-compose is specified in https://docs.docker.com/compose/gpu-support/
- GPUs are identified via `${JUST_PROJECT_PREFIX}_NVIDIA_DEVICE_INDICES`, a space-delimited string of GPU indices
- GPU index ordering is as reported by `nvidia-smi --list-gpus`
- An empty or unset environment variable results in no GPU support
- Default indices can be obtained using `nvidia_tools::nvidia_device_indices`