### PR TITLE
NFS readonly bug

### DIFF
--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -228,6 +228,10 @@ function generate_docker_compose_override()
   local volume_flags
   local compose_config
 
+  local volumes_host=()
+  local volumes_docker=()
+  local volumes_flags=()
+
   # parse_docker_compose_volumes/docker_compose_volumes vars
   local DOCKER_VOLUME_LINES
   local DOCKER_VOLUME_SOURCES
@@ -388,8 +392,41 @@ function generate_docker_compose_override()
         volume_host="$(cygpath -w "${volume_host}")"
       fi
 
+      volumes_host+=("${volume_host}")
+      volumes_docker+=("${volume_docker}")
+      volumes_flags+=("${volume_flags}")
+
+    done
+
+    # Deduplicate. Only need to remove from volumes_host, as that is what is used
+    # for indexing.
+    for i in "${!volumes_host[@]}"; do
+      local -i j=1
+      for j in "${!volumes_host[@]}"; do
+        # only search one sided and just entries already removed
+        if [ "${i}" -ge "${j}" -o -z "${volumes_host[i]+set}" ]; then
+          continue
+        fi
+
+        # Remove duplicates because docker compose doesn't like them
+        if [ "${volumes_host[i]}" = "${volumes_host[j]}" -a \
+             "${volumes_docker[i]}" = "${volumes_docker[j]}" ]; then
+          if [ "${volumes_flags[i]}" = "${volumes_flags[j]}" ]; then
+            unset volumes_host[j]
+          else
+            if [[ ${volumes_flags[j]} =~ :ro ]]; then
+              unset volumes_host[j]
+            else
+              unset volumes_host[i]
+            fi
+          fi
+        fi
+      done
+    done
+
+    for i in "${!volumes_host[@]}"; do
       IFS=:
-      over_volumes+=("      - ${volume_host}:${volume_docker}${volume_flags}")
+      over_volumes+=("      - ${volumes_host[i]}:${volumes_docker[i]}${volumes_flags[i]}")
       IFS="${OLD_IFS}"
     done
     IFS=$'\n'
@@ -400,31 +437,31 @@ function generate_docker_compose_override()
     # the order, the read only would take precedence, and you would be unable to
     # write where you needed to, and get unexpected failures due to using NFS.
     # So the solution for now is to just prefer the read-write over read-only.
