### PR TITLE
docker-compose nvidia capabilities

### DIFF
--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -137,10 +137,16 @@ function _env_echo()
 #   * NVIDIA GPU support can be added to the services listed in ``$2``...
 #
 #     * GPU support in docker-compose is specified in https://docs.docker.com/compose/gpu-support/
-#     * GPUs are identified via ``${1}_NVIDIA_DEVICE_INDICES``, a space-delimited string of GPU indices
-#     * GPU index ordering is as reported by ``nvidia-smi --list-gpus``
-#     * An empty or unset ``${1}_NVIDIA_DEVICE_INDICES`` results in no GPU support
-#     * Default indices can be obtained using :func:`nvidia_tools.bsh nvidia_device_indices`
+#     * ``${1}_NVIDIA_VISIBLE_DEVICES`` a space or comma delimited string controls which GPUs are mounted into the container
+#
+#       * GPU index ordering is as reported by ``nvidia-smi --list-gpus``
+#       * An empty or unset ``${1}_NVIDIA_VISIBLE_DEVICES`` results in no GPU support
+#       * A list of available indices can be obtained using :func:`nvidia_tools.bsh nvidia_device_indices`
+#
+#     * ``${1}_NVIDIA_DRIVER_CAPABILITIES`` a space or comma delimited string controls which driver libraries/binaries will be mounted inside the container
+#
+#       * Driver capabilities default to ``gpu`` as per the docker-compose specification
+#       * https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
 #
 # .. var:: COMPOSE_VERSION
 #
@@ -210,8 +216,10 @@ function generate_docker_compose_override()
   local -i i=1
 
   # nvidia gpu
-  local nvidia_name
-  local nvidia_indices
+  local nvidia_devices_name
+  local nvidia_devices
+  local nvidia_capabilities_name
+  local nvidia_capabilities
 
   # misc
   local host_mount_point
@@ -265,8 +273,10 @@ function generate_docker_compose_override()
   indirect_all="${volumes_name_all}[@]"
 
   # parse GPU info
-  nvidia_name="${JUST_PROJECT_PREFIX}_NVIDIA_DEVICE_INDICES"
-  nvidia_indices="${!nvidia_name-}"
+  nvidia_devices_name="${JUST_PROJECT_PREFIX}_NVIDIA_VISIBLE_DEVICES"
+  nvidia_devices="${!nvidia_devices_name-}"
+  nvidia_capabilities_name="${JUST_PROJECT_PREFIX}_NVIDIA_DRIVER_CAPABILITIES"
+  nvidia_capabilities="${!nvidia_capabilities_name:-gpu}"
 
   echo "version: '${COMPOSE_VERSION-3.2}'"
   echo "services:"
@@ -411,17 +421,16 @@ function generate_docker_compose_override()
 
     container_environment_override _env_echo
 
-    # GPU indices
+    # Add NVIDIA GPU devices
     # https://docs.docker.com/compose/gpu-support/
-    if [ -n "${nvidia_indices:+set}" ]; then
+    if [ -n "${nvidia_devices:+set}" ]; then
       echo "    deploy:"
       echo "      resources:"
       echo "        reservations:"
       echo "          devices:"
-      echo "            - capabilities: [gpu]"
-      echo "              driver: \"nvidia\""
-      echo "              device_ids:"
-      echo "              - \"${nvidia_indices// /, }\""
+      echo "            - driver: nvidia"
+      echo "              capabilities: [${nvidia_capabilities// /,}]"
+      echo "              device_ids: [\"${nvidia_devices// /,}\"]"
     fi
 
   done

--- a/tests/test-docker_compose_override.bsh
+++ b/tests/test-docker_compose_override.bsh
@@ -49,10 +49,9 @@ function nvidia()
   echo "      resources:"
   echo "        reservations:"
   echo "          devices:"
-  echo "            - capabilities: [gpu]"
-  echo "              driver: \"nvidia\""
-  echo "              device_ids:"
-  echo "              - \"${1// /, }\""
+  echo "            - driver: nvidia"
+  echo "              capabilities: [${2// /,}]"
+  echo "              device_ids: [\"${1// /,}\"]"
 }
 
 begin_test "Docker compose override variable substitution"
@@ -228,16 +227,20 @@ begin_test "Just docker compose dynamic nvidia"
   override="$(generate_docker_compose_override TEST test1)"
   assert_str_eq "${override}" "${ans}"
 
-  # TEST_NVIDIA_DEVICE_INDICES
+  # *_NVIDIA_VISIBLE_DEVICES & *_NVIDIA_DRIVER_CAPABILITIES
   indices="0 1 2 3"
