### PR TITLE
Docker compose refactor

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -128,7 +128,8 @@ function caseify()
           ans="clear-linux-os - ${version}, clear-linux-os - ${version}, clear-linux-os - ${version} 0"
           ;;
         amazonlinux*)
-          ans="amzn - 2, centos - 2, rhel fedora - 2 0"
+          version=$(docker run --rm --entrypoint= "${image}" awk '{print $4}' /etc/amazon-linux-release)
+          ans="amzn - ${version}, fedora - ${version}, fedora - ${version} 0"
           ;;
         debian*)
           ans="debian - ${1##*:}, debian - ${1##*:}, debian - ${1##*:} 0"

--- a/Justfile
+++ b/Justfile
@@ -261,12 +261,12 @@ function caseify()
       extra_args=${#}
       ;;
     test_python) # Run python unit tests
-      Docker-compose run python3
-      # Docker-compose run python2
+      Docker compose run python3
+      # Docker compose run python2
       # python3 -B -m unittest discover -s "${VSI_COMMON_DIR}/python/vsi/test"
       ;;
     build_docker) # Build docker image
-      Docker-compose build
+      Docker compose build
       justify docker compose clean venv2 docker compose clean venv3
       justify _post_build_docker
       ;;
@@ -382,11 +382,11 @@ function caseify()
       docker_cp_image "${VSI_COMMON_DOCKER_REPO}:python3_test" "/venv/Pipfile3.lock" "${VSI_COMMON_DIR}/docker/tests/Pipfile3.lock"
       ;;
     run_wine) # Start a wine bash window
-      Docker-compose run -e USER_ID="${VSI_COMMON_UID}" wine ${@+"${@}"} || :
+      Docker compose run -e USER_ID="${VSI_COMMON_UID}" wine ${@+"${@}"} || :
       extra_args=${#}
       ;;
     run_wine-gui) # Start a wine bash window in gui mode
-      Docker-compose run -e USER_ID="${VSI_COMMON_UID}" wine_gui ${@+"${@}"}&
+      Docker compose run -e USER_ID="${VSI_COMMON_UID}" wine_gui ${@+"${@}"}&
       extra_args=${#}
       ;;
     test_wine) # Run unit tests using wine

--- a/Justfile
+++ b/Justfile
@@ -217,7 +217,7 @@ function caseify()
       ;;
 
     ci_load) # Load ci
-      justify docker-compose_ci-load "${VSI_COMMON_DIR}/docker-compose.yml" "bash_test_${1}"
+      justify docker compose ci-load "${VSI_COMMON_DIR}/docker-compose.yml" "bash_test_${1}"
       extra_args=1
       ;;
     test_int_appveyor) # Run integration tests for windows appveyor
@@ -267,7 +267,7 @@ function caseify()
       ;;
     build_docker) # Build docker image
       Docker-compose build
-      justify docker-compose clean venv2 docker-compose clean venv3
+      justify docker compose clean venv2 docker compose clean venv3
       justify _post_build_docker
       ;;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ volumes:
   wine_home:
   venv2:
     labels:
-      com.vsi.just.clean_setup: --wrap Docker-compose run python2 true
+      com.vsi.just.clean_setup: --wrap Docker compose run python2 true
   venv3:
     labels:
-      com.vsi.just.clean_setup: --wrap Docker-compose run python3 true
+      com.vsi.just.clean_setup: --wrap Docker compose run python3 true

--- a/docker/tests/bash_test.Dockerfile
+++ b/docker/tests/bash_test.Dockerfile
@@ -39,9 +39,9 @@ RUN apk add --no-cache \
     command -v xxd &> /dev/null || apk add --no-cache vim
 
 # Disable this check; it gets in the way of running tests locally on git 2.31.2 and newer
-RUN git config --global --add safe.directory '*'; \
+RUN git config --system --add safe.directory '*'; \
     # Fix for https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586
-    git config --global protocol.file.allow always
+    git config --system protocol.file.allow always
 
 ENV JUSTFILE=/vsi/docker/tests/bash_test.Justfile \
     JUST_SETTINGS=/vsi/vsi_common.env

--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -183,7 +183,7 @@ RUN if ! docker-compose --version; then \
 # # A statically linked curl will support tls3 on older OSes
 # ADD https://github.com/dtschan/curl-static/releases/download/v7.63.0/curl /opt/curl
 #
-#     # Docker-compose starting 1.20 is compiled using a glibc that is too new
+#     # docker-compose starting 1.20 is compiled using a glibc that is too new
 # RUN if ! docker-compose --version; then \
 #       # Finish setting up curl, cause most likely will need it.
 #       chmod 755 /opt/curl; \

--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -161,7 +161,7 @@ RUN shopt -s nullglob; for patch in /usr/local/share/just/container_build_patch/
 # used for a few images.
 # This is basically only needed for pre glibc 2.14
 RUN if ! docker-compose --version; then \
-      rm /usr/local/bin/docker-compose; \
+      rm /usr/local/bin/docker-compose /usr/local/libexec/docker/cli-plugins/docker-compose; \
       # Handle symlink dirs, grrr
       cd /opt/python; \
       for d in *; do \

--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -51,7 +51,7 @@ RUN set -euxv; \
              unzip curl; \
     elif command -v zypper; then \
       other='git curl'; \
-      if [ -f "/etc/os-release" ] && [[ $(source /etc/os-release; echo "${ID} ${VERSION}") = sles\ 11.* ]]; then \
+      if [ -f "/etc/os-release" ] && [[ $(source /etc/os-release; echo "${ID} ${VERSION-}") = sles\ 11.* ]]; then \
         zypper --gpg-auto-import-keys --non-interactive install -y \
                http://opensource.wandisco.com/suse/11/git/x86_64/wandisco-git-suse-release-11-1.noarch.rpm; \
         rpm --import http://opensource.wandisco.com/RPM-GPG-KEY-WANdisco; \
@@ -71,6 +71,8 @@ RUN set -euxv; \
              findutils \
              # xxd for unit tests
              vim \
+             # Huh, an OS removed awk
+             awk \
              ${other} ca-certificates\
              gzip tar unzip; \
     elif command -v apk; then \

--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -201,9 +201,9 @@ RUN if ! docker-compose --version; then \
 #     fi
 
 # Disable this check; it gets in the way of running tests locally on git 2.31.2 and newer
-RUN git config --global --add safe.directory '*'; \
+RUN git config --system --add safe.directory '*'; \
     # Fix for https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586
-    git config --global protocol.file.allow always
+    git config --system protocol.file.allow always
 
 ENV JUSTFILE=/vsi/Justfile
 

--- a/docs/just/plugins/index.rst
+++ b/docs/just/plugins/index.rst
@@ -89,7 +89,7 @@ Most vsi_common plugins have docker images to support them. This requires a few 
      {
        local id_project_cwd="${JUST_PROJECT_PREFIX}_CWD"
 
-       # Export variables for docker-compose file
+       # Export variables for docker compose file
        local EXAMPLE_COPY_VALUE="${JUST_PROJECT_PREFIX}_EXAMPLE_COPY_VALUE"
        export EXAMPLE_COPY_VALUE="${!EXAMPLE_COPY_VALUE:-${!id_project_cwd}}"
 

--- a/docs/style.rst
+++ b/docs/style.rst
@@ -294,4 +294,4 @@ Python
 J.U.S.T. Plugins
 ----------------
 
-* Just plugins that use docker-compose should specify the ``docker-compose.yml`` file with every command, to prevent unintended consequences in case the user sets ``COMPOSE_FILE``
+* Just plugins that use docker compose should specify the ``docker-compose.yml`` file with every command, to prevent unintended consequences in case the user sets ``COMPOSE_FILE``

--- a/linux/aliases.bsh
+++ b/linux/aliases.bsh
@@ -62,13 +62,14 @@ fi
 #**
 # .. var:: DOCKER_COMPOSE
 #
-# Name/path of docker-compose executable
+# Name/path of docker compose command
 #
-# :Default: ``docker-compose``
+# :Default: ``docker compose`` (note, this is a bash array by default)
 #**
 
-: ${DOCKER_COMPOSE=docker-compose}
-
+if ! declare -p "DOCKER_COMPOSE" &> /dev/null; then
+  DOCKER_COMPOSE=(docker compose)
+fi
 #**
 # .. var:: SINGULARITY
 #

--- a/linux/ci_load.py
+++ b/linux/ci_load.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+# DEPRECATED #
+
 import argparse
 import tempfile
 from subprocess import Popen, PIPE

--- a/linux/elements.bsh
+++ b/linux/elements.bsh
@@ -346,7 +346,7 @@ function add_element_pre_a()
 # .. function:: add_element_pre
 #
 # :Arguments: * ``$1`` - Name of string to be set
-#             * ``$2`` - String to be appended
+#             * ``$2`` - String to be prepended
 # :Parameters: [``IFS``] - IFS Separator used
 #
 # String version of :func:`add_element_post_a`

--- a/linux/just
+++ b/linux/just
@@ -215,7 +215,7 @@ source "${VSI_COMMON_DIR}/linux/bash_utils.bsh"
 #**
 # .. envvar:: JUST_USER_CWD
 #
-# Although :file:`just` does not have to be run from the just project's root directory, some commands (e.g., docker-compose, but also parts of ``just`` proper) expect to be run from the project's root directory. Typically, the :file:`Justfile` will ``cd`` from the current working directory to the project's root directory, as specified by ``${PROJECT_PREFIX}_CWD`` (thereafter the project's CWD). :envvar:`JUST_USER_CWD` tracks the working directory from which a ``just`` command was run.
+# Although :file:`just` does not have to be run from the just project's root directory, some commands (e.g., ``docker compose``, but also parts of ``just`` proper) expect to be run from the project's root directory. Typically, the :file:`Justfile` will ``cd`` from the current working directory to the project's root directory, as specified by ``${PROJECT_PREFIX}_CWD`` (thereafter the project's CWD). :envvar:`JUST_USER_CWD` tracks the working directory from which a ``just`` command was run.
 #**
 
 #**
@@ -314,8 +314,8 @@ fi
 #
 #     Call stack
 #     ----------
-#     993  _Docker-compose  /opt/projects/just/vsi_common/linux/just_files/docker_functions.bsh
-#     974  Docker-compose   /opt/projects/just/vsi_common/linux/just_files/docker_functions.bsh
+#     993  _Docker          /opt/projects/just/vsi_common/linux/just_files/docker_functions.bsh
+#     974  Docker           /opt/projects/just/vsi_common/linux/just_files/docker_functions.bsh
 #     120  caseify          /opt/projects/just/vsi_common/Justfile
 #     795  justify          /opt/projects/just/vsi_common/linux/just_files/just_functions.bsh
 #     281  main             /opt/projects/just/vsi_common/linux/just
@@ -330,5 +330,5 @@ fi
 #
 #     /opt/projects/just/vsi_common/Justfile: line 21: Returned 2
 #
-# Sometimes there are multiple stacks due to the way `bash` works. However the first one is usually the stack of interest. This stack printout says an error occurred in ``_Docker-compose`` line 993, and can be tracked down to ``Justfile`` line 120. In this case, a ``docker-compose`` command returned non-zero
+# Sometimes there are multiple stacks due to the way `bash` works. However the first one is usually the stack of interest. This stack printout says an error occurred in ``_Docker`` line 993, and can be tracked down to ``Justfile`` line 120. In this case, a ``docker`` command returned non-zero
 #**

--- a/linux/just_files/container_functions.bsh
+++ b/linux/just_files/container_functions.bsh
@@ -104,3 +104,38 @@ function translate_path()
   done
   echo "${__translate_paths_original_path}"
 }
+
+#**
+# .. function:: is_in_container
+#
+# Tests to see if you are currently in a container. Currently only supports:
+# - docker
+# - singularity
+# - podman
+#
+# :Return Value: - ``0`` - In a container
+#                - ``1`` - Not in a container
+#**
+function is_in_container()
+{
+  # Docker check, always works in docker
+  if [ -e /.dockerenv ]; then
+    return 0
+  # singularity check, always works in singularity
+  elif [ -d /.singularity.d ]; then
+    return 0
+  # Podman check, https://github.com/containers/podman/issues/3586#issuecomment-512896997
+  elif [ -e /run/.containerenv ]; then
+    return 0
+  # # Other OCI?
+  # else
+  #   # I feel like the most universal way is to check the / mount point or the mnt namespace.
+  #   # But I don't have a good test off hand to see if it's doesn't match. Examples include:
+  #   # overlay on / type overlay (rw,context="system_u:object_r:container_file_t:s0:c343,c672",relatime,lowerdir=/var/lib/containers/storage/overlay/l/MFXOI7UMIM6NIUIUTPTYP344IM,upperdir=/var/lib/containers/storage/overlay/67284897ca227b4d703704373ee54b623cef5e5219a598bc3780dc90663f5a43/diff,workdir=/var/lib/containers/storage/overlay/67284897ca227b4d703704373ee54b623cef5e5219a598bc3780dc90663f5a43/work,metacopy=on,volatile)
+  #   # overlay on / type overlay (ro,nodev,relatime,seclabel,lowerdir=/var/singularity/mnt/session/overlay-lowerdir:/var/singularity/mnt/session/rootfs)
+  #   # overlay on / type overlay (rw,relatime,seclabel,lowerdir=/var/lib/docker/overlay2/l/7SRMPIDVGTVQGPDQLA4LRIZ4XC:/var/lib/docker/overlay2/l/XHTAYJJXRUOX5LVDQY3YPBKZQH,upperdir=/var/lib/docker/overlay2/aae4df59b5e75200c1e4b4b533463d6f81d27f90fa82c19d6dc7c2159352299d/diff,workdir=/var/lib/docker/overlay2/aae4df59b5e75200c1e4b4b533463d6f81d27f90fa82c19d6dc7c2159352299d/work)
+  #   # But these are just overlayfs examples. There are other storage drivers, and I'd rather not write a test for each one individually.
+  fi
+
+  return 1
+}

--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -255,7 +255,7 @@ function generate_docker_compose_override()
 
   # If there is at least one config, then run docker compose config
   if [ "${#compose_config[@]}" -gt "0" ]; then
