### PR TITLE
SPHINX_*_VERSION default

### DIFF
--- a/docker/vsi_common/docker-compose.yml
+++ b/docker/vsi_common/docker-compose.yml
@@ -17,9 +17,9 @@ services:
       context: .
       dockerfile: sphinx.Dockerfile
       args:
-        PYTHON_VERSION: ${SPHINX_PYTHON_VERSION}
-        PIPENV_VERSION: ${SPHINX_PIPENV_VERSION}
-        VIRTUALENV_VERSION: ${SPHINX_VIRTUALENV_VERSION}
+        PYTHON_VERSION: ${SPHINX_PYTHON_VERSION-}
+        PIPENV_VERSION: ${SPHINX_PIPENV_VERSION-}
+        VIRTUALENV_VERSION: ${SPHINX_VIRTUALENV_VERSION-}
     image: ${SPHINX_COMPILE_IMAGE-vsiri/sphinxdocs:compile}
     environment: &plugin_environment
       DOCKER_UID: ${UID_CONTAINER-1000}


### PR DESCRIPTION
add `-` to `SPHINX_*_VERSION` in docker-compose.yml to avoid "defaulting to blank string" warnings