-  ans+=$(nvidia "${indices}")
-  override="$(TEST_NVIDIA_DEVICE_INDICES="${indices}" \
+  capabilities="compute utility"
+  ans+=$(nvidia "${indices}" "${capabilities}")
+  override="$(TEST_NVIDIA_VISIBLE_DEVICES="${indices}" \
+              TEST_NVIDIA_DRIVER_CAPABILITIES="${capabilities}" \
               generate_docker_compose_override TEST test1)"
   assert_str_eq "${override}" "${ans}"
 
   # Ignores non-project variables
-  override="$(TEST_NVIDIA_DEVICE_INDICES="${indices}" \
-              TEST2_NVIDIA_DEVICE_INDICES="0 1" \
+  override="$(TEST_NVIDIA_VISIBLE_DEVICES="${indices}" \
+              TEST_NVIDIA_DRIVER_CAPABILITIES="${capabilities}" \
+              TEST2_NVIDIA_VISIBLE_DEVICES="0 1" \
+              TEST2_NVIDIA_DRIVER_CAPABILITIES="gpu" \
               generate_docker_compose_override TEST test1)"
   assert_str_eq "${override}" "${ans}"
 )
@@ -269,7 +272,8 @@ begin_test "Generate docker-compose override"
   TEST_VOLUMES+=("vol1:/test1")
   TEST_VOLUMES+=("vol2:/test2")
   TEST_VOLUMES+=("vol3:/test3:ro")
-  TEST_NVIDIA_DEVICE_INDICES="0 1 2 3"
+  TEST_NVIDIA_VISIBLE_DEVICES="0 1 2 3"
+  TEST_NVIDIA_DRIVER_CAPABILITIES="compute utility"
 
   override="$(generate_docker_compose_override TEST test1)"
 
@@ -288,7 +292,8 @@ begin_test "Generate docker-compose override"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
-  ans+="$(nvidia "${TEST_NVIDIA_DEVICE_INDICES}")"
+  ans+="$(nvidia "${TEST_NVIDIA_VISIBLE_DEVICES}" \
+                 "${TEST_NVIDIA_DRIVER_CAPABILITIES}")"
   ans+=$'\nvolumes:'
   ans+=$'\n  vol1:'
   ans+=$'\n  vol2:'
@@ -327,7 +332,8 @@ begin_test "Generate docker-compose override on nfs"
   TEST_VOLUMES+=("${TESTDIR}/a/c:/this is  a   test")
   TEST_VOLUMES+=("${TESTDIR}/a/d:/this is  a   test/subdir")
   TEST_VOLUMES+=("${TESTDIR}/b/a:/foo/bar")
-  TEST_NVIDIA_DEVICE_INDICES="0 1 2 3"
+  TEST_NVIDIA_VISIBLE_DEVICES="0 1 2 3"
+  TEST_NVIDIA_DRIVER_CAPABILITIES="compute utility"
 
   override="$(generate_docker_compose_override TEST test1)"
 
@@ -350,7 +356,8 @@ begin_test "Generate docker-compose override on nfs"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
-  ans+="$(nvidia "${TEST_NVIDIA_DEVICE_INDICES}")"
+  ans+="$(nvidia "${TEST_NVIDIA_VISIBLE_DEVICES}" \
+                 "${TEST_NVIDIA_DRIVER_CAPABILITIES}")"
 
   assert_str_eq "${override}" "${ans}"
 )

--- a/tests/test-docker_compose_override.bsh
+++ b/tests/test-docker_compose_override.bsh
@@ -225,7 +225,7 @@ begin_test "Just docker compose dynamic nvidia"
   # Basic test
   ans="$(head)$(service test1)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    ans+="$(envi "JUST_HOST_WINDOWS=1")"
+    ans+="$(environment)$(envi "JUST_HOST_WINDOWS=1")"
   fi
   override="$(generate_docker_compose_override TEST test1)"
   assert_str_eq "${override}" "${ans}"

--- a/tests/test-docker_compose_override.bsh
+++ b/tests/test-docker_compose_override.bsh
@@ -224,6 +224,9 @@ begin_test "Just docker compose dynamic nvidia"
 
   # Basic test
   ans="$(head)$(service test1)"
+  if [ "${OS-}" = "Windows_NT" ]; then
+    ans+="$(envi "JUST_HOST_WINDOWS=1")"
+  fi
   override="$(generate_docker_compose_override TEST test1)"
   assert_str_eq "${override}" "${ans}"
 


### PR DESCRIPTION
`docker_compose_override` use `*_NVIDIA_VISIBLE_DEVICES` and `*_NVIDIA_DRIVER_CAPABILITIES` to control docker-compose override for GPUs.  Related to PR #449.  Names mimic standard NVIDIA environment variables.