-    compose_config="$("${DOCKER_COMPOSE}" "${compose_config[@]}" config)"
+    compose_config="$("${DOCKER_COMPOSE[@]}" "${compose_config[@]}" config)"
   else
     # Else do not. This is a non-realistic scenario, but makes this more robust
     compose_config=""

--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -78,9 +78,9 @@ function _docker_compose_override_var_sub()
 # :Output: *stdout* - Yaml excerpt
 #          * ``new_environment`` - Value is **"1"** if :func:`_env_echo` has been called already
 #
-# Simple helper function for echoing environment variables in the ``docker-compose`` yaml file
+# Simple helper function for echoing environment variables in the ``docker-compose.yml`` file
 #
-# In docker-compose, the ``environment:`` section can only be added once, and can only be added if there is at least one environment variable set. In case there are none, nothing should be added. This helper only echoes ``environment:`` the first time it is called.
+# In docker compose, the ``environment:`` section can only be added once, and can only be added if there is at least one environment variable set. In case there are none, nothing should be added. This helper only echoes ``environment:`` the first time it is called.
 #**
 function _env_echo()
 {
@@ -96,9 +96,9 @@ function _env_echo()
 #
 # :Arguments: * **1** - Prefix used in many of the just features, such as ``${1}_.*_DOCKER/HOST`` variables, etc...
 #             * [**2 ...**] - List of services to process (see docker_compose_service_names)
-# :Output: *stdout* - The docker-compose override yaml file
+# :Output: *stdout* - The docker compose override yaml file
 #
-# Create a docker override yaml file and extend the current docker-compose configuration with:
+# Create a docker override yaml file and extend the current docker compose configuration with:
 #
 # * Volume features:
 #
@@ -136,7 +136,7 @@ function _env_echo()
 #
 #   * NVIDIA GPU support can be added to the services listed in ``$2``...
 #
-#     * GPU support in docker-compose is specified in https://docs.docker.com/compose/gpu-support/
+#     * GPU support in docker compose is specified in https://docs.docker.com/compose/gpu-support/
 #     * ``${1}_NVIDIA_VISIBLE_DEVICES`` a space or comma delimited string controls which GPUs are mounted into the container
 #
 #       * GPU index ordering is as reported by ``nvidia-smi --list-gpus``
@@ -145,7 +145,7 @@ function _env_echo()
 #
 #     * ``${1}_NVIDIA_DRIVER_CAPABILITIES`` a space or comma delimited string controls which driver libraries/binaries will be mounted inside the container
 #
-#       * Driver capabilities default to ``gpu`` as per the docker-compose specification
+#       * Driver capabilities default to ``gpu`` as per the docker compose specification
 #       * https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
 #
 # .. var:: COMPOSE_VERSION
@@ -181,7 +181,7 @@ function _env_echo()
 #   :Default: ``()``
 #   :Optional: True
 #
-# Array of docker-compose yaml files to parse for volumes
+# Array of docker compose yaml files to parse for volumes
 #
 # .. note::
 #
@@ -228,7 +228,7 @@ function generate_docker_compose_override()
   local volume_flags
   local compose_config
 
-  # parse-docker-compose-volumes/docker-compose-volumes vars
+  # parse_docker_compose_volumes/docker_compose_volumes vars
   local DOCKER_VOLUME_LINES
   local DOCKER_VOLUME_SOURCES
   local DOCKER_VOLUME_TARGETS
@@ -247,13 +247,13 @@ function generate_docker_compose_override()
   local OLD_IFS="${IFS}"
   local IFS="${IFS}"
 
-  # Run docker-compose config once for all files/services
+  # Run docker compose config once for all files/services
   compose_config=()
   for docker_compose_file in ${DOCKER_COMPOSE_FILES[@]+"${DOCKER_COMPOSE_FILES[@]}"}; do
     compose_config+=("-f" "${docker_compose_file}")
   done
 
-  # If there is at least one config, then run docker-compose config
+  # If there is at least one config, then run docker compose config
   if [ "${#compose_config[@]}" -gt "0" ]; then
     compose_config="$("${DOCKER_COMPOSE}" "${compose_config[@]}" config)"
   else
@@ -282,10 +282,10 @@ function generate_docker_compose_override()
   echo "services:"
   for service_index in "${!services_name[@]}"; do
     echo "  ${services_name[service_index]}:"
-    # In docker-compose v2, a service can't be empty or else it will say
+    # In docker compose v2, a service can't be empty or else it will say
     # "services.{name} must be a mapping". This limitation should only apply to
     # the final configuration. However this bug causes it to apply to each
-    # individual (override) file too. So clearly a docker-compose v2 bug
+    # individual (override) file too. So clearly a docker compose v2 bug
     echo "    x-bugfix:"
 
     # Clear list for this service
@@ -307,8 +307,8 @@ function generate_docker_compose_override()
     volumes_name="${JUST_PROJECT_PREFIX}_${services_upper[service_index]}_VOLUMES"
     indirect="${volumes_name}[@]"
 
-    parse-docker-compose-volumes ${services_name[service_index]} <<< "${compose_config}"
-    docker-compose-volumes
+    parse_docker_compose_volumes ${services_name[service_index]} <<< "${compose_config}"
+    docker_compose_volumes
 
     # Get internal volumes of service
     for volume in "${!DOCKER_VOLUME_SOURCES[@]}"; do
@@ -393,7 +393,7 @@ function generate_docker_compose_override()
       IFS="${OLD_IFS}"
     done
     # Remove duplicates (https://unix.stackexchange.com/q/159695) because
-    # docker-compose doesn't like them
+    # docker compose doesn't like them
     IFS=$'\n'
     over_volumes=($(awk '!count[$0]++' <<< "${over_volumes[*]+${over_volumes[*]}}"))
     if [ " ""${over_volumes[@]+set}" = " set" ]; then

--- a/linux/just_files/docker_functions.bsh
+++ b/linux/just_files/docker_functions.bsh
@@ -109,7 +109,7 @@ function is_internal_docker_volume()
 # :Return Value: * ``0`` if it is readonly
 #                * ``1`` it if is writeable (according to docker flags only)
 #
-# Checks to see if a volume string contains the read only attribute. Can be used both for the docker volume syntax and the docker-compose short volume syntax
+# Checks to see if a volume string contains the read only attribute. Can be used both for the docker volume syntax and the docker compose short volume syntax
 #
 # .. note::
 #
@@ -137,7 +137,7 @@ function is_readonly_docker_volume()
 # :Return Value: * ``0`` if it is readonly
 #                * ``1`` it if is writeable (according to docker flags only)
 #
-# Checks to see if a volume string contains the read only attribute. Can be used both for the docker-compose long volume syntax
+# Checks to see if a volume string contains the read only attribute. Can be used both for the docker compose long volume syntax
 #
 # .. note::
 #
@@ -145,8 +145,8 @@ function is_readonly_docker_volume()
 #
 # .. seealso::
 #
-#   docker-compose-volumes
-#     Parses docker-compose volumes and generates DOCKER_VOLUME_FLAGS
+#   docker_compose_volumes
+#     Parses docker compose volumes and generates DOCKER_VOLUME_FLAGS
 #**
 
 function is_readonly_docker_compose_long_volume()
@@ -356,7 +356,7 @@ function docker_parse_mount_string()
 #
 # .. rubric:: Usage
 #
-# Mainly for the docker and docker-compose CLI -v flags
+# Mainly for the docker and docker compose CLI -v flags
 #
 # .. rubric:: Bugs
 #
@@ -509,106 +509,21 @@ function _Docker()
 }
 
 ######################
-### docker-compose ###
+### docker compose ###
 ######################
 
 #**