-    over_volumes=($(awk -F: '
-      # Deduplicate fully identical lines
-      !count[$0]++ {
-        # Save the order of the original lines.
-        original_order[NR]=$0
-        key=$1":"$2
-        deduplicate_keys[NR]=key
-        if ( key in deduplicate ) {
-          # Do nothing if already there, Always prefer not :ro
-          if (deduplicate[key] != $0 && deduplicate[key] ~ /:ro/) {
-            deduplicate[key]=$0
-          }
-        } else {
-          deduplicate[key]=$0
-        }
-      }
-      END{
-        # Print out deduplicated list in order
-        for (key in original_order) {
-          # If the line matches exactly, print it
-          if ( deduplicate[deduplicate_keys[key]] == original_order[key] ) {
-            print original_order[key]
-          }
-        }
-      }' <<< "${over_volumes[*]}"))
+    # over_volumes=($(awk -F: '
+    #   # Deduplicate fully identical lines
+    #   {
+    #     # Save the order of the original lines.
+    #     original_order[NR]=$0
+    #     key=$1":"$2
+    #     deduplicate_keys[NR]=key
+    #     if ( key in deduplicate ) {
+    #       # Do nothing if already there, Always prefer not :ro
+    #       if (deduplicate[key] != $0 && deduplicate[key] ~ /:ro/) {
+    #         deduplicate[key]=$0
+    #       }
+    #     } else {
+    #       deduplicate[key]=$0
+    #     }
+    #   }
+    #   END{
+    #     # Print out deduplicated list in order
+    #     for (key in original_order) {
+    #       # If the line matches exactly, print it
+    #       if ( deduplicate[deduplicate_keys[key]] == original_order[key] ) {
+    #         print original_order[key]
+    #       }
+    #     }
+    #   }' <<< "${over_volumes[*]}"))
 
     if [ " ""${over_volumes[@]+set}" = " set" ]; then
       echo "    volumes:"

--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -408,12 +408,18 @@ function generate_docker_compose_override()
           continue
         fi
 
-        # Remove duplicates because docker compose doesn't like them
+        # Look for identical host:container pairs
         if [ "${volumes_host[i]}" = "${volumes_host[j]}" -a \
              "${volumes_docker[i]}" = "${volumes_docker[j]}" ]; then
           if [ "${volumes_flags[i]}" = "${volumes_flags[j]}" ]; then
+            # Remove exact duplicates because docker compose doesn't like them
             unset volumes_host[j]
           else
+            # This is really crude. The following flags are not being considered:
+            # [z|Z]
+            # [[r]shared|[r]slave|[r]private]
+            # [delegated|cached|consistent]
+            # [nocopy]
             if [[ ${volumes_flags[j]} =~ :ro ]]; then
               unset volumes_host[j]
             else
@@ -430,38 +436,6 @@ function generate_docker_compose_override()
       IFS="${OLD_IFS}"
     done
     IFS=$'\n'
-    # Remove duplicates (https://unix.stackexchange.com/q/159695) because
-    # docker compose doesn't like them
-    # Originally this just had to remove duplicate entries, but the nfs code could
-    # easily create pairs of mounts that were some :ro and some :rw. Depending on
-    # the order, the read only would take precedence, and you would be unable to
-    # write where you needed to, and get unexpected failures due to using NFS.
-    # So the solution for now is to just prefer the read-write over read-only.
-    # over_volumes=($(awk -F: '
-    #   # Deduplicate fully identical lines
-    #   {
-    #     # Save the order of the original lines.
-    #     original_order[NR]=$0
-    #     key=$1":"$2
-    #     deduplicate_keys[NR]=key
-    #     if ( key in deduplicate ) {
-    #       # Do nothing if already there, Always prefer not :ro
-    #       if (deduplicate[key] != $0 && deduplicate[key] ~ /:ro/) {
-    #         deduplicate[key]=$0
-    #       }
-    #     } else {
-    #       deduplicate[key]=$0
-    #     }
-    #   }
-    #   END{
-    #     # Print out deduplicated list in order
-    #     for (key in original_order) {
-    #       # If the line matches exactly, print it
-    #       if ( deduplicate[deduplicate_keys[key]] == original_order[key] ) {
-    #         print original_order[key]
-    #       }
-    #     }
-    #   }' <<< "${over_volumes[*]}"))
 
     if [ " ""${over_volumes[@]+set}" = " set" ]; then
       echo "    volumes:"

--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -392,10 +392,40 @@ function generate_docker_compose_override()
       over_volumes+=("      - ${volume_host}:${volume_docker}${volume_flags}")
       IFS="${OLD_IFS}"
     done
+    IFS=$'\n'
     # Remove duplicates (https://unix.stackexchange.com/q/159695) because
     # docker compose doesn't like them
-    IFS=$'\n'
-    over_volumes=($(awk '!count[$0]++' <<< "${over_volumes[*]+${over_volumes[*]}}"))
+    # Originally this just had to remove duplicate entries, but the nfs code could
+    # easily create pairs of mounts that were some :ro and some :rw. Depending on
+    # the order, the read only would take precedence, and you would be unable to
+    # write where you needed to, and get unexpected failures due to using NFS.
+    # So the solution for now is to just prefer the read-write over read-only.
+    over_volumes=($(awk -F: '
+      # Deduplicate fully identical lines
+      !count[$0]++ {
+        # Save the order of the original lines.
+        original_order[NR]=$0
+        key=$1":"$2
+        deduplicate_keys[NR]=key
+        if ( key in deduplicate ) {
+          # Do nothing if already there, Always prefer not :ro
+          if (deduplicate[key] != $0 && deduplicate[key] ~ /:ro/) {
+            deduplicate[key]=$0
+          }
+        } else {
+          deduplicate[key]=$0
+        }
+      }
+      END{
+        # Print out deduplicated list in order
+        for (key in original_order) {
+          # If the line matches exactly, print it
+          if ( deduplicate[deduplicate_keys[key]] == original_order[key] ) {
+            print original_order[key]
+          }
+        }
+      }' <<< "${over_volumes[*]}"))
+
     if [ " ""${over_volumes[@]+set}" = " set" ]; then
       echo "    volumes:"
       echo "${over_volumes[*]+${over_volumes[*]}}"

--- a/tests/test-docker_compose_override.bsh
+++ b/tests/test-docker_compose_override.bsh
@@ -124,7 +124,7 @@ begin_test "Just docker compose dynamic volumes"
   fi
   TEST_VOLUMES=(".:/trash:z")
   override="$(generate_docker_compose_override TEST test1)"
-  [ "${override}" = "${ans1}" ]
+  assert_str_eq "${override}" "${ans1}"
 
   TEST_VOLUMES=("/tmp:/temp:ro")
   ans+="$(vol "$(real_path "/tmp")" /temp:ro)"
@@ -174,6 +174,15 @@ begin_test "Just docker compose dynamic volumes"
 
   TEST_TEST1_VOLUME_2="${TESTDIR}/bar2:/foo5"
   ans+="$(vol "$(real_path "${TESTDIR}/bar2")" /foo5)"
+  override="$(generate_docker_compose_override TEST test1)"
+  if [ "${OS-}" = "Windows_NT" ]; then
+    [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
+  else
+    assert_str_eq "${override}" "${ans}"
+  fi
+
+  # Make sure readonly doesn't shadow a read-write
+  TEST_TEST1_VOLUME_3="${TESTDIR}/bar2:/foo5:ro"
   override="$(generate_docker_compose_override TEST test1)"
   if [ "${OS-}" = "Windows_NT" ]; then
     [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]


### PR DESCRIPTION
Fix so that read/write is preferred over read-only

The NFS code is liklly to create multiple mount points that are the same, except the :ro vs :rw flag. The original awk code was not good enough to remove complicated duplicates, so it was converted to bash looks that remove identical volumes, and if it see an `:ro` flag, it will prefer the other one (even if the first volume has `:ro`.