-# .. function:: docker-compose-volumes-old
-#
-# :Arguments: * ``$1`` - Name of service of interest
-#          * [``$2``] - Prefix to volume names
-# :Output: ``DOCKER_VOLUME_FLAGS`` - Array of the docker flags, including necessary -v's
-#
-# Get volume flags from docker-compose config
-#
-# Reformats the output from docker-compose config to an array with -v flags
-# for use in passing to another docker or docker-compose run command.
-#
-# .. rubric:: Example
-# .. code-block:: bash
-#
-#  docker-compose.yml
-#    version: "3.2"
-#    services:
-#      nb:
-#        image : some_image
-#        volumes:
-#        - /tmp:/mnt
-#        - test:/opt
-#    volumes:
-#      test:
-#
-#  docker-compose-volumes-old nb test_prefix_ < <(docker-compose config)
-#  # Or
-#  # docker-compose-volumes-old nb <<< "$(docker-compose config)"
-#
-#  declare -p DOCKER_VOLUME_FLAGS
-#  > declare -a DOCKER_VOLUME_FLAGS='([0]="-v" [1]="/tmp:/mnt:rw" [2]="-v"
-#                                     [3]="test_prefix_test:/opt")'
-#
-# .. rubric:: Bugs
-#
-# Currently only works on volume short format
-#
-# .. note::
-#   Useful for working around docker/compose#4728
-#**
-
-function docker-compose-volumes-old()
-{
-  local PREFIX="${2-}"
-  local IFS=$'\n'
-  DOCKER_VOLUME_FLAGS=(\
-    $(sed -n${sed_flag_rE} \
-              '/^services:$/b services
-               d
-               :services
-               n
-               # Search for the service entry
-               /^  '"${1}"':$/b found
-               /^ /b services
-               d
-               :found
-               # Clear pattern buffer and read next line
-               n
-               # Read volumes: found
-               /^    volumes:/b volumes
-               # Search all of the service entry
-               /^    /b found
-               # Volumes were not found, give up
-               d
-               :volumes
-               # Read in a new line
-               n
-               # Match this new line for an indented(4) list
-               /^    -/{
-                 s|^    - ([^./])|    - '"${PREFIX}"'\1|
-                 # Add these lines to the hold buffer
-                 H
-                 # Repeat
-                 b volumes
-               }
-               # Switch the hold and pattern buffer
-               x
-               # Format indented list to look like docker flags
-            '$'s|\\n    - |\\\n-v\\\n|g''
-               #s|^\n|| # Remove the first blank line - Not needed with array magic
-               # Print out that pretty pattern!
-               p'))
-}
-
-#**
-# .. function:: parse-docker-compose-volumes
+# .. function:: parse_docker_compose_volumes
 #
 # :Arguments: * ``$1`` - Name of service of interest
 #             * [``$2``] - Prefix to volume names
 #
 # :Output: ``DOCKER_VOLUME_LINES`` - Array of the docker lines. Lines starting with an S represent the short format. Lines starting with an L represent the beginning of a long format entry. Subsequent lines starting with an l are the additional lines of the long format entry. Order matters when in this format.
 #
-# Get volume lines from docker-compose config
+# Get volume lines from docker compose config
 #
-# Parses the output from docker-compose config so that information about the
-# available mounts are ready to be used by docker-compose-volumes
+# Parses the output from docker compose config so that information about the
+# available mounts are ready to be used by docker_compose_volumes
 #
 # .. rubric:: Example
 #
@@ -628,9 +543,9 @@ function docker-compose-volumes-old()
 #    volumes:
 #      test:
 #
-#  parse-docker-compose-volumes nb test_prefix_ < <(docker-compose config)
+#  parse_docker_compose_volumes nb test_prefix_ < <(docker compose config)
 #  # Or
-#  # parse-docker-compose-volumes nb <<< "$(docker-compose config)"
+#  # parse_docker_compose_volumes nb <<< "$(docker compose config)"
 #
 #  declare -p DOCKER_VOLUME_LINES
 #  > declare -a DOCKER_VOLUME_LINES='([0]="S/tmp:/mnt" [1]="Ltype: bind"
@@ -643,10 +558,10 @@ function docker-compose-volumes-old()
 #   Supports both short and long format
 #
 # .. seealso::
-#   docker-compose-volumes
+#   docker_compose_volumes
 #**
 
-function parse-docker-compose-volumes()
+function parse_docker_compose_volumes()
 {
   local PREFIX="${2-}"
   local IFS=$'\n'
@@ -709,12 +624,12 @@ function parse-docker-compose-volumes()
 }
 
 #**
-# .. function:: docker-compose-list-internal-volumes
+# .. function:: docker_compose_list_internal_volumes
 #
 # :Input: **stdin** - Docker-compose yaml file
 # :Output: ``DOCKER_INTERNAL_VOLUMES`` - Array of the docker volumes
 #
-# Parses the output from ``docker-compose config`` to get the list of all internal volumes
+# Parses the output from ``docker compose config`` to get the list of all internal volumes
 #
 # .. rubric:: Example
 #
@@ -731,9 +646,9 @@ function parse-docker-compose-volumes()
 #      test:
 #      stuff:
 #
-#  docker-compose-list-internal-volumes < <(docker-compose config)
+#  docker_compose_list_internal_volumes < <(docker compose config)
 #  # Or
-#  # docker-compose-list-internal-volumes <<< "$(docker-compose config)"
+#  # docker_compose_list_internal_volumes <<< "$(docker compose config)"
 #
 #  declare -p DOCKER_INTERNAL_VOLUMES
 #  > declare -a DOCKER_INTERNAL_VOLUMES='([0]="test" [1]="stuff")'
@@ -742,7 +657,7 @@ function parse-docker-compose-volumes()
 #
 #    Both ``test`` and ``stuff`` will be returned, even though stuff is not used.
 #**
-function docker-compose-list-internal-volumes()
+function docker_compose_list_internal_volumes()
 {
   local IFS=$'\n'
   DOCKER_INTERNAL_VOLUMES=(\
@@ -768,7 +683,7 @@ function docker-compose-list-internal-volumes()
 }
 
 #**
-# .. function:: docker-compose-volumes
+# .. function:: docker_compose_volumes
 #
 # :Output: * ``DOCKER_VOLUME_SOURCES`` - List of sources
 #          * ``DOCKER_VOLUME_TARGETS`` - Corresponding list of targets
@@ -781,14 +696,14 @@ function docker-compose-list-internal-volumes()
 #
 # .. code-block:: bash
 #
-#   parse-docker-compose-volumes nb test_prefix_ < <(docker-compose config)
-#   docker-compose-volumes
+#   parse_docker_compose_volumes nb test_prefix_ < <(docker compose config)
+#   docker_compose_volumes
 #
 # .. seealso::
-#   parse-docker-compose-volumes
+#   parse_docker_compose_volumes
 #**
 
-function docker-compose-volumes()
+function docker_compose_volumes()
 {
   local volume_line
   DOCKER_VOLUME_SOURCES=()
@@ -843,17 +758,17 @@ function docker-compose-volumes()
 }
 
 #**
-# .. function:: parse-docker-compose
+# .. function:: parse_docker_compose
 #
-# :Arguments: ``$1``.. - Arguments to be sent to docker-compose command
-# :Parameters: [``JUST_DOCKER_COMPOSE_DIR``] - By default, the docker-compose files will initially be searched for in the ``JUSTFILE`` directory, and then up the parent dirs until / is hit. However, if you wish to the disable this behavior and start searching for a docker-compose file from the current directory where "just" is called, then set this var to an empty string. You can also set to a specific directory to start searching from within that directory.
-# :Output: * ``docker_compose_args`` - Arguments to docker-compose, before the docker-compose command (run, up, down, etc...)
+# :Arguments: ``$1``.. - Arguments to be sent to docker compose command
+# :Parameters: [``JUST_DOCKER_COMPOSE_DIR``] - By default, the docker compose files will initially be searched for in the ``JUSTFILE`` directory, and then up the parent dirs until / is hit. However, if you wish to the disable this behavior and start searching for a docker compose file from the current directory where "just" is called, then set this var to an empty string. You can also set to a specific directory to start searching from within that directory.
+# :Output: * ``docker_compose_args`` - Arguments to docker compose, before the docker compose command (run, up, down, etc...)
 #          * ``docker_compose_command`` - Docker compose command specified
 #          * ``docker_compose_command_args`` - Arguments for the specified command
 #          * ``docker_compose_files`` - Array of docker compose files that are used
 #          * ``docker_compose_project_name`` - Docker compose project name
 #
-# Parse docker-compose's arguments and pull out a few important pieces of
+# Parse docker compose's arguments and pull out a few important pieces of
 # information (See OUTPUT)
 #
 # .. rubric:: Usage
@@ -865,7 +780,7 @@ function docker-compose-volumes()
 #
 # .. code-block:: bash
 #
-#   docker-compose "${docker_compose_args[@]}" "${docker_compose_command}" \
+#   docker compose "${docker_compose_args[@]}" "${docker_compose_command}" \
 #                  "${docker_compose_command_args[@]}"
 #
 # .. rubric:: Example
@@ -890,11 +805,11 @@ function docker-compose-volumes()
 #   Because the -f argument overrides all other forms of choosing the compose
 #   file, the ``docker_compose_args`` are updated to use this notation instead of
 #   other methods that may be used. This will not change the behavior of the
-#   ``docker-compose`` command run, but will make adding additional compose files
+#   ``docker compose`` command run, but will make adding additional compose files
 #   a lot easier.
 #**
 
-function parse-docker-compose()
+function parse_docker_compose()
 {
   local compose_file
 
@@ -982,7 +897,7 @@ function parse-docker-compose()
     local file_matches
     # This is one of the few times the directory you are in matters. To create
     # an expected default behavior, switch to the JUSTFILE dir before searching
-    # for the docker-compose file.
+    # for the docker compose file.
     pushd "${JUST_DOCKER_COMPOSE_DIR-$(dirname "${JUSTFILE}")}" > /dev/null
       parent_find_files docker-compose.yml docker-compose.yaml
     popd > /dev/null
@@ -1021,9 +936,9 @@ function parse-docker-compose()
 #
 # :Output: *stdout* - IFS string
 #
-# Reproduce ``docker-compose`` logic for pathsep
+# Reproduce ``docker compose`` logic for pathsep
 #
-# ``docker-compose`` uses some logic to determine the IFS separator for splitting
+# ``docker compose`` uses some logic to determine the IFS separator for splitting
 # up the ``COMPOSE_FILE`` environment variable. This should return the exact same
 # result
 #
@@ -1051,16 +966,16 @@ function compose_path_separator()
 #**
 # .. function:: Docker-compose
 #
-# :Arguments: ``$1``.. - Arguments to be sent to docker-compose command
-# :Parameters: * ``DOCKER_COMPOSE_EXTRA_ARGS`` - Array of extra arguments inserted after ``docker-compose`` but before the docker subcommand
+# :Arguments: ``$1``.. - Arguments to be sent to docker compose command
+# :Parameters: * ``DOCKER_COMPOSE_EXTRA_ARGS`` - Array of extra arguments inserted after ``docker compose`` but before the docker subcommand
 #              * ``DOCKER_COMPOSE_EXTRA_{subcommand}_ARGS`` - Array of extra arguments inserted right after the docker subcommand
-#              * [``DOCKER_COMPOSE_AUTOREMOVE``] - Automatically add the --rm flag to ``docker-compose`` run commands when using the Docker-compose helper function. Default: 1
+#              * [``DOCKER_COMPOSE_AUTOREMOVE``] - Automatically add the --rm flag to ``docker compose`` run commands when using the Docker-compose helper function. Default: 1
 #              * ``DRYRUN``] - Optional variable inserted at the beginning of all docker commands. Useful for setting to "echo" or similar for dryrun mode
-# :Output: Runs docker-compose command
+# :Output: Runs docker compose command
 #
 # Helper function to execute (dryrun) the right command
 #
-# Instead of calling the ``docker-compose`` command directly, the ``Docker-compose``
+# Instead of calling the ``docker compose`` command directly, the ``Docker-compose``
 # command should be called instead (for all dryrun-able activities. Simple
 # commands like ps, etc. don't make as much sense to dryrun, as the reset of
 # the script will never be executed, thus rendering dryrun useless.)
@@ -1072,7 +987,13 @@ function compose_path_separator()
 # result in fifo buffers being left behind in /tmp
 #**
 
+# Backwards compatibility with just 0.2.x
 function Docker-compose()
+{
+  Docker_compose ${@+"${@}"}
+}
+
+function Docker_compose()
 {
   local docker_compose_args
   local docker_compose_command
@@ -1080,12 +1001,12 @@ function Docker-compose()
   local docker_compose_files
   local docker_compose_project_name
 
-  parse-docker-compose ${@+"${@}"}
+  parse_docker_compose ${@+"${@}"}
 
-  _Docker-compose
+  _Docker_compose
 }
 
-function _Docker-compose()
+function _Docker_compose()
 {
   local docker_compose_extra_command_args=()
   local cmd=(${DRYRUN} "${DOCKER_COMPOSE}")
@@ -1112,10 +1033,10 @@ function _Docker-compose()
 #**
 # .. function:: get_docker_compose_version
 #
-# :Arguments: ``$1``... - ``docker-compose`` yaml filenames
-# :Output: *stdout* - ``docker-compose`` version. Nothing if none are found
+# :Arguments: ``$1``... - ``docker compose`` yaml filenames
+# :Output: *stdout* - ``docker compose`` version. Nothing if none are found
 #
-# Returns the first ``docker-compose`` version found
+# Returns the first ``docker compose`` version found
 #**
 
 function get_docker_compose_version()
@@ -1152,7 +1073,7 @@ function get_docker_stage_names()
 #**
 # .. function:: get_dockerfile_from_compose
 #
-# :Arguments: - ``$1`` - docker-compose file
+# :Arguments: - ``$1`` - docker compose file
 #             - ``$2`` - Service name
 #             - [``$3``] - :file:`yarp` of compose file
 # :Output: *stdout* - The Dockerfile. Not guaranteed to be a full path
@@ -1192,7 +1113,7 @@ function get_dockerfile_from_compose()
 #**
 # .. function:: Just-docker-compose
 #
-# :Arguments: ``$1``... - Arguments to docker-compose
+# :Arguments: ``$1``... - Arguments to docker compose
 # :Parameters: * ``JUST_PROJECT_PREFIX`` - Typically, the project name that is prepended to all the variables. EXAMPLE would cover EXAMPLE_VARIABLE
 #              * [``COMPOSE_VERSION``] - The docker compose yaml version number is auto determined by parsing the existing files, and is used in the auto generated files. In order to bypass this, you can specify the version number manually using this variable.
 #
@@ -1203,14 +1124,14 @@ function get_dockerfile_from_compose()
 # last mile in getting docker started and setup with a predictable environment
 # user permissions, mounts (and more...)
 #
-# Creates a docker override yaml file and extends the current docker-compose
+# Creates a docker override yaml file and extends the current docker compose
 # configuration.
 #
 # See :func:`docker_compose_override generate_docker_compose_override` for more
 # information.
 #
 # Determines which docker compose yaml files to use by mimicking the
-# behavior of docker-compose, which includes querying the ``COMPOSE_FILE``
+# behavior of docker compose, which includes querying the ``COMPOSE_FILE``
 # environment variable or trying the default files.
 #
 # .. rubric:: Bugs
@@ -1222,7 +1143,7 @@ function get_dockerfile_from_compose()
 # Using this function with windows paths is not currently supported.
 #
 # You can not use process substitution for the docker-compose.yml file because
-# ``bash`` has to read it before docker-compose reads it. So this will not work:
+# ``bash`` has to read it before docker compose reads it. So this will not work:
 # Just-docker-compose -f <(echo "${compose_file}") run test
 # You have to use files.
 #
@@ -1249,9 +1170,9 @@ function Just-docker-compose()
 
   local override_file="$(mktemp)"
 
-  parse-docker-compose ${@+"${@}"}
+  parse_docker_compose ${@+"${@}"}
 
-  # 1. Get docker-compose version
+  # 1. Get docker compose version
   # Auto detect compose version (PURE BASH, WHAT?!)
   if [ -z "${COMPOSE_VERSION:+set}" ]; then
     COMPOSE_VERSION="$(get_docker_compose_version "${docker_compose_files[0]}")"
@@ -1292,14 +1213,14 @@ function Just-docker-compose()
 # .. function:: docker_service_running
 #
 # :Arguments: [``$1``...] - service names, if none are provided, all are used
-# :Parameters: ``COMPOSE_FILE`` - Colon delimited file listing docker-compose files to use
+# :Parameters: ``COMPOSE_FILE`` - Colon delimited file listing docker compose files to use
 # :Output: *stdout* - State of service running, Up/Exited/Creating/etc...
 # :Return Value: * ``0`` - Service found
 #                * ``1`` - Service not found
 #
 # Checks to see if a service is running
 #
-# Returns the state-status of any containers, using the docker-compose service
+# Returns the state-status of any containers, using the docker compose service
 # names.
 #**
 
@@ -1343,7 +1264,7 @@ function docker_compose_service_names()
            b services' "${1}"
 }
 
-# :Arguments: ``$1`` docker-compose filename or :file:`yarp` of compose file
+# :Arguments: ``$1`` docker compose filename or :file:`yarp` of compose file
 function docker_compose_service_names2()
 {
   local compose_yarp
@@ -1359,7 +1280,7 @@ function docker_compose_service_names2()
 #**
 # .. function:: docker_compose_sanitize_project_name
 #
-# :Arguments:  * ``$1`` - Directory name. Can also be any name really. But directory name is what docker-compose uses to come up with the project name
+# :Arguments:  * ``$1`` - Directory name. Can also be any name really. But directory name is what docker compose uses to come up with the project name
 #              * [``$2``] - Optionally specify a prefix (like a username) to assist in making a (user) specific project name
 #
 # .. rubric:: Example
@@ -1381,7 +1302,7 @@ function docker_compose_service_names2()
 # name. A docker compose project name can only have lowercase letters and
 # numbers. This function will reproduce that same functionality so that you
 # can have that value in ``bash``, with some added benefits (prefix) to truly take
-# control of your docker-compose experience.
+# control of your docker compose experience.
 #**
 
 function docker_compose_sanitize_project_name()

--- a/linux/just_files/docker_functions.bsh
+++ b/linux/just_files/docker_functions.bsh
@@ -437,14 +437,6 @@ function parse-docker()
 }
 
 #**
-# .. function:: Exec-Docker
-#
-# Version of Docker that ``exec``'s the command rather than call
-#**
-
-function Exec-Docker(){ DOCKER_EXEC=1 Docker "${@}";}
-
-#**
 # .. function:: Docker
 #
 # :Arguments: ``$1``.. - Arguments to be sent to docker command
@@ -468,6 +460,12 @@ function Exec-Docker(){ DOCKER_EXEC=1 Docker "${@}";}
 
 function Docker()
 {
+  if [ "${1-}" == "compose" ]; then
+    shift 1
+    Docker_compose ${@+"${@}"}
+    return ${?}
+  fi
+
   local docker_args
   local docker_command
   local docker_command_args
@@ -500,12 +498,8 @@ function _Docker()
       ${docker_extra_command_args[@]+"${docker_extra_command_args[@]}"}
       ${docker_command_args[@]+"${docker_command_args[@]}"})
 
-  if [ "${DOCKER_EXEC-}" == "" ] || [ "${DRYRUN}" != "" ]; then
-    "${cmd[0]}" "${cmd[@]:1}"
-    return ${?}
-  else
-    exec "${cmd[@]}"
-  fi
+  "${cmd[0]}" "${cmd[@]:1}"
+  return ${?}
 }
 
 ######################
@@ -626,7 +620,7 @@ function parse_docker_compose_volumes()
 #**
 # .. function:: docker_compose_list_internal_volumes
 #
-# :Input: **stdin** - Docker-compose yaml file
+# :Input: **stdin** - Docker compose yaml file
 # :Output: ``DOCKER_INTERNAL_VOLUMES`` - Array of the docker volumes
 #
 # Parses the output from ``docker compose config`` to get the list of all internal volumes
@@ -964,35 +958,23 @@ function compose_path_separator()
 }
 
 #**
-# .. function:: Docker-compose
+# .. function:: Docker_compose
 #
 # :Arguments: ``$1``.. - Arguments to be sent to docker compose command
 # :Parameters: * ``DOCKER_COMPOSE_EXTRA_ARGS`` - Array of extra arguments inserted after ``docker compose`` but before the docker subcommand
 #              * ``DOCKER_COMPOSE_EXTRA_{subcommand}_ARGS`` - Array of extra arguments inserted right after the docker subcommand
-#              * [``DOCKER_COMPOSE_AUTOREMOVE``] - Automatically add the --rm flag to ``docker compose`` run commands when using the Docker-compose helper function. Default: 1
+#              * [``DOCKER_COMPOSE_AUTOREMOVE``] - Automatically add the --rm flag to ``docker compose`` run commands when using the Docker_compose helper function. Default: 1
 #              * ``DRYRUN``] - Optional variable inserted at the beginning of all docker commands. Useful for setting to "echo" or similar for dryrun mode
 # :Output: Runs docker compose command
 #
 # Helper function to execute (dryrun) the right command
 #
-# Instead of calling the ``docker compose`` command directly, the ``Docker-compose``
-# command should be called instead (for all dryrun-able activities. Simple
-# commands like ps, etc. don't make as much sense to dryrun, as the reset of
-# the script will never be executed, thus rendering dryrun useless.)
+# Instead of calling the ``docker compose`` command directly, the ``Docker_compose`` command should be called instead (for all dryrun-able activities. Simple commands like ps, etc. don't make as much sense to dryrun, as the reset of the script will never be executed, thus rendering dryrun useless.)
 #
 # .. rubric:: Bugs
 #
-# ``Docker-compose`` should not be exec'd like Docker was. Since fifo buffers are
-# created in common usage of ``Docker-compose``, `exec Docker-compose` would
-# result in fifo buffers being left behind in /tmp
+# ``Docker_compose`` should not be exec'd like ``Docker`` was. Since fifo buffers are created in common usage of ``Docker_compose``, `exec Docker_compose` would result in fifo buffers being left behind in /tmp
 #**
-
-# Backwards compatibility with just 0.2.x
-function Docker-compose()
-{
-  Docker_compose ${@+"${@}"}
-}
-
 function Docker_compose()
 {
   local docker_compose_args
@@ -1006,10 +988,16 @@ function Docker_compose()
   _Docker_compose
 }
 
+# Backwards compatibility with just 0.2.x
+function Docker-compose()
+{
+  Docker_compose ${@+"${@}"}
+}
+
 function _Docker_compose()
 {
   local docker_compose_extra_command_args=()
-  local cmd=(${DRYRUN} "${DOCKER_COMPOSE}")
+  local cmd=(${DRYRUN} "${DOCKER_COMPOSE[@]}")
   local extra_args_var
 
   if [ "${docker_compose_command}" = "run" ] && [ "${DOCKER_COMPOSE_AUTOREMOVE-1}" == "1" ]; then
@@ -1117,7 +1105,7 @@ function get_dockerfile_from_compose()
 # :Parameters: * ``JUST_PROJECT_PREFIX`` - Typically, the project name that is prepended to all the variables. EXAMPLE would cover EXAMPLE_VARIABLE
 #              * [``COMPOSE_VERSION``] - The docker compose yaml version number is auto determined by parsing the existing files, and is used in the auto generated files. In order to bypass this, you can specify the version number manually using this variable.
 #
-# ``Docker-compose`` with advance just features
+# ``Docker_compose`` with advance just features
 #
 # To provide a smoother just experience, advanced features are baked into
 # ``Just-docker-compose`` to work with Just and :file:`just_entrypoint_functions` to cover the
@@ -1204,7 +1192,7 @@ function Just-docker-compose()
   # "Fail later" behavior for set -eu. This should guarantee the override_file
   # is deleted. If this isn't enough, investigate adding cleanup to a trap
   local rv=0
-  _Docker-compose || rv="${?}"
+  _Docker_compose || rv="${?}"
   ${DRYRUN} rm "${override_file}"
   return "${rv}"
 }
@@ -1227,7 +1215,7 @@ function Just-docker-compose()
 function docker_service_running()
 {
   "${DOCKER}" inspect -f '{{.State.Status}}' \
-              $("${DOCKER_COMPOSE}" ps -q ${@+"${@}"}) 2>/dev/null # noquotes
+              $("${DOCKER_COMPOSE[@]}" ps -q ${@+"${@}"}) 2>/dev/null # noquotes
 }
 
 #**

--- a/linux/just_files/just_bashcov_functions.bsh
+++ b/linux/just_files/just_bashcov_functions.bsh
@@ -87,7 +87,7 @@ function bashcov_defaultify()
 {
   local id_project_cwd="${JUST_PROJECT_PREFIX}_CWD"
 
-  # Export variables for docker-compose file
+  # Export variables for docker-compose.yml file
   local BASH_COV_SOURCE_DIR="${JUST_PROJECT_PREFIX}_BASHCOV_SOURCE_DIR"
   export BASH_COV_SOURCE_DIR="${!BASH_COV_SOURCE_DIR:-${!id_project_cwd}}"
 

--- a/linux/just_files/just_ci_functions.bsh
+++ b/linux/just_files/just_ci_functions.bsh
@@ -143,7 +143,7 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 # .. command:: ci_load-services
 #
 # :Arguments: ``$1`` - Docker compose yaml file
-#             ``$2`` - Main docker-compose service
+#             ``$2`` - Main docker compose service
 #             [``$3``]... - Optional `ci_load.py` inputs
 #
 # Runs `ci_load.py` for specified docker services. Recipes are expected to be loaded prior to call via ``just ci load-recipes-auto``.

--- a/linux/just_files/just_docker_functions.bsh
+++ b/linux/just_files/just_docker_functions.bsh
@@ -47,6 +47,7 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 #
 # Even though all the stages are restored, only the services specified (``$2`` ...) are retagged so that they can be used. If you need more than one service's images restored, you will need to specify them all. If multiple services use the same image tag, they do not need to be specified. For example, service ``foo`` uses image ``stuff:foo``, service ``bar`` uses image ``stuff:bar``, and service ``car`` uses image ``stuff:bar`, only services ``foo`` and ``bar`` need to be passed in.
 #**
+# DEPRECATED
 function docker-compose_restore_from_cache()
 {
   local compose_file="${1}"
@@ -144,6 +145,7 @@ function docker-compose_restore_from_cache()
   ${DRYRUN-} rm "${temp_file}" "${temp_override}" "${temp_push_pull}"
 }
 
+# DEPRECATED
 # docker-compose_restore_from_cache helper function
 function _dynamic_docker-compose_push_pull()
 {
@@ -166,6 +168,7 @@ function _dynamic_docker-compose_push_pull()
   done
 }
 
+# DEPRECATED
 # docker-compose_restore_from_cache helper function
 function _dynamic_docker-compose_restore_recipes()
 {
@@ -185,6 +188,7 @@ function _dynamic_docker-compose_restore_recipes()
 # stdout - patched docker-compose file
 # fid 3 out - docker-compose override file, 3 by default, unless set by override_fd
 # arguments - Services to use cache
+# DEPRECATED
 function _dynamic_docker-compose_add_cache_from()
 {
   local main_service="${1}"
@@ -288,7 +292,7 @@ function get_docker_recipes()
 #
 # :Arguments: [``$1``]... - Recipe names to run
 #
-# Runs ``docker-compose build`` for the docker recipes. Useful command to call before ``docker build`` on your own project that uses recipes in vsi_common, to keep them synced with your build.
+# Runs ``docker compose build`` for the docker recipes. Useful command to call before ``docker build`` on your own project that uses recipes in vsi_common, to keep them synced with your build.
 #
 # .. command:: build_recipes-auto
 #
@@ -306,7 +310,7 @@ function get_docker_recipes()
 #
 #   Does not pick up containers that didn't exist when starting ``just`` log
 #
-# Override the log target in your ``Justfile`` and call ``__docker-compose-log`` if you need to set other parameters.
+# Override the log target in your ``Justfile`` and call ``__docker-compose_log`` if you need to set other parameters.
 #
 # .. command:: docker_clean
 #
@@ -432,14 +436,14 @@ function docker_defaultify()
 
       extra_args=1
       ;;
-    docker-compose_clean) # Delete a docker-compose volume. The next container \
+    docker-compose_clean) # Delete a docker compose volume. The next container \
                           # to use this volume will automatically copy any \
                           # content from the image. Use --all to clean all \
                           # volumes listed in the docker-compose.yml file
       if [ "${1}" = "--all" ]; then
         local DOCKER_INTERNAL_VOLUMES
         local volume
-        docker-compose-list-internal-volumes < <(Just-docker-compose config)
+        docker_compose_list_internal_volumes < <(Just-docker-compose config)
         for volume in ${DOCKER_INTERNAL_VOLUMES[@]+"${DOCKER_INTERNAL_VOLUMES[@]}"}; do
           justify docker_clean "${COMPOSE_PROJECT_NAME}_${volume}"
         done
@@ -453,7 +457,7 @@ function docker_defaultify()
                           # specific service. Additional arguments are run in
                           # lieu of bash
       # Not Docker-compose; no quotes
-      local containers=($(docker-compose ps -q -a --status running ${COMPOSE_SERVICES-} || :))
+      local containers=($(docker compose ps -q -a --status running ${COMPOSE_SERVICES-} || :))
       if [ "${#containers[@]}" == "0" ]; then
         echo "No running containers found"
         extra_args=${#}
@@ -485,12 +489,12 @@ function docker_defaultify()
          # specify service names to only log specific containers. Bug: Does \
          # not pick up containers that didn't exist when starting just log
 
-      # Override the log target in your Justfile and call __docker-compose-log
+      # Override the log target in your Justfile and call __docker-compose_log
       # if you need to set other parameters
-      justify __docker-compose-log ${@+"${@}"}
+      justify __docker-compose_log ${@+"${@}"}
       extra_args=${#}
       ;;
-    __docker-compose-log)
+    __docker-compose_log)
       function stop_logging(){ JUST_STOP_LOGGING=1; }
       JUST_STOP_LOGGING=0
       trap stop_logging INT
@@ -511,16 +515,23 @@ function docker_defaultify()
       extra_args=${#}
       ;;
 
-    docker-compose) # Run generic docker-compose command
+    # This pair maintains backwards compatibility and lets things like "just docker compose clean" work
+    docker_compose) # Run generic docker compose command
+      justify docker-compose ${@+"${@}"}
+      extra_args=${#}
+      ;;
+    docker-compose)
       Just-docker-compose ${@+"${@}"}
       extra_args=${#}
       ;;
 
+    # DEPRECATED
     docker-compose_ci-save) # Build and tag all stages of an image. $1 - compose filename, $2 - docker-compose service to build (for final stage)
       docker-compose_tag_all_stages "${1}" "${2}"
       extra_args=2
       ;;
 
+    # DEPRECATED
     docker-compose_ci-load) # Build all stages of an image from a pulled cache. $1 - compose filename, $2 - docker-compose service to build (for final stage), [$3...] - additional service names that might point to other stage targets in the same dockerfile.
       docker-compose_restore_from_cache "${@}"
       extra_args=${#}

--- a/linux/just_files/just_docker_functions.bsh
+++ b/linux/just_files/just_docker_functions.bsh
@@ -25,7 +25,7 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 #**
 # .. function:: docker-compose_restore_from_cache
 #
-# :Arguments: - ``$1`` - Docker-compose filename
+# :Arguments: - ``$1`` - Docker compose filename
 #             - ``$2`` - Main service name to restore and rebuild. This needs to be the last (unnamed) stage
 #             - ``[$3...]`` - Addition services based on same dockerfile to restore and rebuild
 # :Parameters: - ``JUST_DOCKER_COMPOSE_CACHE_REPO`` - Default value: ``vsiri/ci_cache``
@@ -79,7 +79,7 @@ function docker-compose_restore_from_cache()
 
   if [ "${JUST_DOCKER_COMPOSE_PULL-1}" = "1" ]; then
     # Let it fail, since the first time the images won't exist
-    Docker-compose -f "${temp_push_pull}" pull || :
+    Docker compose -f "${temp_push_pull}" pull || :
   fi
 
   ##############################
@@ -90,7 +90,7 @@ function docker-compose_restore_from_cache()
   _dynamic_docker-compose_restore_recipes "${1}" > "${temp_override}"
 
   if [ "${JUST_DOCKER_COMPOSE_BUILD-1}" = "1" ]; then
-    Docker-compose -f "${recipes_compose_file}" -f "${temp_override}" build ${recipes[@]+"${recipes[@]}"}
+    Docker compose -f "${recipes_compose_file}" -f "${temp_override}" build ${recipes[@]+"${recipes[@]}"}
     # retag recipes for push
     for i in ${recipes[@]+"${recipes[@]}"}; do
       Docker tag "vsiri/recipe:${i}" "${JUST_DOCKER_COMPOSE_CACHE_REPO}:recipe_${1}_${i}"
@@ -116,7 +116,7 @@ function docker-compose_restore_from_cache()
 
   # Build images
   if [ "${JUST_DOCKER_COMPOSE_BUILD-1}" = "1" ]; then
-    Docker-compose -f "${temp_file}" -f "${temp_override}" --project-directory "$(dirname "${compose_file}")" build "${services[@]}"
+    Docker compose -f "${temp_file}" -f "${temp_override}" --project-directory "$(dirname "${compose_file}")" build "${services[@]}"
   fi
 
   # Tag the final image for push
@@ -138,7 +138,7 @@ function docker-compose_restore_from_cache()
   # done
 
   if [ "${JUST_DOCKER_COMPOSE_PUSH-1}" = "1" ]; then
-    Docker-compose -f "${temp_push_pull}" push
+    Docker compose -f "${temp_push_pull}" push
   fi
 
   # Cleanup
@@ -456,7 +456,7 @@ function docker_defaultify()
                           # bash session. Set COMPOSE_SERVICES to limit to a
                           # specific service. Additional arguments are run in
                           # lieu of bash
-      # Not Docker-compose; no quotes
+      # Not Docker compose; no quotes
       local containers=($(docker compose ps -q -a --status running ${COMPOSE_SERVICES-} || :))
       if [ "${#containers[@]}" == "0" ]; then
         echo "No running containers found"
@@ -500,7 +500,7 @@ function docker_defaultify()
       trap stop_logging INT
       trap stop_logging TERM
       while [ "${JUST_STOP_LOGGING}" == "0" ]; do
-        Docker-compose logs --tail=20 -f ${@+"${@}"} || echo ${?}
+        Docker compose logs --tail=20 -f ${@+"${@}"} || echo ${?}
         while [ "${JUST_STOP_LOGGING}" == "0" ] && ! docker_service_running | grep running > /dev/null; do
           sleep 1
         done

--- a/linux/just_files/just_entrypoint_functions
+++ b/linux/just_files/just_entrypoint_functions
@@ -214,7 +214,7 @@ function docker_link_mounts()
   fi
 
   for y in ${!link_destinations[@]}; do
-    # Last link wins; this matches docker-compose behavior
+    # Last link wins; this matches docker compose behavior
     for ((x=${#JUST_DOCKER_ENTRYPOINT_LINKS[@]}-2; x>=0; x-=2)); do
       if [ -n "${link_destinations[y]+set}" ] && \
          [ "${JUST_DOCKER_ENTRYPOINT_LINKS[x+1]}" == "${link_destinations[y]}" ]; then

--- a/linux/just_files/just_functions.bsh
+++ b/linux/just_files/just_functions.bsh
@@ -543,10 +543,11 @@ function set_array_default()
 {
   local _set_array_default_index
 
-  # Handle case if using indirect variable name
+  # Handle case if using default variable name
   if [ "${1}" = "default" ]; then
     shift 1
     default=(${@+"${@}"})
+    return 0
   fi
 
   local default="${1}"

--- a/linux/just_files/just_pyinstaller_functions.bsh
+++ b/linux/just_files/just_pyinstaller_functions.bsh
@@ -116,7 +116,7 @@
 #       extra_args+=${#}
 #       ;;
 #     pyinstaller_clean) # Cleans doc directory
-#       justify docker-compose clean pyinstaller-build
+#       justify docker compose clean pyinstaller-build
 #       ;;
 #     *)
 #       plugin_not_found=1

--- a/linux/just_files/just_singularity_functions.bsh
+++ b/linux/just_files/just_singularity_functions.bsh
@@ -95,7 +95,7 @@ function singular_defaultify()
     #**
     # .. command:: singular-compose
     #
-    # singular-compose take the equivalent place of ``docker-compose``, but for singularity. This does not use `singularity-compose <https://github.com/singularityhub/singularity-compose>`_, instead it is a much simpler and plainer bash version.
+    # singular-compose take the equivalent place of ``docker compose``, but for singularity. This does not use `singularity-compose <https://github.com/singularityhub/singularity-compose>`_, instead it is a much simpler and plainer bash version.
     #
     # :Arguments: [``-f {filename}`` | ``--file {filename}``] - Optionally specify one or more singular-compose files, and ignoring the default found ``singular-compose.env`` file.
     #

--- a/linux/just_files/just_sphinx_functions.bsh
+++ b/linux/just_files/just_sphinx_functions.bsh
@@ -133,8 +133,7 @@ function _sphinx_docker_compose()
   MIFS=/// join_a VSI_COMMON_JUST_SETTINGS ${JUST_SETTINGSS[@]+"${JUST_SETTINGSS[@]}"}
   export VSI_COMMON_JUST_SETTINGS
 
-  Docker-compose \
-      -f "${VSI_COMMON_DIR}/docker/vsi_common/docker-compose.yml" ${@+"${@}"}
+  Docker compose -f "${VSI_COMMON_DIR}/docker/vsi_common/docker-compose.yml" ${@+"${@}"}
 }
 
 #**

--- a/linux/just_files/just_version.bsh
+++ b/linux/just_files/just_version.bsh
@@ -20,4 +20,4 @@
 # .. seealso::
 #   :envvar:`JUST_SETUP_SCRIPT`
 #**
-JUST_VERSION=0.2.2+1dev
+JUST_VERSION=0.3.0+1dev

--- a/linux/just_files/just_version.bsh
+++ b/linux/just_files/just_version.bsh
@@ -20,4 +20,4 @@
 # .. seealso::
 #   :envvar:`JUST_SETUP_SCRIPT`
 #**
-JUST_VERSION=0.3.0+1dev
+JUST_VERSION=0.2.2+1dev

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -338,7 +338,7 @@ function write_justfile()
                 case ${just_arg} in
                   build) # Build Docker image
                     if [ "${#}" -gt "0" ]; then
-                      Docker-compose "${just_arg}" ${@+"${@}"}
+                      Docker compose "${just_arg}" ${@+"${@}"}
               ' >> "${1}"
     if [ "${USE_PIPENV}" = "1" ]; then
       uwecho '        if isin '"${APP_NAME}"' ${@+"${@}"}; then
@@ -348,7 +348,7 @@ function write_justfile()
     uwecho   '        extra_args=${#}
                     else
                       justify build recipes-auto "${'"${PROJECT_PREFIX}"'_CWD}/docker"/*.Dockerfile
-                      Docker-compose build
+                      Docker compose build
               ' >> "${1}"
     if [ "${USE_PIPENV}" = "1" ]; then
       uwecho '        justify docker compose clean venv' >> "${1}"
@@ -373,7 +373,7 @@ function write_justfile()
                       touch "${'"${PROJECT_PREFIX}"'_CWD}/.just_synced"
                     fi
                     # Add any extra steps to run when syncing
-                    Docker-compose down
+                    Docker compose down
                     justify git_submodule-update # For those users who don'"'"'t remember!
                     justify build
                     ;;

--- a/linux/just_files/new_just
+++ b/linux/just_files/new_just
@@ -29,7 +29,7 @@ cat - << 'true' > "${temp_file}"
 # There are many moving pieces to set up a working just project and use
 # all the features. Just getting started is hard, without knowing where to
 # start. This script will create all the files necessary to have a new
-# docker-compose based just project up and running.
+# docker compose based just project up and running.
 #
 # .. rubric:: Usage
 #
@@ -231,7 +231,7 @@ function write_project_env()
             : ${'"${PROJECT_PREFIX}"'_GID=${'"${PROJECT_PREFIX}"'_GIDS%% *}}
             : ${'"${PROJECT_PREFIX}"'_GROUP_NAMES=$(group_names)}
 
-            #T# This directory is added to the container using the docker-compose file. This mechanism
+            #T# This directory is added to the container using the docker compose file. This mechanism
             #T# should only be used when the directory is guaranteed to exist
             : ${'"${PROJECT_PREFIX}"'_SOURCE_DIR=${'"${PROJECT_PREFIX}"'_CWD}}
             : ${'"${PROJECT_PREFIX}"'_SOURCE_DIR_DOCKER=/src}
@@ -263,8 +263,8 @@ function write_project_env()
 
             : ${COMPOSE_HTTP_TIMEOUT=600}
 
-            # Use this to add the user name to the docker-compose project name. This is
-            # important when multiple users are using this docker-compose project on a
+            # Use this to add the user name to the docker compose project name. This is
+            # important when multiple users are using this docker compose project on a
             # single host. This way all of the docker resources are prefixed with a unique
             # name and do not collide
             source "${VSI_COMMON_DIR}/linux/just_files/docker_functions.bsh" # define docker_compose_sanitize_project_name
@@ -342,7 +342,7 @@ function write_justfile()
               ' >> "${1}"
     if [ "${USE_PIPENV}" = "1" ]; then
       uwecho '        if isin '"${APP_NAME}"' ${@+"${@}"}; then
-                        justify docker-compose clean venv
+                        justify docker compose clean venv
                       fi' >> "${1}"
     fi
     uwecho   '        extra_args=${#}
@@ -351,7 +351,7 @@ function write_justfile()
                       Docker-compose build
               ' >> "${1}"
     if [ "${USE_PIPENV}" = "1" ]; then
-      uwecho '        justify docker-compose clean venv' >> "${1}"
+      uwecho '        justify docker compose clean venv' >> "${1}"
     fi
     uwecho   '      fi
                     ;;' >> "${1}"
@@ -387,7 +387,7 @@ function write_justfile()
                   clean_all) # Delete all local volumes
                     #T# Confirm action to protect accidental deletion. Can be removed if you don'"'"'t want it.
                     ask_question "Are you sure you want to delete all docker volumes?" n
-                    justify docker-compose clean --all
+                    justify docker compose clean --all
                     ;;
               ' >> "${1}"
     fi
@@ -983,7 +983,7 @@ function new_just()
         echo "  --[no-]docker - Enable/[disable] setting up docker"
         echo "  --[no-]pipenv - Enable/[disable] using pipenv in docker"
         echo "  --[no-]tutorial - Enable/[disable] adding tutorial comments"
-        echo "  --app APP - Application name for docker-compose service"
+        echo "  --app APP - Application name for docker compose service"
         echo "  --repo REPO - Docker repo name for compiled images"
         echo "  --defaults - Use all defaults without prompting"
         echo "  --continue - Set to auto continue summary without prompting"
@@ -1255,7 +1255,7 @@ function new_just()
     #**
     if set_default APP_NAME \
                    "$(echo "${APP_NAME-example}" | tr '[A-Z]' '[a-z]' | sed -${sed_flag_rE} 's|[^a-z0-9_.-]+||g')" \
-                   "Name of the example docker-compose app"; then
+                   "Name of the example docker compose app"; then
       APP_NAME="$(echo "${APP_NAME}" | tr '[A-Z]' '[a-z]' | sed -${sed_flag_rE} 's|[^a-z0-9_.-]+||g')"
     fi
 

--- a/linux/just_files/singularity_functions.bsh
+++ b/linux/just_files/singularity_functions.bsh
@@ -176,7 +176,7 @@ function singular_load_env()
     local file_matches
     # This is one of the few times the directory you are in matters. To create
     # an expected default behavior, switch to the JUSTFILE dir before searching
-    # for the docker-compose file.
+    # for the docker compose file.
     pushd "${JUST_SINGULAR_COMPOSE_DIR-$(dirname "${JUSTFILE}")}" > /dev/null
       parent_find_files singular-compose.env
     popd > /dev/null

--- a/linux/versions.bsh
+++ b/linux/versions.bsh
@@ -58,15 +58,14 @@ function docker_version()
 #**
 # .. function:: docker_compose_version
 #
-# Retrieves the version number of ``docker-compose``.
+# Retrieves the version number of ``docker compose``.
 #
-# :Parameters: [``DOCKER_COMPOSE``] - The ``docker-compose`` executable that will be called. Can be overwritten to call a different executable. Defaults to ``docker-compose``.
-# :Output: *stdout* - The ``docker-compose`` version number
+# :Parameters: [``DOCKER_COMPOSE``] - The ``docker compose`` command that will be called. Can be overwritten to call a different executable. Defaults to ``docker compose``.
+# :Output: *stdout* - The ``docker compose`` version number
 #**
 function docker_compose_version()
 {
-  local version="$("${DOCKER_COMPOSE}" --version | awk '{print $3}')"
-  echo "${version%,}"
+  "${DOCKER_COMPOSE[@]}" version | awk 'NR == 1 {if ( $1 == "docker-compose" ) { print substr($3, 0, length($3)-1)} else { print substr($4, 2) }}'
 }
 
 #**

--- a/linux/versions.bsh
+++ b/linux/versions.bsh
@@ -65,7 +65,7 @@ function docker_version()
 #**
 function docker_compose_version()
 {
-  "${DOCKER_COMPOSE[@]}" version | awk 'NR == 1 {if ( $1 == "docker-compose" ) { print substr($3, 0, length($3)-1)} else { print substr($4, 2) }}'
+  "${DOCKER_COMPOSE[@]}" version | awk 'NR == 1 {if ( $1 == "docker-compose" ) { print substr($3, 1, length($3)-1)} else { print substr($4, 2) }}'
 }
 
 #**

--- a/linux/yarp
+++ b/linux/yarp
@@ -57,7 +57,7 @@ fi
 # * Collapsed nested sequence indicators ``- -``
 # * And any other YAML features
 #
-# The supported subset is enough to handle the output of ``docker-compose config``. docker-compose's config command will parse anchors, multilines, and remove comments.
+# The supported subset is enough to handle the output of ``docker compose config``. docker compose's config command will parse anchors, multilines, and remove comments.
 #
 # .. seealso::
 #

--- a/linux/yarp.awk
+++ b/linux/yarp.awk
@@ -135,7 +135,7 @@ function pre_process_line()
   if (length($0) && substr($0, length($0)) == "\r" )
     $0 = substr($0, 0, length($0)-1)
 
-  # Handle multiline output from docker-compose config
+  # Handle multiline output from docker compose config
   while (match($0, /\\$/))
   {
     $0 = substr($0, 0, length($0)-1)
@@ -166,7 +166,7 @@ function pre_process_line()
   #      of the multiline, and start the main awk loop all over again with that
   #      value. This part is try, since I can only do next in the main loop
 
-  # However... docker-compose parses this for you, so there's no need to do
+  # However... docker compose parses this for you, so there's no need to do
   # this anymore :)
 
   # Detect multiline (|)

--- a/linux/yarp.awk
+++ b/linux/yarp.awk
@@ -133,12 +133,12 @@ function pre_process_line()
   # Add compatibility for handling Windows line endings on Linux
   # (Still works in Windows with \r removed)
   if (length($0) && substr($0, length($0)) == "\r" )
-    $0 = substr($0, 0, length($0)-1)
+    $0 = substr($0, 1, length($0)-1)
 
   # Handle multiline output from docker compose config
   while (match($0, /\\$/))
   {
-    $0 = substr($0, 0, length($0)-1)
+    $0 = substr($0, 1, length($0)-1)
     getline line
     line = lstrip(line)
     $0 = $0 line

--- a/tests/int/test-docker_compose_override.bsh
+++ b/tests/int/test-docker_compose_override.bsh
@@ -33,7 +33,7 @@ function envi()
 if ! command -v "${DOCKER_COMPOSE}" &> /dev/null; then
   skip_next_test
 fi
-begin_test "Generate docker-compose override internal volumes"
+begin_test "Generate docker compose override internal volumes"
 (
   setup_test
 
@@ -75,7 +75,7 @@ end_test
 if ! command -v "${DOCKER_COMPOSE}" &> /dev/null; then
   skip_next_test
 fi
-begin_test "Generate docker-compose override long syntax volume"
+begin_test "Generate docker compose override long syntax volume"
 (
   setup_test
 

--- a/tests/int/test-docker_compose_override.bsh
+++ b/tests/int/test-docker_compose_override.bsh
@@ -30,7 +30,7 @@ function envi()
   echo -e "\n      - ${1}"
 }
 
-if ! command -v "${DOCKER_COMPOSE}" &> /dev/null; then
+if ! "${DOCKER_COMPOSE[@]}" &> /dev/null; then
   skip_next_test
 fi
 begin_test "Generate docker compose override internal volumes"
@@ -72,7 +72,7 @@ volumes:
 )
 end_test
 
-if ! command -v "${DOCKER_COMPOSE}" &> /dev/null; then
+if ! "${DOCKER_COMPOSE[@]}" &> /dev/null; then
   skip_next_test
 fi
 begin_test "Generate docker compose override long syntax volume"

--- a/tests/int/test-docker_functions.bsh
+++ b/tests/int/test-docker_functions.bsh
@@ -87,7 +87,7 @@ begin_test "Just docker compose"
 )
 end_test
 
-if ! (command -v "${DOCKER}" &> /dev/null && command -v "${DOCKER_COMPOSE}" &> /dev/null); then
+if ! (command -v "${DOCKER}" &> /dev/null && "${DOCKER_COMPOSE[@]}" &> /dev/null); then
   skip_next_test
 fi
 begin_test "Docker service running"
@@ -96,19 +96,19 @@ begin_test "Docker service running"
 
   echo "${compose_file_sleep}" > "${TESTDIR}/dsr.yml"
 
-  "${DOCKER_COMPOSE}" -f "${TESTDIR}/dsr.yml" rm -s -f
-  "${DOCKER_COMPOSE}" -f "${TESTDIR}/dsr.yml" up -d test_sleepy
+  "${DOCKER_COMPOSE[@]}" -f "${TESTDIR}/dsr.yml" rm -s -f
+  "${DOCKER_COMPOSE[@]}" -f "${TESTDIR}/dsr.yml" up -d test_sleepy
   assert_str_eq "$(COMPOSE_FILE="${TESTDIR}/dsr.yml" docker_service_running test_sleepy)" "running"
   assert_str_eq "$(COMPOSE_FILE="${TESTDIR}/dsr.yml" docker_service_running test_sleepy2)" ""
-  "${DOCKER_COMPOSE}" -f "${TESTDIR}/dsr.yml" kill test_sleepy
+  "${DOCKER_COMPOSE[@]}" -f "${TESTDIR}/dsr.yml" kill test_sleepy
   assert_str_eq "$(COMPOSE_FILE="${TESTDIR}/dsr.yml" docker_service_running test_sleepy)" "exited"
 
   # Clean up
-  "${DOCKER_COMPOSE}" -f "${TESTDIR}/dsr.yml" rm -s -f
+  "${DOCKER_COMPOSE[@]}" -f "${TESTDIR}/dsr.yml" rm -s -f
 )
 end_test
 
-if ! command -v "${DOCKER_COMPOSE}" &> /dev/null; then
+if ! "${DOCKER_COMPOSE[@]}" &> /dev/null; then
   skip_next_test
 fi
 begin_test "Just docker compose with internal volumes"

--- a/tests/int/test-new_just.bsh
+++ b/tests/int/test-new_just.bsh
@@ -98,19 +98,15 @@ begin_test "New Just"
 
   pushd "${CWD}"
     uwecho '#!/usr/bin/env bash
-            echo mockdc "${@}"' > "${TESTDIR}/ss/docker-compose"
-
-    uwecho '#!/usr/bin/env bash
             echo mockd "${@}"
             exit 0' > "${TESTDIR}/ss/docker"
   popd
-  chmod 755 ss/docker-compose
   chmod 755 ss/docker
 
   [ "$(just build)" = "mockd buildx bake gosu pipenv tini vsi
-mockdc -f ${TESTDIR}/docker-compose.yml build
+mockd compose -f ${TESTDIR}/docker-compose.yml build
 mockd volume rm testpro_venv" ]
-  [ "$(just build example)" = "mockdc -f ${TESTDIR}/docker-compose.yml build example" ]
+  [ "$(just build example)" = "mockd compose -f ${TESTDIR}/docker-compose.yml build example" ]
 
   file_name="${TESTDIR}/docker-compose.yml"
   if [[ ${file_name} =~ ^${does_not_needs_quote_escape_regex}$ ]]; then
@@ -120,7 +116,7 @@ mockd volume rm testpro_venv" ]
     file_name="$(quote_escape "${file_name}")"
   fi
 
-  [[ $(just -n run yaan) =~ docker-compose\ -f\ ${file_name}\ -f\ (.*)\ run\ --rm\ --service-ports\ yaan ]] || false
+  [[ $(just -n run yaan) =~ docker compose\ -f\ ${file_name}\ -f\ (.*)\ run\ --rm\ --service-ports\ yaan ]] || false
 
   tmp_file="$(quote_unescape "${BASH_REMATCH[1]}")"
 
@@ -164,7 +160,7 @@ services:
   rm "${tmp_file}"
 
   # Test clean venv when volume exists
-  assert_str_eq "$(just docker-compose clean venv)" "mockd volume rm testpro_venv"
+  assert_str_eq "$(just docker compose clean venv)" "mockd volume rm testpro_venv"
 
 
   pushd "${CWD}"
@@ -175,7 +171,7 @@ services:
   popd
   chmod 755 ss/docker
 
-  assert_str_eq "$(just docker-compose clean venv 2>&1)" "testpro_venv already removed"
+  assert_str_eq "$(just docker compose clean venv 2>&1)" "testpro_venv already removed"
 )
 end_test
 
@@ -200,17 +196,14 @@ begin_test "New Just no pipenv"
 
   pushd "${CWD}"
     uwecho '#!/usr/bin/env bash
-            echo mockdc "${@}"' > "${TESTDIR}/ss/docker-compose"
-
-    uwecho '#!/usr/bin/env bash
             echo mockd "${@}"
             exit 0' > "${TESTDIR}/ss/docker"
   popd
   chmod 755 ${TESTDIR}/ss/docker*
 
   [ "$(just build)" = "mockd buildx bake gosu tini vsi
-mockdc -f ${TESTDIR}/docker-compose.yml build" ]
-  [ "$(just build example)" = "mockdc -f ${TESTDIR}/docker-compose.yml build example" ]
+mockd compose -f ${TESTDIR}/docker-compose.yml build" ]
+  [ "$(just build example)" = "mockd compose -f ${TESTDIR}/docker-compose.yml build example" ]
 
   file_name="${TESTDIR}/docker-compose.yml"
   if [[ ${file_name} =~ ^${does_not_needs_quote_escape_regex}$ ]]; then
@@ -220,7 +213,7 @@ mockdc -f ${TESTDIR}/docker-compose.yml build" ]
     file_name="$(quote_escape "${file_name}")"
   fi
 
-  [[ $(just -n run example) =~ docker-compose\ -f\ ${file_name}\ -f\ (.*)\ run\ --rm\ --service-ports\ example ]] || false
+  [[ $(just -n run example) =~ docker compose\ -f\ ${file_name}\ -f\ (.*)\ run\ --rm\ --service-ports\ example ]] || false
 
   tmp_file="$(quote_unescape "${BASH_REMATCH[1]}")"
 
@@ -414,7 +407,7 @@ begin_test "New just docker test"
   # for some reason, only on Windows running through xargs do I have this tty issue, and only here
   [[ $(DOCKER_COMPOSE_EXTRA_RUN_ARGS='-T' just run yaan pipenv run pip freeze --all) =~ pip==.*setuptools==.*wheel==.* ]] || false
 
-  just docker-compose down
+  just docker compose down
 )
 end_test
 

--- a/tests/int/test-new_just.bsh
+++ b/tests/int/test-new_just.bsh
@@ -330,16 +330,16 @@ begin_test "New just instructions test (git)"
   rv=0
   # Evaluate git commands
   "${VSI_COMMON_DIR}/linux/just_files/new_just" --continue --vsi \
-                                             --docker --pipenv --git \
-                                             --prefix JTEST \
-                                             --project-dir "${TESTDIR}" \
-                                             --justfile "j.u.s.t  f i'l${tough_name}e" \
-                                             --setupfile "set u.p  f i'l${tough_name}e" \
-                                             --project-name "je.  t e's${tough_name}t" \
-                                             --vsi-dir "v.s.i  d i'r${tough_name}" \
-                                             --app yaan \
-                                             --tutorial \
-                                             --repo tmp || rv="${?}"
+                                                --docker --pipenv --git \
+                                                --prefix JTEST \
+                                                --project-dir "${TESTDIR}" \
+                                                --justfile "j.u.s.t  f i'l${tough_name}e" \
+                                                --setupfile "set u.p  f i'l${tough_name}e" \
+                                                --project-name "je.  t e's${tough_name}t" \
+                                                --vsi-dir "v.s.i  d i'r${tough_name}" \
+                                                --app yaan \
+                                                --tutorial \
+                                                --repo tmp || rv="${?}"
 
   if [ "${git_email_set}" = "0" ]; then
     git config --global --unset user.email

--- a/tests/int/test-new_just.bsh
+++ b/tests/int/test-new_just.bsh
@@ -116,7 +116,7 @@ mockd volume rm testpro_venv" ]
     file_name="$(quote_escape "${file_name}")"
   fi
 
-  [[ $(just -n run yaan) =~ docker compose\ -f\ ${file_name}\ -f\ (.*)\ run\ --rm\ --service-ports\ yaan ]] || false
+  [[ $(just -n run yaan) =~ docker\ compose\ -f\ ${file_name}\ -f\ (.*)\ run\ --rm\ --service-ports\ yaan ]] || false
 
   tmp_file="$(quote_unescape "${BASH_REMATCH[1]}")"
 
@@ -213,7 +213,7 @@ mockd compose -f ${TESTDIR}/docker-compose.yml build" ]
     file_name="$(quote_escape "${file_name}")"
   fi
 
-  [[ $(just -n run example) =~ docker compose\ -f\ ${file_name}\ -f\ (.*)\ run\ --rm\ --service-ports\ example ]] || false
+  [[ $(just -n run example) =~ docker\ compose\ -f\ ${file_name}\ -f\ (.*)\ run\ --rm\ --service-ports\ example ]] || false
 
   tmp_file="$(quote_unescape "${BASH_REMATCH[1]}")"
 

--- a/tests/test-docker_compose_override.bsh
+++ b/tests/test-docker_compose_override.bsh
@@ -262,7 +262,7 @@ setup_mock()
   }
 }
 
-begin_test "Generate docker-compose override"
+begin_test "Generate docker compose override"
 (
   setup_test
   setup_mock
@@ -324,7 +324,7 @@ setup_mock()
   }
 }
 
-begin_test "Generate docker-compose override on nfs"
+begin_test "Generate docker compose override on nfs"
 (
   setup_test
   setup_mock

--- a/tests/test-docker_functions.bsh
+++ b/tests/test-docker_functions.bsh
@@ -282,10 +282,11 @@ begin_test "Test DOCKER_COMPOSE var"
 (
   setup_test
   DRYRUN=echo
+  unset DOCKER_COMPOSE
   DOCKER_COMPOSE="DoCkErCoMpOsE"
-  [ "$(JUSTFILE="${TESTDIR}/Justfile" Docker-compose run test)" = "DoCkErCoMpOsE run --rm test" ]
+  [ "$(JUSTFILE="${TESTDIR}/Justfile" Docker compose run test)" = "DoCkErCoMpOsE run --rm test" ]
   DOCKER_COMPOSE=("DoCkEr" "CoMpOsE")
-  [ "$(JUSTFILE="${TESTDIR}/Justfile" Docker-compose run test)" = "DoCkEr CoMpOsE run --rm test" ]
+  [ "$(JUSTFILE="${TESTDIR}/Justfile" Docker compose run test)" = "DoCkEr CoMpOsE run --rm test" ]
 )
 end_test
 
@@ -551,7 +552,7 @@ begin_test "Custom IFS"
 )
 end_test
 
-begin_test "Docker-compose command"
+begin_test "Docker compose command"
 (
   setup_test
   export DRYRUN=print_command
@@ -559,8 +560,8 @@ begin_test "Docker-compose command"
   export JUSTFILE="${TESTDIR}/Justfile"
 
   DOCKER_COMPOSE_AUTOREMOVE=0
-  a=("${DOCKER_COMPOSE}" run -v '/test  this/:blah' 'debian:9')
-  r="$(Docker-compose run -v "/test  this/:blah" debian:9)"
+  a=("${DOCKER_COMPOSE[@]}" run -v '/test  this/:blah' 'debian:9')
+  r="$(Docker compose run -v "/test  this/:blah" debian:9)"
   eval "r=(${r})" # noquotes
   cmp_elements_a a r
 )
@@ -572,14 +573,14 @@ begin_test "DOCKER_COMPOSE_AUTOREMOVE and DOCKER_COMPOSE_EXTRA_*_ARGS"
   export DRYRUN=print_command
   export JUSTFILE="${TESTDIR}/Justfile"
 
-  a=("${DOCKER_COMPOSE}" run --rm -v '/test  this/:blah' 'debian')
-  r="$(Docker-compose run -v "/test  this/:blah" debian)"
+  a=("${DOCKER_COMPOSE[@]}" run --rm -v '/test  this/:blah' 'debian')
+  r="$(Docker compose run -v "/test  this/:blah" debian)"
   eval "r=(${r})" # noquotes
   cmp_elements_a a r
 
   DOCKER_COMPOSE_EXTRA_RUN_ARGS=('aaa' 'bbb')
-  a=("${DOCKER_COMPOSE}" run --rm aaa bbb -v '/test  this/:blah' 'debian')
-  r="$(Docker-compose run -v "/test  this/:blah" debian)"
+  a=("${DOCKER_COMPOSE[@]}" run --rm aaa bbb -v '/test  this/:blah' 'debian')
+  r="$(Docker compose run -v "/test  this/:blah" debian)"
   eval "r=(${r})" # noquotes
   cmp_elements_a a r
 )
@@ -593,8 +594,8 @@ begin_test "DOCKER_COMPOSE_EXTRA_ARGS"
 
   DOCKER_COMPOSE_EXTRA_BUILD_ARGS=('aaa' 'bbb')
   DOCKER_COMPOSE_EXTRA_ARGS=(--config bl\ \ ah.json -l=debug -H 123)
-  a=("${DOCKER_COMPOSE}" --tls "${DOCKER_COMPOSE_EXTRA_ARGS[@]}" build aaa bbb -v '/test  this/:blah' 'debian')
-  r="$(Docker-compose --tls build -v "/test  this/:blah" debian)"
+  a=("${DOCKER_COMPOSE[@]}" --tls "${DOCKER_COMPOSE_EXTRA_ARGS[@]}" build aaa bbb -v '/test  this/:blah' 'debian')
+  r="$(Docker compose --tls build -v "/test  this/:blah" debian)"
   eval "r=(${r})" # noquotes
   cmp_elements_a a r
 )

--- a/tests/test-docker_functions.bsh
+++ b/tests/test-docker_functions.bsh
@@ -282,28 +282,10 @@ begin_test "Test DOCKER_COMPOSE var"
 (
   setup_test
   DRYRUN=echo
-  DOCKER_COMPOSE="DoCkEr-CoMpOsE"
-  [ "$(JUSTFILE="${TESTDIR}/Justfile" Docker-compose run test)" = "DoCkEr-CoMpOsE run --rm test" ]
-)
-end_test
-
-begin_test "docker compose parse volumes old"
-(
-  setup_test
-
-  ans=(-v "/tmp:/mnt" -v "test:/opt")
-  docker-compose-volumes-old nb <<< "${compose_file}"
-  cmp_elements_a DOCKER_VOLUME_FLAGS ans
-
-  ans=()
-  docker-compose-volumes-old foo <<< "${compose_file}"
-  cmp_elements_a DOCKER_VOLUME_FLAGS ans
-
-  docker-compose-volumes-old bar <<< "${compose_file}"
-  cmp_elements_a DOCKER_VOLUME_FLAGS ans
-
-  docker-compose-volumes-old none <<< "${compose_file}"
-  cmp_elements_a DOCKER_VOLUME_FLAGS ans
+  DOCKER_COMPOSE="DoCkErCoMpOsE"
+  [ "$(JUSTFILE="${TESTDIR}/Justfile" Docker-compose run test)" = "DoCkErCoMpOsE run --rm test" ]
+  DOCKER_COMPOSE=("DoCkEr" "CoMpOsE")
+  [ "$(JUSTFILE="${TESTDIR}/Justfile" Docker-compose run test)" = "DoCkEr CoMpOsE run --rm test" ]
 )
 end_test
 
@@ -316,7 +298,7 @@ begin_test "parse docker compose volumes"
        "Stest:/opt"
        "Lsource: internal" "ltarget: /src" "ltype: volume"
        "Ltarget: /tmp2" "ltype: tmpfs")
-  parse-docker-compose-volumes nb <<< "${compose_file_long}"
+  parse_docker_compose_volumes nb <<< "${compose_file_long}"
   cmp_elements_a DOCKER_VOLUME_LINES ans
 
   ans=("S/tmp:/mnt"
@@ -324,17 +306,17 @@ begin_test "parse docker compose volumes"
        "Stest_prefix_test:/opt"
        "Lsource: test_prefix_internal" "ltarget: /src" "ltype: volume"
        "Ltarget: /tmp2" "ltype: tmpfs")
-  parse-docker-compose-volumes nb test_prefix_ <<< "${compose_file_long}"
+  parse_docker_compose_volumes nb test_prefix_ <<< "${compose_file_long}"
   cmp_elements_a DOCKER_VOLUME_LINES ans
 
   ans=()
-  parse-docker-compose-volumes foo <<< "${compose_file_long}"
+  parse_docker_compose_volumes foo <<< "${compose_file_long}"
   cmp_elements_a DOCKER_VOLUME_LINES ans
 
-  parse-docker-compose-volumes bar <<< "${compose_file_long}"
+  parse_docker_compose_volumes bar <<< "${compose_file_long}"
   cmp_elements_a DOCKER_VOLUME_LINES ans
 
-  parse-docker-compose-volumes none <<< "${compose_file_long}"
+  parse_docker_compose_volumes none <<< "${compose_file_long}"
   cmp_elements_a DOCKER_VOLUME_LINES ans
 )
 end_test
@@ -348,7 +330,7 @@ begin_test "docker compose volumes"
        "Stest:/opt"
        "Lsource: internal" "ltarget: /src" "ltype: volume"
        "Ltarget: /tmp2" "ltype: tmpfs")
-  docker-compose-volumes
+  docker_compose_volumes
   sources=("/tmp" "/home/user/src" "test" "internal" "")
   targets=("/mnt" "/src" "/opt" "/src" "/tmp2")
   flags=("" "" "" "" "")
@@ -365,7 +347,7 @@ begin_test "docker compose volumes"
                          "ltype: volume"
                          "lvolume:"
                          "l  nocopy: true")
-  docker-compose-volumes
+  docker_compose_volumes
   sources=("/test1" "test3" "internal")
   targets=("/test2" "/test4" "/src")
   flags=(":ro" ":Z" $'volume:\n  nocopy: true')
@@ -374,7 +356,7 @@ begin_test "docker compose volumes"
   cmp_elements_a DOCKER_VOLUME_FLAGS flags
 
   DOCKER_VOLUME_LINES+=("S/test5:/test6:rw")
-  docker-compose-volumes
+  docker_compose_volumes
   sources+=("/test5")
   targets+=("/test6")
   flags+=(":rw")
@@ -400,7 +382,7 @@ begin_test "docker compose volumes with missing fields"
 
   DOCKER_VOLUME_LINES=("${DOCKER_VOLUME_LINES_ORIG[@]}")
   unset DOCKER_VOLUME_LINES[2]
-  docker-compose-volumes
+  docker_compose_volumes
 
   assert_array_values DOCKER_VOLUME_SOURCES "${sources[@]}"
   assert_array_values DOCKER_VOLUME_TARGETS "/mnt" "" "/opt" "/src" "/tmp2"
@@ -408,7 +390,7 @@ begin_test "docker compose volumes with missing fields"
   assert_array_values DOCKER_VOLUME_FORMATS "${formats[@]}"
 
   DOCKER_VOLUME_LINES[1]='Ltarget: /src'
-  docker-compose-volumes
+  docker_compose_volumes
 
   assert_array_values DOCKER_VOLUME_SOURCES "/tmp" "" "test" "internal" ""
   assert_array_values DOCKER_VOLUME_TARGETS "${targets[@]}"
@@ -418,13 +400,13 @@ begin_test "docker compose volumes with missing fields"
 )
 end_test
 
-begin_test "Parse docker-compose args"
+begin_test "Parse docker compose args"
 (
   setup_test
 
   export JUSTFILE="${TESTDIR}/Justfile"
 
-  parse-docker-compose run test
+  parse_docker_compose run test
   assert_array_values docker_compose_args
   [ "${docker_compose_command}" = "run" ]
   assert_array_values docker_compose_command_args test
@@ -432,13 +414,13 @@ begin_test "Parse docker-compose args"
   # Test all args that take an argument
   for arg in -f -p -H -c --file --project-name --host --context --log-level \
              --tlscacert --tlscert --tlskey --project-directory --env-file; do
-    parse-docker-compose "${arg}" foobar
+    parse_docker_compose "${arg}" foobar
     assert_array_values docker_compose_args "${arg}" foobar
     [ "${docker_compose_command-}" = "" ]
     assert_array_values docker_compose_command_args
 
     # Test = notation
-    parse-docker-compose "${arg}=foobar"
+    parse_docker_compose "${arg}=foobar"
     assert_array_values docker_compose_args "${arg}=foobar"
     [ "${docker_compose_command-}" = "" ]
     assert_array_values docker_compose_command_args
@@ -446,7 +428,7 @@ begin_test "Parse docker-compose args"
 
   # Test single letter combine notation too
   for arg in -f -p -H -c; do
-    parse-docker-compose "${arg}foobar"
+    parse_docker_compose "${arg}foobar"
     assert_array_values docker_compose_args "${arg}foobar"
     [ "${docker_compose_command-}" = "" ]
     assert_array_values docker_compose_command_args
@@ -454,13 +436,13 @@ begin_test "Parse docker-compose args"
 
   # Test all flags
   for arg in --no-ansi -v --verbose --tls --skip-hostname-check --tlsverify --compatibility; do
-    parse-docker-compose "${arg}"
+    parse_docker_compose "${arg}"
     assert_array_values docker_compose_args "${arg}"
     [ "${docker_compose_command-}" = "" ]
     assert_array_values docker_compose_command_args
   done
 
-  parse-docker-compose --no-ansi -H=blah.json --verbose run -v /foo:/bar debian bash
+  parse_docker_compose --no-ansi -H=blah.json --verbose run -v /foo:/bar debian bash
   assert_array_values docker_compose_args --no-ansi -H=blah.json --verbose
   [ "${docker_compose_command}" = "run" ]
   assert_array_values docker_compose_command_args -v /foo:/bar debian bash
@@ -471,18 +453,18 @@ begin_test "Parse docker compose project name"
 (
   setup_test
 
-  parse-docker-compose --project-name foo
+  parse_docker_compose --project-name foo
   [ "${docker_compose_project_name}" = "foo" ]
 
-  parse-docker-compose --project-name foo run alpine
+  parse_docker_compose --project-name foo run alpine
   [ "${docker_compose_project_name}" = "foo" ]
-  parse-docker-compose -p bar run alpine
+  parse_docker_compose -p bar run alpine
   [ "${docker_compose_project_name}" = "bar" ]
-  parse-docker-compose -p foobar run alpine
+  parse_docker_compose -p foobar run alpine
   [ "${docker_compose_project_name}" = "foobar" ]
 
   # Make sure -p/--project-name wins
-  COMPOSE_PROJECT_NAME=foo parse-docker-compose -p bar run alpine
+  COMPOSE_PROJECT_NAME=foo parse_docker_compose -p bar run alpine
   [ "${docker_compose_project_name}" = "bar" ]
 )
 end_test
@@ -494,50 +476,50 @@ begin_test "Parse docker compose file args"
 
   touch docker-compose2.yml
 
-  # parse-docker-compose uses the location of the Justfile as the starting
-  # point for looking for docker-compose files to prevent "different results
+  # parse_docker_compose uses the location of the Justfile as the starting
+  # point for looking for docker compose files to prevent "different results
   # when running just from a different CWD"
   export JUSTFILE="${TESTDIR}/Justfile"
 
-  parse-docker-compose run alpine
-  # No docker-compose
+  parse_docker_compose run alpine
+  # No docker compose
   [ "${docker_compose_project_name}" = "default" ]
   [ "${#docker_compose_files[@]}" -eq "0" ]
 
   # Make sure COMPOSE_FILE works
-  COMPOSE_FILE=docker-compose2.yml parse-docker-compose run alpine
+  COMPOSE_FILE=docker-compose2.yml parse_docker_compose run alpine
   [ "${docker_compose_project_name}" = "$(basename "$(pwd)")" ]
   [ "${#docker_compose_files[@]}" -eq "1" ]
   [ "${docker_compose_files[0]}" = "docker-compose2.yml" ]
 
   # Make sure COMPOSE_FILE overrides docker-compose.yml
   touch docker-compose.yml
-  COMPOSE_FILE=docker-compose2.yml parse-docker-compose run alpine
+  COMPOSE_FILE=docker-compose2.yml parse_docker_compose run alpine
   [ "${docker_compose_project_name}" = "$(basename "$(pwd)")" ]
   [ "${#docker_compose_files[@]}" -eq "1" ]
   [ "${docker_compose_files[0]}" = "docker-compose2.yml" ]
 
   # Make sure docker-compose.yml works
-  parse-docker-compose run alpine
+  parse_docker_compose run alpine
   [ "${docker_compose_project_name}" = "$(basename "$(pwd)")" ]
   [ "${#docker_compose_files[@]}" -eq "1" ]
   [ "${docker_compose_files[0]}" = "${TESTDIR}/docker-compose.yml" ]
 
   # Make sure override works
   touch docker-compose.override.yaml
-  parse-docker-compose run alpine
+  parse_docker_compose run alpine
   [ "${docker_compose_project_name}" = "$(basename "$(pwd)")" ]
   [ "${#docker_compose_files[@]}" -eq "2" ]
   [ "${docker_compose_files[0]}" = "${TESTDIR}/docker-compose.yml" ]
   [ "${docker_compose_files[1]}" = "${TESTDIR}/docker-compose.override.yaml" ]
 
   # Make sure -f/--file wins
-  COMPOSE_FILE=docker-compose2.yml parse-docker-compose -f test3.yml run alpine
+  COMPOSE_FILE=docker-compose2.yml parse_docker_compose -f test3.yml run alpine
   [ "${docker_compose_project_name}" = "$(basename "$(pwd)")" ]
   [ "${#docker_compose_files[@]}" -eq "1" ]
   [ "${docker_compose_files[0]}" = "test3.yml" ]
 
-  parse-docker-compose -f test1.yml -ftest2 --file test3 --file=test4 run debian:9 bash
+  parse_docker_compose -f test1.yml -ftest2 --file test3 --file=test4 run debian:9 bash
   [ "${#docker_compose_files[@]}" -eq "4" ]
 )
 end_test
@@ -618,7 +600,7 @@ begin_test "DOCKER_COMPOSE_EXTRA_ARGS"
 )
 end_test
 
-begin_test "docker-compose service names"
+begin_test "docker compose service names"
 (
   setup_test
   service_names="$(docker_compose_service_names <(echo "${compose_file}"))"
@@ -628,7 +610,7 @@ begin_test "docker-compose service names"
 )
 end_test
 
-begin_test "docker-compose service names2"
+begin_test "docker compose service names2"
 (
   setup_test
   service_names="$(docker_compose_service_names2 <(echo "${compose_file}"))"
@@ -673,7 +655,7 @@ services:
   ttouch "${override_file}"
   [ "$(cat "${override_file}")" = "${ans}" ]
 
-  # Test when two docker-compose files reference the same service
+  # Test when two docker compose files reference the same service
   echo "${compose_file_hay}" > "${TESTDIR}/dc2.yml"
   override_file="$(Just-docker-compose -f "${TESTDIR}/dc.yml" -f "${TESTDIR}/dc2.yml" run test_hay|tail -n1)"
   override_file="${override_file#rm *}"
@@ -745,19 +727,19 @@ mock_docker: rm mock_container_name_my_image:foo" ]
 )
 end_test
 
-begin_test "docker-compose list internal volumes"
+begin_test "docker compose list internal volumes"
 (
   setup_test
-  docker-compose-list-internal-volumes <<< "${compose_file}"
+  docker_compose_list_internal_volumes <<< "${compose_file}"
   assert_array_values DOCKER_INTERNAL_VOLUMES test
 
   unset DOCKER_INTERNAL_VOLUMES
-  docker-compose-list-internal-volumes <<< "${compose_file_long}"
+  docker_compose_list_internal_volumes <<< "${compose_file_long}"
   assert_array_values DOCKER_INTERNAL_VOLUMES test
 
   # None case
   unset DOCKER_INTERNAL_VOLUMES
-  docker-compose-list-internal-volumes <<< ""
+  docker_compose_list_internal_volumes <<< ""
   assert_array_values DOCKER_INTERNAL_VOLUMES
 
   # Multiple case
@@ -769,7 +751,7 @@ begin_test "docker-compose list internal volumes"
   test3:"
 
   unset DOCKER_INTERNAL_VOLUMES
-  docker-compose-list-internal-volumes <<< "${file_test}"
+  docker_compose_list_internal_volumes <<< "${file_test}"
   declare -p DOCKER_INTERNAL_VOLUMES
   assert_array_values DOCKER_INTERNAL_VOLUMES test1 test2 test3
 
@@ -777,13 +759,13 @@ begin_test "docker-compose list internal volumes"
 notvolumes:
   test4:"
   unset DOCKER_INTERNAL_VOLUMES
-  docker-compose-list-internal-volumes <<< "${file_test}"
+  docker_compose_list_internal_volumes <<< "${file_test}"
   declare -p DOCKER_INTERNAL_VOLUMES
   assert_array_values DOCKER_INTERNAL_VOLUMES test1 test2 test3
 )
 end_test
 
-begin_test "get docker-compose version"
+begin_test "get docker compose version"
 (
   setup_test
 

--- a/tests/test-just_docker_functions.bsh
+++ b/tests/test-just_docker_functions.bsh
@@ -39,11 +39,6 @@ begin_test "docker-compose restore from cache"
     echo D "${@}"
   }
 
-  function Docker-compose()
-  {
-    echo DC "${@}"
-  }
-
   # only use for docker-compose config
   function docker-compose()
   {
@@ -86,12 +81,12 @@ RUN more things
   stages=(bar far stuff)
 
   # Normal test
-  ans="DC -f ${TESTDIR}/tmp3 pull
-DC -f ${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml -f ${TESTDIR}/tmp2 build boo foo
+  ans="D compose -f ${TESTDIR}/tmp3 pull
+D compose -f ${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml -f ${TESTDIR}/tmp2 build boo foo
 D tag vsiri/recipe:boo vsiri/ci_cache:recipe_foos_boo
 D tag vsiri/recipe:foo vsiri/ci_cache:recipe_foos_foo
-DC -f ${TESTDIR}/tmp1 -f ${TESTDIR}/tmp2 --project-directory . build foos_auto_gen_bar foos_auto_gen_far foos_auto_gen_stuff foos
-DC -f ${TESTDIR}/tmp3 push"
+D compose -f ${TESTDIR}/tmp1 -f ${TESTDIR}/tmp2 --project-directory . build foos_auto_gen_bar foos_auto_gen_far foos_auto_gen_stuff foos
+D compose -f ${TESTDIR}/tmp3 push"
   cmd="$(docker-compose_restore_from_cache compose.yml foos)"
   [ "${cmd}" = "${ans}" ]
   # [ "$(xxd <<< "${cmd}")" = "$(xxd <<< "${ans}")" ]
@@ -108,10 +103,10 @@ RUN something
 FROM stuff
 RUN more things
 " > foo.Dockerfile
-  ans="DC -f ${TESTDIR}/tmp3 pull
-DC -f ${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml -f ${TESTDIR}/tmp2 build
-DC -f ${TESTDIR}/tmp1 -f ${TESTDIR}/tmp2 --project-directory . build foos_auto_gen_stuff foos
-DC -f ${TESTDIR}/tmp3 push"
+  ans="D compose -f ${TESTDIR}/tmp3 pull
+D compose -f ${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml -f ${TESTDIR}/tmp2 build
+D compose -f ${TESTDIR}/tmp1 -f ${TESTDIR}/tmp2 --project-directory . build foos_auto_gen_stuff foos
+D compose -f ${TESTDIR}/tmp3 push"
   echo 1 > "${TESTDIR}/tmpcount"
   cmd="$(docker-compose_restore_from_cache compose.yml foos)"
   [ "${cmd}" = "${ans}" ]
@@ -120,10 +115,10 @@ DC -f ${TESTDIR}/tmp3 push"
   echo "FROM stuff
 RUN more things
 " > foo.Dockerfile
-  ans="DC -f ${TESTDIR}/tmp3 pull
-DC -f ${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml -f ${TESTDIR}/tmp2 build
-DC -f ${TESTDIR}/tmp1 -f ${TESTDIR}/tmp2 --project-directory . build foos
-DC -f ${TESTDIR}/tmp3 push"
+  ans="D compose -f ${TESTDIR}/tmp3 pull
+D compose -f ${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml -f ${TESTDIR}/tmp2 build
+D compose -f ${TESTDIR}/tmp1 -f ${TESTDIR}/tmp2 --project-directory . build foos
+D compose -f ${TESTDIR}/tmp3 push"
   echo 1 > "${TESTDIR}/tmpcount"
   cmd="$(docker-compose_restore_from_cache compose.yml foos)"
   [ "${cmd}" = "${ans}" ]
@@ -144,10 +139,10 @@ FROM stuff
 RUN more things
 " > bar/bar.Dockerfile
 
-  ans="DC -f ${TESTDIR}/tmp3 pull
-DC -f ${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml -f ${TESTDIR}/tmp2 build
-DC -f ${TESTDIR}/tmp1 -f ${TESTDIR}/tmp2 --project-directory . build bars_auto_gen_stuff bars
-DC -f ${TESTDIR}/tmp3 push"
+  ans="D compose -f ${TESTDIR}/tmp3 pull
+D compose -f ${VSI_COMMON_DIR}/docker/recipes/docker-compose.yml -f ${TESTDIR}/tmp2 build
+D compose -f ${TESTDIR}/tmp1 -f ${TESTDIR}/tmp2 --project-directory . build bars_auto_gen_stuff bars
+D compose -f ${TESTDIR}/tmp3 push"
   echo 1 > "${TESTDIR}/tmpcount"
   cmd="$(docker-compose_restore_from_cache compose.yml bars)"
   [ "${cmd}" = "${ans}" ]

--- a/tests/test-just_docker_functions.bsh
+++ b/tests/test-just_docker_functions.bsh
@@ -30,6 +30,7 @@ end_test
 
 source "${VSI_COMMON_DIR}/linux/just_files/just_docker_functions.bsh"
 
+# DEPRECATED
 begin_test "docker-compose restore from cache"
 (
   setup_test
@@ -153,6 +154,7 @@ DC -f ${TESTDIR}/tmp3 push"
 )
 end_test
 
+# DEPRECATED
 begin_test "auto gen push pull file"
 (
   setup_test
@@ -178,6 +180,7 @@ begin_test "auto gen push pull file"
 )
 end_test
 
+# DEPRECATED
 begin_test "auto gen recipe from cache file"
 (
   setup_test
@@ -196,6 +199,7 @@ services:" ]
 )
 end_test
 
+# DEPRECATED
 begin_test "auto gen add cache from"
 (
   setup_test

--- a/tests/test-new_just.bsh
+++ b/tests/test-new_just.bsh
@@ -184,15 +184,15 @@ begin_test "new_just write docker_pipenv_version"
 
     . Justfile
     ans="docker buildx bake gosu pipenv tini vsi
-docker-compose -f ${TESTDIR}/docker-compose.yml build
+docker compose -f ${TESTDIR}/docker-compose.yml build
 docker volume rm username${project_name}_venv"
 
     [ "$(DRYRUN=echo caseify build)" = "${ans}" ]
-    ans="docker-compose -f ${TESTDIR}/docker-compose.yml build example
+    ans="docker compose -f ${TESTDIR}/docker-compose.yml build example
 docker volume rm username${project_name}_venv"
     [ "$(DRYRUN=echo caseify build example)" = "${ans}" ]
 
-    ans="docker-compose -f ${TESTDIR}/docker-compose.yml build example2"
+    ans="docker compose -f ${TESTDIR}/docker-compose.yml build example2"
     [ "$(DRYRUN=echo caseify build example2)" = "${ans}" ]
 
     function Just-docker-compose()
@@ -206,7 +206,7 @@ docker volume rm username${project_name}_venv"
     {
       echo "Justify ${@}"
     }
-    ans="docker-compose -f ${TESTDIR}/docker-compose.yml down
+    ans="docker compose -f ${TESTDIR}/docker-compose.yml down
 Justify git_submodule-update
 Justify build"
     [ ! -e ".just_synced" ]

--- a/tests/test-versions.bsh
+++ b/tests/test-versions.bsh
@@ -1056,7 +1056,7 @@ OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019'
   [ "$(docker_version)" = "19.03.5" ]
   for index in "${!docker_compose_strings[@]}"; do
     docker_compose_string="${docker_compose_strings[index]}"
-    asster_str_eq "$(DOCKER_COMPOSE=docker_compose docker_compose_version)" "${docker_compose_versions[index]}"
+    assert_str_eq "$(DOCKER_COMPOSE=docker_compose docker_compose_version)" "${docker_compose_versions[index]}"
   done
 )
 end_test

--- a/tests/test-versions.bsh
+++ b/tests/test-versions.bsh
@@ -1007,10 +1007,29 @@ begin_test "program versions"
     fi
   }
 
+  docker_compose_strings=('docker-compose version 1.25.5, build 8a1c60f6
+docker-py version: 4.1.0
+CPython version: 3.7.5
+OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019'
+  'docker-compose version 1.29.2, build 5becea4c
+docker-py version: 5.0.0
+CPython version: 3.7.10
+OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019'
+  'Docker Compose version v2.0.1'
+  'Docker Compose version v2.1.0'
+  'Docker Compose version v2.10.1'
+  'Docker Compose version v2.1.1'
+  'Docker Compose version v2.15.1'
+  'Docker Compose version v2.18.1'
+  'Docker Compose version v2.3.3'
+  'Docker Compose version v2.4.1')
+  docker_compose_versions=("1.25.5" "1.29.2" "2.0.1" "2.1.0" "2.10.1" "2.1.1" "2.15.1" "2.18.1" "2.3.3" "2.4.1")
   function docker_compose()
   {
-    if [ "${1}" = "--version" ]; then
-      echo "docker-compose version 1.24.0, build 0aa59064"
+    if [ "${1}" = "version" ]; then
+      echo "${docker_compose_string}"
+    else
+      false
     fi
   }
 
@@ -1035,7 +1054,10 @@ begin_test "program versions"
   [ "$(BASH=bash_mock bash_version)" = "5.0.10r1" ]
   [ "$(git_version)" = "2.24.1" ]
   [ "$(docker_version)" = "19.03.5" ]
-  [ "$(DOCKER_COMPOSE=docker_compose docker_compose_version)" = "1.24.0" ]
+  for index in "${!docker_compose_strings[@]}"; do
+    docker_compose_string="${docker_compose_strings[index]}"
+    asster_str_eq "$(DOCKER_COMPOSE=docker_compose docker_compose_version)" "${docker_compose_versions[index]}"
+  done
 )
 end_test
 

--- a/tests/test-yarp.bsh
+++ b/tests/test-yarp.bsh
@@ -36,7 +36,7 @@ a[0] = 1
 a[1] = 2"
   check_ans
 
-# This is a would be nice feature, but docker-compose parses this out, so it's
+# This is a would be nice feature, but docker compose parses this out, so it's
 # not an immediate concern
 #   doc="\
 # a:

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -71,8 +71,8 @@ set_array_default VSI_COMMON_TEST_OSES \
 
 # Put variables that do not begin with VSI_COMMON here.
 
-# Use this to add the user name to the docker-compose project name. This is
-# important when multiple users are using this docker-compose project on a
+# Use this to add the user name to the docker compose project name. This is
+# important when multiple users are using this docker compose project on a
 # single host. This way all of the docker resources are prefixed with a unique
 # name and do not collide
 source "${VSI_COMMON_DIR}/linux/just_files/docker_functions.bsh"


### PR DESCRIPTION
This is the bulk of the refactor to upgrade from docker-compose version 1 to docker compose version 2

In order to achieve this I had to:
- Update the test docker images used in CI
- Remove the `-` in `docker-compose`
- Change `DOCKER_COMPOSE` into an array
- Removing `Exec-Docker` as this seems to never be used
- Old ci load scripts were not updated, as they will be removed in the near future
- `docker compose build` has not been fully replaced with `docker buildx bake` yet
