### PR TITLE
Master main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,4 +198,4 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |Linux|Windows|macOS|docs|
 |--|--|--|--|
-|[![CircleCI](https://circleci.com/gh/VisionSystemsInc/vsi_common.svg?style=shield)](https://circleci.com/gh/VisionSystemsInc/vsi_common)|[![Build status](https://ci.appveyor.com/api/projects/status/3a3hd3m41clxd5gw/branch/master?svg=true)](https://ci.appveyor.com/project/andyneff/vsi-common/branch/master)|[![Build Status](https://github.com/visionsystemsinc/vsi_common/actions/workflows/macos.yml/badge.svg?branch=master)](https://github.com/VisionSystemsInc/vsi_common/actions)|[![Docs](https://img.shields.io/circleci/build/gh/VisionSystemsInc/vsi_common/master?label=docs)](https://visionsystemsinc.github.io/vsi_common)|
+|[![CircleCI](https://circleci.com/gh/VisionSystemsInc/vsi_common.svg?style=shield)](https://circleci.com/gh/VisionSystemsInc/vsi_common)|[![Build status](https://ci.appveyor.com/api/projects/status/3a3hd3m41clxd5gw/branch/main?svg=true)](https://ci.appveyor.com/project/andyneff/vsi-common/branch/main)|[![Build Status](https://github.com/visionsystemsinc/vsi_common/actions/workflows/macos.yml/badge.svg?branch=main)](https://github.com/VisionSystemsInc/vsi_common/actions)|[![Docs](https://img.shields.io/circleci/build/gh/VisionSystemsInc/vsi_common/main?label=docs)](https://visionsystemsinc.github.io/vsi_common)|
 
 In order to use these directories, all you have to do is
 
@@ -20,7 +20,7 @@ In order to use these directories, all you have to do is
 
 * Python
 
-  * Prefered
+  * Preferred
 
     ```bash
     pip install git+https://github.com/visionsystemsinc/vsi_common.git

--- a/linux/git_functions.bsh
+++ b/linux/git_functions.bsh
@@ -37,7 +37,7 @@ source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 # List all commits on branches/tags that have not been pushed to a remote. This is a set operation: it lists all the commits from a branch in the DAG except those reachable by a remote-tracking branch. It does not require an *associated* remote-tracking branch
 #
 # :Arguments: - [``$1``] - A name of a remote to filter by; e.g., origin. If unset, then don't filter
-#             - [``$2...``] - A branch/tag to filter by (or multiple branches/tags); e.g., master. If unset, then don't filter
+#             - [``$2...``] - A branch/tag to filter by (or multiple branches/tags); e.g., main. If unset, then don't filter
 #
 # :Output: - ``*stdout*`` - Print all unpushed commits for tracking branches to stdout
 #
@@ -93,7 +93,7 @@ function _log_commits_helper()
 #
 # Get the corresponding remote-tracking branch for a local-tracking branch
 #
-# :Arguments: - ``$1`` - A local-tracking branch; e.g., master
+# :Arguments: - ``$1`` - A local-tracking branch; e.g., main
 #
 # :Output: - ``*stdout*`` - The corresponding remote-tracking branch, or the empty string if there is no tracking branch
 #
@@ -174,7 +174,7 @@ function git_tracking_branches()
   #
   # Alternatively,
   #   git for-each-ref --format='%(upstream:short) %(refname) %(upstream:track)' refs/heads
-  # where, for example, upstream:short=origin/master, refname=refs/heads/master
+  # where, for example, upstream:short=origin/main, refname=refs/heads/main
   # and upstream:track=[ahead 3] or [gone] if the remote-tracking branch has
   # been pruned. upstream:short is a blank space (' ') if upstream is unset,
   # i.e., there is no remote-tracking branch setup
@@ -210,7 +210,7 @@ function git_tracking_branches()
 #
 # List all unpushed commits for a tracking branch to stdout
 #
-# :Arguments: - ``$1...`` - A local-tracking branch (or multiple branches); e.g., master
+# :Arguments: - ``$1...`` - A local-tracking branch (or multiple branches); e.g., main
 #
 # :Output: - ``*stdout*`` - Print all unpushed commits for the tracking branch to stdout
 #
@@ -1024,8 +1024,8 @@ function submodule-helper-relative-url()
     mkdir -p "${sm_path}" .git/modules/"${sm_path}"/{objects,refs/heads}
     # Strip trailing slash (not necessary, but easy)
     echo "gitdir: ${up_path%/}/.git/modules/${sm_path}" > "${sm_path}"/.git
-    echo "ref: refs/heads/master" > .git/modules/"${sm_path}"/HEAD
-    echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" > .git/modules/"${sm_path}"/refs/heads/master
+    echo "ref: refs/heads/main" > .git/modules/"${sm_path}"/HEAD
+    echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" > .git/modules/"${sm_path}"/refs/heads/main
 
     # from https://stackoverflow.com/a/37378302
     "${GIT}" update-index --add --cacheinfo 160000 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "${sm_path}" 1>/dev/null

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -546,7 +546,8 @@ function git_mirror_repos()
   fi
 
   local BRANCH="${2-}"
-  # Use git's init.defaultBranch default value. If it is unset, the default is still master in the latest git
+  # Use git's init.defaultBranch default value. If it is unset, the default is
+  # still master in the latest git
   if [ -z "${BRANCH}" ]; then
     BRANCH=$("${GIT}" config --get init.defaultBranch) || BRANCH=master
   fi

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -433,7 +433,7 @@ function sync_submodules()
 #
 # Mirror the main repository and all submodules (recursively)
 #
-# Downloads a mirror of a git repository and all of its submodules. The normal ``git clone --mirror`` command does not support submodules at all. This at least clones all the submodules available in the specified branch (master by default).
+# Downloads a mirror of a git repository and all of its submodules. The normal ``git clone --mirror`` command does not support submodules at all. This at least clones all the submodules available in the specified branch (git's init.defaultBranch by default).
 #
 # The script creates a directory, referred to as a prep directory (or prep_dir), which will contain all of the mirrored repositories plus a single ``transfer_{date}.tgz`` archive file containing all of these repositories, lfs objects, etc... Only this `tgz` file needs to be transferred to your destination.
 #
@@ -546,12 +546,9 @@ function git_mirror_repos()
   fi
 
   local BRANCH="${2-}"
-  # Use git's init.defaultBranch default value. If it is unset, the default is still master in the lastest git
+  # Use git's init.defaultBranch default value. If it is unset, the default is still master in the latest git
   if [ -z "${BRANCH}" ]; then
-    BRANCH="${GIT}" config --get init.defaultBranch
-    if [ -z "${BRANCH}" ]; then
-      BRANCH=master # The default default is still master
-    fi
+    BRANCH=$("${GIT}" config --get init.defaultBranch) || BRANCH=master
   fi
 
   local MAIN_DIR="$(basename "${GIT_MIRROR_MAIN_REPO}")"

--- a/linux/git_mirror
+++ b/linux/git_mirror
@@ -35,7 +35,7 @@ GIT_MIRROR_SOURCE="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"/"$(basename "${B
 #
 # Example usage:
 #
-# #. ``git_mirror mirror https://github.com/visionsystemsinc/vsi_common.git master`` - Mirror the repository and recursively create mirrors of all submodules currently in the master branch.
+# #. ``git_mirror mirror https://github.com/visionsystemsinc/vsi_common.git main`` - Mirror the repository and recursively create mirrors of all submodules currently in the main branch.
 # #. Transfer ``vsi_common_prep/transfer_{date}.tgz`` to your destination
 # #. On the destination, create a directory, e.g., vsi_common_prep, and move the archive into it
 # #. Extract the archive (the archive will extract directly into this directory)
@@ -444,7 +444,7 @@ function sync_submodules()
 # After you have moved the transfer archive to its destination, you can use :func:`git_push_main` to push these mirrored repositories to a new git server.
 #
 # :Arguments: - ``$1`` - URL of the main git repository. On subsequent calls to this function, the prep (cache) dir created by this function can be used in lue of the repository's URL
-#             - [``$2``] - The git branch from which to identify the submodules. Default: master
+#             - [``$2``] - The git branch from which to identify the submodules. Default: git's init.defaultBranch
 # :Parameters: [``GIT_MIRROR_PREP_DIR``] - The output directory in which to mirror the repositories; Default: ``${PWD}/{repo_name}_prep``
 # :Output: - A prep directory which will contain all of the repositories plus a single ``transfer_{date}.tgz``
 #          - ``GIT_MIRROR_PREP_DIR`` - The path to the mirrored repositories
@@ -456,7 +456,7 @@ function sync_submodules()
 #
 # .. code-block:: bash
 #
-#    git_mirror_main https://github.com/visionsystemsinc/vsi_common.git master
+#    git_mirror_main https://github.com/visionsystemsinc/vsi_common.git main
 #    # produces ./vsi_common_prep/transfer_2020_03_02_14_16_09.tgz
 #
 # .. rubric:: Example
@@ -483,7 +483,7 @@ function sync_submodules()
 #
 # .. note::
 #
-#   ``git_mirror_main`` does not mirror all submodules that have ever been part of the repo, only those from a specific branch/SHA/tag you specify (master by default). This is because trying to mirror all submodules from the past could be very lengthy, and is very likely to include URLs that do not exist anymore.
+#   ``git_mirror_main`` does not mirror all submodules that have ever been part of the repo, only those from a specific branch/SHA/tag you specify (git's init.defaultBranch by default). This is because trying to mirror all submodules from the past could be very lengthy, and is very likely to include URLs that do not exist anymore.
 #
 # .. rubric:: Bugs
 #
@@ -501,12 +501,12 @@ function git_mirror_main()
 #
 # Mirror the main repository and all submodules (recursively)
 #
-# Downloads a mirror of a git repository and all of its submodules. The normal ``git clone --mirror`` command does not support submodules at all. This at least clones all the submodules available in the specified branch (master by default).
+# Downloads a mirror of a git repository and all of its submodules. The normal ``git clone --mirror`` command does not support submodules at all. This at least clones all the submodules available in the specified branch (git's init.defaultBranch by default).
 #
 # Creates a directory, referred to as a prep directory (or prep_dir), which will contain all of the mirrored repositories. Subsequent calls to :func:`git_mirror_repos` can use the existing prep directory as cache, updating faster than the first time.
 #
 # :Arguments: - ``$1`` - URL of the main git repository. On subsequent calls to this function, the prep (cache) directory created by this function can be used in lue of the repository's URL
-#             - [``$2``] - The git branch from which to identify the submodules. Default: master
+#             - [``$2``] - The git branch from which to identify the submodules. Default: git's init.defaultBranch
 # :Parameters: [``GIT_MIRROR_PREP_DIR``] - The output directory in which to mirror the repositories; Default: ``${PWD}/{repo_name}_prep``
 # :Output: - A prep directory which will contain all of the repositories
 #          - ``GIT_MIRROR_PREP_DIR`` - The path to the mirrored repositories
@@ -514,7 +514,7 @@ function git_mirror_main()
 #
 # .. note::
 #
-#   :func:`git_mirror_repos` does not mirror all submodules that have ever been part of the repo, only those from a specific branch/SHA/tag you specify (master by default). This is because trying to mirror all submodules from the past could be very lengthy, and is very likely to include URLs that do not exist anymore.
+#   :func:`git_mirror_repos` does not mirror all submodules that have ever been part of the repo, only those from a specific branch/SHA/tag you specify (git's init.defaultBranch by default). This is because trying to mirror all submodules from the past could be very lengthy, and is very likely to include URLs that do not exist anymore.
 #
 # .. rubric:: Bugs
 #
@@ -544,7 +544,15 @@ function git_mirror_repos()
   else
     GIT_MIRROR_MAIN_REPO="${1}"
   fi
-  local BRANCH="${2-master}"
+
+  local BRANCH="${2-}"
+  # Use git's init.defaultBranch default value. If it is unset, the default is still master in the lastest git
+  if [ -z "${BRANCH}" ]; then
+    BRANCH="${GIT}" config --get init.defaultBranch
+    if [ -z "${BRANCH}" ]; then
+      BRANCH=master # The default default is still master
+    fi
+  fi
 
   local MAIN_DIR="$(basename "${GIT_MIRROR_MAIN_REPO}")"
   MAIN_DIR="${MAIN_DIR%.*}"
@@ -1013,11 +1021,11 @@ function git_push_main()
 #
 # Tag the refs in the mirrored repository and all submodules
 #
-# Before pushing the mirrored repository and all of its submodules to the new git server with :func:`git_push_main`, tag the refs so that if, during the **next** transfer, they become dereferenced (due to a force push, which is sometimes necessary), they are not lost. For a ref of the form refs/heads/master, this (annotated) tag takes the (long) form of refs/tags/just_git_mirror/{datetime}/heads/master
+# Before pushing the mirrored repository and all of its submodules to the new git server with :func:`git_push_main`, tag the refs so that if, during the **next** transfer, they become dereferenced (due to a force push, which is sometimes necessary), they are not lost. For a ref of the form refs/heads/main, this (annotated) tag takes the (long) form of refs/tags/just_git_mirror/{datetime}/heads/main
 #
 # :Arguments: ``$1`` - A file specifying the mapping between each repository and its mirror URL; see :func:`_git_mirror_load_info`
 #             ``$2`` - The mirrored repositories (extracted from the archive) created by :func:`git_mirror_main`
-# :Parameters: [``GIT_MIRROR_TAG_REFS_REGEX``] - An extended regular expression specifying which refs to tag. The refs should be matched in their long form, e.g., refs/heads/master or refs/tags/v1.0.0. Default: ^refs/heads/.+
+# :Parameters: [``GIT_MIRROR_TAG_REFS_REGEX``] - An extended regular expression specifying which refs to tag. The refs should be matched in their long form, e.g., refs/heads/main or refs/tags/v1.0.0. Default: ^refs/heads/.+
 #
 # .. seealso::
 #
@@ -1073,7 +1081,7 @@ function git_tag_main()
             # [1] https://git-scm.com/book/en/v2/Git-Basics-Tagging
 
             # A ref is tagged with just_git_mirror/{date}/{namespaced_ref},
-            # where namespaced_ref is the long-form ref (e.g., refs/heads/master)
+            # where namespaced_ref is the long-form ref (e.g., refs/heads/main)
             # with the refs/ domain stripped off
             local namespaced_ref="${ref/refs\//}"
             local SHA="$("${GIT}" show-ref --hash "${ref}")"

--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -368,7 +368,7 @@ function generate_docker_compose_override()
       # inheritance.
       unset_flag E
       local mp_rv=0
-      host_mount_point="$(mount_point "${volume_host}" nfs nfs3 nfs4)" || mp_rv="${?}"
+      host_mount_point="$(set -xv; mount_point "${volume_host}" nfs nfs3 nfs4)" || mp_rv="${?}"
       reset_flag E
 
       # If the volume is not a docker volume

--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -368,7 +368,7 @@ function generate_docker_compose_override()
       # inheritance.
       unset_flag E
       local mp_rv=0
-      host_mount_point="$(set -xv; mount_point "${volume_host}" nfs nfs3 nfs4)" || mp_rv="${?}"
+      host_mount_point="$(mount_point "${volume_host}" nfs nfs3 nfs4)" || mp_rv="${?}"
       reset_flag E
 
       # If the volume is not a docker volume

--- a/linux/just_files/docker_functions.bsh
+++ b/linux/just_files/docker_functions.bsh
@@ -1215,7 +1215,7 @@ function Just-docker-compose()
 function docker_service_running()
 {
   "${DOCKER}" inspect -f '{{.State.Status}}' \
-              $("${DOCKER_COMPOSE[@]}" ps -q ${@+"${@}"}) 2>/dev/null # noquotes
+              $("${DOCKER_COMPOSE[@]}" ps -qa ${@+"${@}"}) 2>/dev/null # noquotes
 }
 
 #**

--- a/linux/just_files/just_diff
+++ b/linux/just_files/just_diff
@@ -31,7 +31,7 @@ fi
 #
 # .. code-block::
 #
-#   just_diff "$(git rev-parse HEAD)" "$(git describe --abbrev=0 --tags origin/master)"
+#   just_diff "$(git rev-parse HEAD)" "$(git describe --abbrev=0 --tags origin/main)"
 #
 # Another use case, is in a ``just`` project, if you have checkout out the newest vsi_common commit, but not commit that change to the project:
 #

--- a/linux/just_git_airgap_repo.bsh
+++ b/linux/just_git_airgap_repo.bsh
@@ -83,7 +83,7 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 #
 # This repository is now setup and can be mirrored and pushed to a new air-gapped git server:
 #
-# #. ``just git export-repo-guided`` - This target asks a series of questions and then mirrors the repository and its submodules (recursively). For this example, when prompted, we will, "Create a new mirror from a remote's URL", and save the the mirrored repositories to the output directory, ``{output_dir}``. In this case, because there is only a single remote, ``origin``, and a single branch, ``master``, they are chosen automatically.
+# #. ``just git export-repo-guided`` - This target asks a series of questions and then mirrors the repository and its submodules (recursively). For this example, when prompted, we will, "Create a new mirror from a remote's URL", and save the the mirrored repositories to the output directory, ``{output_dir}``. In this case, because there is only a single remote, ``origin``, and a single branch, ``main``, they are chosen automatically.
 #
 # .. note::
 #   The mirror is created from (the URL of) the remote---not directly from this clone itself.
@@ -141,7 +141,7 @@ JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 #
 #   1. While the mirrored repository is a proper git repository, care must be taken to ensure subsequent (incremental) mirrors are successful: specifically, the transferred branches must remain read-only. However, additional branches/tags can be created as long as their names won't clash with those from the host repository.
 #
-#   #. :func:`git_mirror git_mirror_main`, and by extension this plugin, does not mirror all submodules that have ever been part of the repo, only those from a specific branch/SHA/tag you specify (master by default). Consequently, checking out another version of the repository with a different version of the .gitmodules file in which a submodule has been deleted or renamed may cause the ``git_airgap-submodule-update`` to fail because the submodule's remote URL could not be re-configured to point to the mirror.
+#   #. :func:`git_mirror git_mirror_main`, and by extension this plugin, does not mirror all submodules that have ever been part of the repo, only those from a specific branch/SHA/tag you specify (git's init.defaultBranch by default). Consequently, checking out another version of the repository with a different version of the .gitmodules file in which a submodule has been deleted or renamed may cause the ``git_airgap-submodule-update`` to fail because the submodule's remote URL could not be re-configured to point to the mirror.
 #
 # .. seealso::
 #
@@ -462,7 +462,7 @@ function relocate_git_defaultify()
         echo "                            [-r|--remote-name] [-p|--prep-dir]"
         echo "                            [-o|--output-dir] [-h|--help]"
         echo
-        echo "   -b, --branch         The branch on which to base the mirror; e.g., master"
+        echo "   -b, --branch         The branch on which to base the mirror; e.g., main"
         echo "   -c, check-remote     Ensure that changes to a submodule that are tracked"
         echo "   --no-check-remote    by its parent have been pushed to the submodule's URL"
         echo "   -h, --help           Print this help"

--- a/tests/int/test-git_functions.bsh
+++ b/tests/int/test-git_functions.bsh
@@ -699,7 +699,7 @@ begin_test "git functionality"
   #
   # git branch -vv
   #   checkpoint                     Sixth commit
-  #   main                         [origin/main: ahead 4] Tenth commit
+  #   main                           [origin/main: ahead 4] Tenth commit
   #   nontracking_branch_ahead       Seventh commit
   #   nontracking_branch_behind      Second commit
   #   nontracking_branch_equal       Fourth commit
@@ -709,7 +709,7 @@ begin_test "git functionality"
   #   tracking_branch_behind         [origin/main: behind 1] Third commit
   #   tracking_branch_equal          [origin/tracking_branch_equal] Fourth commit
   #   tracking_branchpoint           [origin/main: ahead 5] Eleventh commit
-  #   up_main                      [upstream/main: ahead 3] Tenth commit
+  #   up_main                        [upstream/main: ahead 3] Tenth commit
 
   BUILD_REPO="${TESTDIR}"/build_repo
   PRETEND_URL="${TESTDIR}/git/pretend_repo.git" # bare repo

--- a/tests/int/test-git_functions.bsh
+++ b/tests/int/test-git_functions.bsh
@@ -679,11 +679,11 @@ begin_test "git functionality"
 
   # git log --pretty=format:"%s%d" --graph --all
   # * Eleventh commit (HEAD -> tracking_branchpoint)
-  # * Tenth commit (up_master, master)
+  # * Tenth commit (up_main, main)
   # *   Merge branch 'nontracking_merge'
   # |\
   # | * Branching commit (nontracking_merge)
-  # * | Ninth commit (upstream/master)
+  # * | Ninth commit (upstream/main)
   # |/
   # | * Eighth commit (tracking_branch_ahead)
   # | * Seventh commit (nontracking_branch_ahead)
@@ -691,7 +691,7 @@ begin_test "git functionality"
   # |/
   # | * Tag commit (tag: v0.9)
   # |/
-  # * Fourth commit (origin/tracking_branch_equal, origin/tracking_branch_ahead, origin/master, tracking_branch_equal, nontracking_branch_equal)
+  # * Fourth commit (origin/tracking_branch_equal, origin/tracking_branch_ahead, origin/main, tracking_branch_equal, nontracking_branch_equal)
   # * Third commit (tracking_branch_behind)
   # * Second commit (nontracking_branch_behind)
   # * First commit (remote_tracking_branch_deleted)
@@ -699,17 +699,17 @@ begin_test "git functionality"
   #
   # git branch -vv
   #   checkpoint                     Sixth commit
-  #   master                         [origin/master: ahead 4] Tenth commit
+  #   main                         [origin/main: ahead 4] Tenth commit
   #   nontracking_branch_ahead       Seventh commit
   #   nontracking_branch_behind      Second commit
   #   nontracking_branch_equal       Fourth commit
   #   nontracking_merge              Branching commit
   #   remote_tracking_branch_deleted [origin/remote_tracking_branch_deleted: gone] First commit
   # * tracking_branch_ahead          [origin/tracking_branch_ahead: ahead 3] Eighth commit
-  #   tracking_branch_behind         [origin/master: behind 1] Third commit
+  #   tracking_branch_behind         [origin/main: behind 1] Third commit
   #   tracking_branch_equal          [origin/tracking_branch_equal] Fourth commit
-  #   tracking_branchpoint           [origin/master: ahead 5] Eleventh commit
-  #   up_master                      [upstream/master: ahead 3] Tenth commit
+  #   tracking_branchpoint           [origin/main: ahead 5] Eleventh commit
+  #   up_main                      [upstream/main: ahead 3] Tenth commit
 
   BUILD_REPO="${TESTDIR}"/build_repo
   PRETEND_URL="${TESTDIR}/git/pretend_repo.git" # bare repo
@@ -765,7 +765,7 @@ begin_test "git functionality"
 
     git push origin "${GIT_DEFAULT_BRANCH}"
     # create a remote-tracking branch, origin/tracking_branch_ahead, at
-    # origin/master
+    # origin/main
     git push origin origin/"${GIT_DEFAULT_BRANCH}":refs/heads/tracking_branch_ahead
 
     git checkout -b checkpoint
@@ -889,20 +889,20 @@ begin_test "git functionality"
 
 
   pushd "${BUILD_REPO}" &> /dev/null
-    # nothing unpushed - branch (non-tracking) behind origin/master
+    # nothing unpushed - branch (non-tracking) behind origin/main
     output="$(log_unpushed_commits origin nontracking_branch_behind)"
     assert_str_eq "${output}" ""
 
-    # no outgoing commits - tracking branch is behind its tracked branch, origin/master (a differently named branch)
+    # no outgoing commits - tracking branch is behind its tracked branch, origin/main (a differently named branch)
     output="$(log_outgoing_commits tracking_branch_behind)"
     assert_str_eq "${output}" ""
 
-    # nothing unpushed - branch (non-tracking) equal to origin/* (origin/master
+    # nothing unpushed - branch (non-tracking) equal to origin/* (origin/main
     # in this case)
     output="$(log_unpushed_commits origin nontracking_branch_equal)"
     assert_str_eq "${output}" ""
 
-    # no outgoing commits - tracking branch is equal to its tracked branch, origin/master (a differently named branch)
+    # no outgoing commits - tracking branch is equal to its tracked branch, origin/main (a differently named branch)
     output="$(log_outgoing_commits tracking_branch_equal)"
     assert_str_eq "${output}" ""
 
@@ -910,16 +910,16 @@ begin_test "git functionality"
     [[ $(log_unpushed_commits origin nontracking_branch_ahead | head -n 1) = *"1 unpushed"* ]] || false
 
     # unpushed commits - branch (non-tracking) ahead of upstream/*
-    # (upstream/master in this case)
+    # (upstream/main in this case)
     [[ $(log_unpushed_commits upstream "${GIT_DEFAULT_BRANCH}" | head -n 1) = *"3 unpushed"* ]] || false
 
-    # outgoing commits - non-tracking branch ahead of upstream/master
+    # outgoing commits - non-tracking branch ahead of upstream/main
     [[ $(log_outgoing_commits "up_${GIT_DEFAULT_BRANCH}" | head -n 1) = *"3 outgoing"* ]] || false
 
     # unpushed commits - branch (tracking) is ahead of origin/*
     [[ $(log_unpushed_commits origin tracking_branch_ahead | head -n 1) = *"2 unpushed"* ]] || false
 
-    # outgoing commits - tracking branch is ahead of its tracked branch, origin/master (a differently named branch)
+    # outgoing commits - tracking branch is ahead of its tracked branch, origin/main (a differently named branch)
     [[ $(log_outgoing_commits tracking_branch_ahead | head -n 1) = *"3 outgoing"* ]] || false
 
     # unpushed commits - branches (one tracking and one non-tracking) are both

--- a/tests/int/test-git_mirror.bsh
+++ b/tests/int/test-git_mirror.bsh
@@ -105,6 +105,15 @@ git -c lfs.customtransfer.lfs-folder.path="'"${TRASHDIR}/lfs-folderstore-${os}/l
     mkdir subdir
     touch readme archive.tgz subdir/archive.tgz subdir/readme1
   popd &> /dev/null
+
+  mkdir -p "${TESTDIR}/default_branch"
+  pushd "${TESTDIR}/default_branch" &> /dev/null
+    git init . &> /dev/null
+    touch file
+    git add file &> /dev/null
+    git commit -m "Initial commit" &> /dev/null
+    export GIT_DEFAULT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  popd &> /dev/null
 }
 
 begin_test "Part 1 - Setup test repo"
@@ -122,7 +131,7 @@ begin_test "Part 1 - Setup test repo"
     touch readme_sub_sub
     git add readme_sub_sub
     git commit -m "Initial commit"
-    git branch -m master
+    git branch -m main
 
     # A branch to force push
     git checkout -b to_force2
@@ -132,7 +141,7 @@ begin_test "Part 1 - Setup test repo"
     echo 1 > rewritten_file
     git add rewritten_file
     git commit -m "sub_sub_1"
-    git checkout master
+    git checkout main
   popd &> /dev/null
   mkdir -p "${PRETEND_URL}_sub_sub"
   pushd "${PRETEND_URL}_sub_sub" &> /dev/null
@@ -154,7 +163,7 @@ begin_test "Part 1 - Setup test repo"
     git add readme_sub
     git submodule add "${PRETEND_URL}_sub_sub" "a_sub_sub_module"
     git commit -m "Initial commit"
-    git branch -m master
+    git branch -m main
   popd &> /dev/null
   mkdir -p "${PRETEND_URL}_sub"
   pushd "${PRETEND_URL}_sub" &> /dev/null
@@ -173,7 +182,7 @@ begin_test "Part 1 - Setup test repo"
     echo hi > readme1.bin
     git add readme1.bin .gitattributes
     git commit -m "Initial commit"
-    git branch -m master
+    git branch -m main
 
     echo bye > readme1.bin
     git add readme1.bin
@@ -221,7 +230,7 @@ begin_test "Part 1 - Setup test repo"
     # git mv $'  diff  i \t cult' $' \n diff  i \t cult'
     # However, at random this gives permission denied errors, good thing I don't need it...
     git commit -m "Added submodules"
-    git branch -m master
+    git branch -m main
 
     # A branch to force push
     git checkout -b to_force1
@@ -231,7 +240,7 @@ begin_test "Part 1 - Setup test repo"
     echo 1 > rewritten_file
     git add rewritten_file
     git commit -m "1"
-    git checkout master
+    git checkout main
   popd &> /dev/null
   mkdir -p "${PRETEND_URL}"
   pushd "${PRETEND_URL}" &> /dev/null
@@ -251,7 +260,7 @@ begin_test "Part 2 - Initial mirror"
   setup_test
 
   pushd "${TRASHDIR}" &> /dev/null
-    LFS_DIR="${PRETEND_URL}_lfs/lfs/objects" GIT="${TRASHDIR}/git2" git_mirror_main "${PRETEND_URL}"
+    LFS_DIR="${PRETEND_URL}_lfs/lfs/objects" GIT="${TRASHDIR}/git2" git_mirror_main "${PRETEND_URL}" main
   popd &> /dev/null
 )
 end_test
@@ -276,7 +285,7 @@ begin_test "Part 4 - Pushing to mirror"
     mkdir -p "${MIRROR_DIR}/${d}"
     pushd "${MIRROR_DIR}/${d}" &> /dev/null
       git init --bare
-      git symbolic-ref HEAD refs/heads/master
+      git symbolic-ref HEAD refs/heads/main
     popd &> /dev/null
   done
 
@@ -312,18 +321,18 @@ begin_test "Part 5 - Cloning from mirror"
   pushd "${MIRROR_DIR}/main" &> /dev/null
     # (These may need to be sorted)
     output=\
-'^refs/heads/master
+'^refs/heads/main
 refs/heads/to_force1
-refs/tags/just_git_mirror/[-.0-9TZ]+/heads/master
+refs/tags/just_git_mirror/[-.0-9TZ]+/heads/main
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force1
 refs/tags/original_commit$'
     [[ $(git for-each-ref --format='%(refname)') =~ ${output} ]] || false
   popd &> /dev/null
   pushd "${MIRROR_DIR}/recipes" &> /dev/null
     output=\
-'^refs/heads/master
+'^refs/heads/main
 refs/heads/to_force2
-refs/tags/just_git_mirror/[-.0-9TZ]+/heads/master
+refs/tags/just_git_mirror/[-.0-9TZ]+/heads/main
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force2$'
     [[ $(git for-each-ref --format='%(refname)') =~ ${output} ]] || false
   popd &> /dev/null
@@ -331,14 +340,14 @@ refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force2$'
   # git 1.8.3 does not support git -C
   pushd "${CLONE_DIR}" &> /dev/null
     [ -f "readme" ]
-    [ "$(git log master -n1 --format="%s")" = "Added submodules" ]
+    [ "$(git log main -n1 --format="%s")" = "Added submodules" ]
     # (to_force1 has not been checked out locally)
     [ "$(git log origin/to_force1 -n1 --format="%s")" = "1" ]
   popd &> /dev/null
   [ -f "${CLONE_DIR}/${DIFFICULT_NAME}/readme_sub" ]
   pushd "${CLONE_DIR}/${DIFFICULT_NAME}/a_sub_sub_module" &> /dev/null
     [ -f "readme_sub_sub" ]
-    [ "$(git log master -n1 --format="%s")" = "Initial commit" ]
+    [ "$(git log main -n1 --format="%s")" = "Initial commit" ]
     [ "$(git log origin/to_force2 -n1 --format="%s")" = "sub_sub_1" ]
   popd &> /dev/null
   [ "$(sha256sum "${CLONE_DIR}/lfs/readme1.bin" | awk '{print $1}')" = "abc6fd595fc079d3114d4b71a4d84b1d1d0f79df1e70f8813212f2a65d8916df" ]
@@ -369,7 +378,7 @@ begin_test "Part 6 - Update a repo and mirror"
       touch newfile_sub
       git add newfile_sub
       git commit -m "add a new file"
-      git push origin master
+      git push origin main
 
       pushd a_sub_sub_module &> /dev/null
         # Rewrite the to_force2 branch
@@ -380,12 +389,12 @@ begin_test "Part 6 - Update a repo and mirror"
         git add rewritten_file
         git commit -m "sub_sub_2"
         git push --force origin to_force2
-        git checkout master
+        git checkout main
       popd &> /dev/null
     popd &> /dev/null
     git add "${DIFFICULT_NAME}"
     git commit -m "update submodule"
-    git push "${PRETEND_URL}" master
+    git push "${PRETEND_URL}" main
 
     # Add a commit to a submodule that is not tracked by the main repo
     # REVIEW It would be better if this were done in "${BUILD_REPO}_sub" and
@@ -394,7 +403,7 @@ begin_test "Part 6 - Update a repo and mirror"
       echo "1" >> newfile_sub
       git add newfile_sub
       git commit -m "update file"
-      git push origin master
+      git push origin main
     popd &> /dev/null
 
     # Add a branch to the main repo
@@ -403,7 +412,7 @@ begin_test "Part 6 - Update a repo and mirror"
     git add branchfile
     git commit -m "add a file on a branch"
     git push "${PRETEND_URL}" a_branch
-    git checkout master
+    git checkout main
 
     # Rewrite the to_force1 branch
     git checkout to_force1~1
@@ -413,7 +422,7 @@ begin_test "Part 6 - Update a repo and mirror"
     git add rewritten_file
     git commit -m "2"
     git push --force "${PRETEND_URL}" to_force1
-    git checkout master
+    git checkout main
   popd &> /dev/null
 
   # Add a branch to the air-gapped main repo
@@ -429,7 +438,7 @@ begin_test "Part 6 - Update a repo and mirror"
 
   # Update the prepped mirror
   pushd "${TRASHDIR}" &> /dev/null
-    LFS_DIR="${PRETEND_URL}_lfs/lfs/objects" GIT="${TRASHDIR}/git2" git_mirror_main "${PRETEND_URL}"
+    LFS_DIR="${PRETEND_URL}_lfs/lfs/objects" GIT="${TRASHDIR}/git2" git_mirror_main "${PRETEND_URL}" main
   popd &> /dev/null
 
   # Select the incremental backup if it exists (should be at most one)
@@ -475,21 +484,21 @@ begin_test "Part 6 - Update a repo and mirror"
     output=\
 '^refs/heads/a_branch
 refs/heads/airgap_branch
-refs/heads/master
+refs/heads/main
 refs/heads/to_force1
-refs/tags/just_git_mirror/[-.0-9TZ]+/heads/master
+refs/tags/just_git_mirror/[-.0-9TZ]+/heads/main
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force1
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/a_branch
-refs/tags/just_git_mirror/[-.0-9TZ]+/heads/master
+refs/tags/just_git_mirror/[-.0-9TZ]+/heads/main
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force1
 refs/tags/original_commit$'
     [[ $(git for-each-ref --format='%(refname)') =~ ${output} ]] || false
   popd &> /dev/null
   pushd "${MIRROR_DIR}/recipes" &> /dev/null
     output=\
-'^refs/heads/master
+'^refs/heads/main
 refs/heads/to_force2
-refs/tags/just_git_mirror/[-.0-9TZ]+/heads/master
+refs/tags/just_git_mirror/[-.0-9TZ]+/heads/main
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force2
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force2$'
     [[ $(git for-each-ref --format='%(refname)') =~ ${output} ]] || false
@@ -528,7 +537,7 @@ refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force2$'
   PREP_FILE="$(shopt -s nullglob; echo "${PRETEND_URL}_prep"/transfer_*_transfer_*.tgz)"
   if [ -n "${PREP_FILE:+set}" ]; then
     pushd "${TRASHDIR}" &> /dev/null
-      LFS_DIR="${PRETEND_URL}_lfs/lfs/objects" GIT="${TRASHDIR}/git2" git_mirror_main "${PRETEND_URL}"
+      LFS_DIR="${PRETEND_URL}_lfs/lfs/objects" GIT="${TRASHDIR}/git2" git_mirror_main "${PRETEND_URL}" main
       last_incremental_tar_file="$(LC_ALL=C ls "${PRETEND_URL}_prep"/transfer_*_transfer_*.tgz 2>/dev/null | \
           tail -n1)"
       # There should not be any files under git's objects directory; these look
@@ -553,7 +562,7 @@ begin_test "Part 7 - Rewrite a ref and mirror"
   # | | * add a file on a branch (tag: just_git_mirror/2021-03-17T01.43.07Z/heads/a_branch, a_branch)
   # | |/
   # |/|
-  # * | update submodule (HEAD -> master, tag: just_git_mirror/2021-03-17T01.43.07Z/heads/master)
+  # * | update submodule (HEAD -> main, tag: just_git_mirror/2021-03-17T01.43.07Z/heads/main)
   # * | add a file
   # | | * add a new file on this branch (airgap_branch)
   # | |/
@@ -564,13 +573,13 @@ begin_test "Part 7 - Rewrite a ref and mirror"
   # | |/
   # | * A file to be rewritten
   # |/
-  # * Added submodules (tag: just_git_mirror/2021-03-17T01.42.55Z/heads/master)
+  # * Added submodules (tag: just_git_mirror/2021-03-17T01.42.55Z/heads/main)
   # * Initial commit (tag: original_commit)
 
 
   pushd "${BUILD_REPO}" &> /dev/null
     # Tagging, pushing and force pushing a branch has already been tested using
-    # the branches master and to_force1 (among others)
+    # the branches main and to_force1 (among others)
 
     # Rewrite the to_force1 branch again; this time, GIT_MIRROR_FORCE_PUSH_REFS
     # will be disabled
@@ -581,13 +590,13 @@ begin_test "Part 7 - Rewrite a ref and mirror"
     git add rewritten_file
     git commit -m "3"
     git push --force "${PRETEND_URL}" to_force1
-    git checkout master
+    git checkout main
 
     # A branch to NOT tag
     git checkout -b no_tag1
     git commit --allow-empty -m "Shouldn't get tagged"
     git push "${PRETEND_URL}" no_tag1
-    git checkout master
+    git checkout main
 
     pushd "${DIFFICULT_NAME}"/a_sub_sub_module &> /dev/null
       # Rewrite the to_force2 branch again
@@ -598,19 +607,19 @@ begin_test "Part 7 - Rewrite a ref and mirror"
       git add rewritten_file
       git commit -m "sub_sub_3"
       git push --force origin to_force2
-      git checkout master
+      git checkout main
 
       # A branch to NOT tag
       git checkout -b no_tag2
       git commit --allow-empty -m "Shouldn't get tagged"
       git push origin no_tag2
-      git checkout master
+      git checkout main
     popd &> /dev/null
   popd &> /dev/null
 
   # Update the prepped mirror
   pushd "${TRASHDIR}" &> /dev/null
-    LFS_DIR="${PRETEND_URL}_lfs/lfs/objects" GIT="${TRASHDIR}/git2" git_mirror_main "${PRETEND_URL}"
+    LFS_DIR="${PRETEND_URL}_lfs/lfs/objects" GIT="${TRASHDIR}/git2" git_mirror_main "${PRETEND_URL}" main
   popd &> /dev/null
 
   # Select the incremental backup if it exists
@@ -654,12 +663,12 @@ begin_test "Part 7 - Rewrite a ref and mirror"
   # pushed:
   #     just_git_mirror/{date}/heads/to_force1
   # RE While a little unexpected, this is not obviously wrong
-  # Verify that no_tag1 was not tagged (by git_tag_main) and that master has
+  # Verify that no_tag1 was not tagged (by git_tag_main) and that main has
   # not been tagged a third time, which would indicate that there are two tags
-  # referencing the same SHA because master was not updated between the second
+  # referencing the same SHA because main was not updated between the second
   # and third transfer
   # RE This could also be checked explicitly for each ref with:
-  # git ls-remote . --tags just_git_mirror/*/heads/master^{} | awk '{print $1}'
+  # git ls-remote . --tags just_git_mirror/*/heads/main^{} | awk '{print $1}'
   # and then check for duplicate SHAs (this is sort of an abuse of ls-remote,
   # but I can't find a way to do this with git show-ref or git rev-parse)
   #
@@ -672,13 +681,13 @@ begin_test "Part 7 - Rewrite a ref and mirror"
     output=\
 '^refs/heads/a_branch
 refs/heads/airgap_branch
-refs/heads/master
+refs/heads/main
 refs/heads/no_tag1
 refs/heads/to_force1
-refs/tags/just_git_mirror/[-.0-9TZ]+/heads/master
+refs/tags/just_git_mirror/[-.0-9TZ]+/heads/main
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force1
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/a_branch
-refs/tags/just_git_mirror/[-.0-9TZ]+/heads/master
+refs/tags/just_git_mirror/[-.0-9TZ]+/heads/main
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force1
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force1
 refs/tags/original_commit$'
@@ -686,10 +695,10 @@ refs/tags/original_commit$'
   popd &> /dev/null
   pushd "${MIRROR_DIR}/recipes" &> /dev/null
     output=\
-'^refs/heads/master
+'^refs/heads/main
 refs/heads/no_tag2
 refs/heads/to_force2
-refs/tags/just_git_mirror/[-.0-9TZ]+/heads/master
+refs/tags/just_git_mirror/[-.0-9TZ]+/heads/main
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force2
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force2
 refs/tags/just_git_mirror/[-.0-9TZ]+/heads/to_force2$'

--- a/tests/int/test-git_mirror.bsh
+++ b/tests/int/test-git_mirror.bsh
@@ -105,15 +105,6 @@ git -c lfs.customtransfer.lfs-folder.path="'"${TRASHDIR}/lfs-folderstore-${os}/l
     mkdir subdir
     touch readme archive.tgz subdir/archive.tgz subdir/readme1
   popd &> /dev/null
-
-  mkdir -p "${TESTDIR}/default_branch"
-  pushd "${TESTDIR}/default_branch" &> /dev/null
-    git init . &> /dev/null
-    touch file
-    git add file &> /dev/null
-    git commit -m "Initial commit" &> /dev/null
-    export GIT_DEFAULT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-  popd &> /dev/null
 }
 
 begin_test "Part 1 - Setup test repo"

--- a/tests/int/test-just_git_airgap_repo.bsh
+++ b/tests/int/test-just_git_airgap_repo.bsh
@@ -106,7 +106,7 @@ begin_test "Part 1 - Setup test repo"
     touch readme
     git add readme
     git commit -m "Initial commit"
-    git branch -m master
+    git branch -m main
 
     # The working tree of this vsi_common submodule will have the same SHA
     # checked out as the VSI_COMMON_DIR being tested. Uncommited changes will
@@ -138,7 +138,7 @@ begin_test "Part 2 - Initial mirror"
     source "${BUILD_REPO}/vsi_common/linux/just_git_airgap_repo.bsh"
     GIT_MIRROR_PREP_DIR="${PREP_DIR}"
     VSI_COMMON_DIR="${BUILD_REPO}"/vsi_common JUST_VERSION="${JUST_VERSION}" JUST_USER_CWD="${PWD}" \
-        relocate_git_defaultify git_export-repo "${PRETEND_URL}" master
+        relocate_git_defaultify git_export-repo "${PRETEND_URL}" main
   popd &> /dev/null
 )
 end_test
@@ -165,7 +165,7 @@ begin_test "Part 4 - Pushing to mirror"
     mkdir -p "${AIRGAP_MIRROR_DIR}/${d}"
     pushd "${AIRGAP_MIRROR_DIR}/${d}" &> /dev/null
       git init --bare
-      git symbolic-ref HEAD refs/heads/master
+      git symbolic-ref HEAD refs/heads/main
     popd &> /dev/null
   done
 
@@ -234,7 +234,7 @@ begin_test "Part 6 - Incremental update"
     git add vsi_common
     git commit -m "update submodule"
 
-    git push origin master
+    git push origin main
   popd &> /dev/null
 
   # Update the prepped mirror
@@ -247,7 +247,7 @@ begin_test "Part 6 - Incremental update"
     GIT_MIRROR_PREP_DIR="${PREP_DIR}"
     # URL and branch are chosen automatically
     VSI_COMMON_DIR="${BUILD_REPO}"/vsi_common JUST_VERSION="${JUST_VERSION}" JUST_USER_CWD="${PWD}" \
-        relocate_git_defaultify git_export-repo "${PRETEND_URL}" master
+        relocate_git_defaultify git_export-repo "${PRETEND_URL}" main
   )
   popd &> /dev/null
 

--- a/tests/int/test-just_git_airgap_repo.bsh
+++ b/tests/int/test-just_git_airgap_repo.bsh
@@ -70,7 +70,7 @@ begin_test "Part 1 - Setup test repo"
     [ "${VSI_COMMON_SHA}" = "$(git rev-parse HEAD)" ]
     # This is creating a faux-mirror from a (local) clone. Therefore, the
     # tracked commit (HEAD) cannot exist on a remote-only branch (e.g.,
-    # origin/master) because these are skipped during git_import-repo to the
+    # origin/main) because these are skipped during git_import-repo to the
     # air-gapped server (in a true mirror, there should be no refs/remotes;
     # they get translated to refs/heads by the refspec on push)
     # This will fail with:

--- a/tests/int/test-just_git_functions.bsh
+++ b/tests/int/test-just_git_functions.bsh
@@ -55,7 +55,7 @@ begin_test "Test safe-submodule-update"
     touch readme_sub_sub
     git add readme_sub_sub
     git commit -m "Initial commit"
-    git branch -m master
+    git branch -m main
   popd &> /dev/null
   mkdir -p "${PRETEND_URL}_sub_sub"
   pushd "${PRETEND_URL}_sub_sub" &> /dev/null
@@ -77,7 +77,7 @@ begin_test "Test safe-submodule-update"
     git add readme_sub
     git submodule add "${PRETEND_URL}_sub_sub" "a_sub_sub_module"
     git commit -m "Initial commit"
-    git branch -m master
+    git branch -m main
   popd &> /dev/null
   mkdir -p "${PRETEND_URL}_sub"
   pushd "${PRETEND_URL}_sub" &> /dev/null
@@ -96,7 +96,7 @@ begin_test "Test safe-submodule-update"
     touch readme_behind
     git add readme_behind
     git commit -m "Behind (1)"
-    git branch -m master
+    git branch -m main
   popd &> /dev/null
   mkdir -p "${PRETEND_URL}_behind"
   pushd "${PRETEND_URL}_behind" &> /dev/null
@@ -110,7 +110,7 @@ begin_test "Test safe-submodule-update"
     touch readme_equal
     git add readme_equal
     git commit -m "Equal (1)"
-    git branch -m master
+    git branch -m main
     echo 2 >> readme_equal
     git add readme_equal
     git commit -m "Equal (2)"
@@ -127,7 +127,7 @@ begin_test "Test safe-submodule-update"
     touch readme_ahead
     git add readme_ahead
     git commit -m "Ahead (1)"
-    git branch -m master
+    git branch -m main
   popd &> /dev/null
   mkdir -p "${PRETEND_URL}_ahead"
   pushd "${PRETEND_URL}_ahead" &> /dev/null
@@ -150,7 +150,7 @@ begin_test "Test safe-submodule-update"
   mkdir -p "${PRETEND_URL}"
   pushd "${PRETEND_URL}" &> /dev/null
     git init --bare .
-    git symbolic-ref HEAD refs/heads/master
+    git symbolic-ref HEAD refs/heads/main
   popd &> /dev/null
   mkdir -p "${BUILD_REPO}"
   pushd "${BUILD_REPO}" &> /dev/null
@@ -160,7 +160,7 @@ begin_test "Test safe-submodule-update"
     touch subdir/a_file
     git add readme subdir/a_file
     git commit -m "Initial commit"
-    git branch -m master
+    git branch -m main
 
     git submodule add --name "${DIFFICULT_NAME}" "${PRETEND_URL}_sub" "${DIFFICULT_PATH}"
     # Git itself can't handle newlines, although the config file actually can
@@ -181,7 +181,7 @@ begin_test "Test safe-submodule-update"
     git add behind equal ahead
     git commit -m "Added submodules"
     git remote add origin "${PRETEND_URL}"
-    git push origin master
+    git push origin main
   popd &> /dev/null
 
   # REVIEW The TEST_REPO isn't strictly necessary for most of these tests
@@ -208,31 +208,31 @@ begin_test "Test safe-submodule-update"
   pushd "${BUILD_REPO}" &> /dev/null
     pushd "${DIFFICULT_PATH}" &> /dev/null
       pushd a_sub_sub_module &> /dev/null
-        git checkout master
+        git checkout main
         mkdir subdir
         touch subdir/a_sub_sub_file
         git add subdir/a_sub_sub_file
         git commit -m "Second Commit"
-        git push origin master
+        git push origin main
       popd &> /dev/null
 
       git add a_sub_sub_module
       git commit -m "update (sub) sub module"
-      git push origin master
+      git push origin main
     popd &> /dev/null
     git add "${DIFFICULT_PATH}"
 
     pushd behind &> /dev/null
-      git checkout master
+      git checkout main
       echo 2 >> readme_behind
       git add readme_behind
       git commit -m "Behind (2)"
-      git push origin master
+      git push origin main
     popd &> /dev/null
     git add behind
 
     git commit -m "Update submodules (1)"
-    git push origin master
+    git push origin main
   popd &> /dev/null
 
   #################################
@@ -367,7 +367,7 @@ begin_test "Test safe-submodule-update"
   # Modify a tracked file in the ahead submodule of the test repo
   pushd "${TEST_REPO}" &> /dev/null
     pushd "ahead" &> /dev/null
-      git checkout master
+      git checkout main
       echo 2 >> readme_ahead
     popd &> /dev/null
     output="$(safe_git_submodule_update | grep "Uncommited tracked files")"
@@ -394,7 +394,7 @@ begin_test "Test safe-submodule-update"
     pushd "ahead" &> /dev/null
       # Create a local commit; this submodule is now ahead of the tracked commit
       git commit -m "Ahead (2)"
-      git push origin master
+      git push origin main
     popd &> /dev/null
     if git_feature_submodule_update_with_custom_command; then
       # Warns that the repository 'ahead' is not on the expected SHA; prompts
@@ -427,17 +427,17 @@ begin_test "Test safe-submodule-update"
 
   # Pull new changes
   pushd "${TEST_REPO}" &> /dev/null
-    # In git <= v1.8.3, 'git fetch origin master' amazingly does not update the
+    # In git <= v1.8.3, 'git fetch origin main' amazingly does not update the
     # remote tracking branch: https://stackoverflow.com/a/20967347
-    # RE git fetch origin master:refs/remotes/origin/master would have also
+    # RE git fetch origin main:refs/remotes/origin/main would have also
     # worked
     git fetch
     # main repo - merges (commits) changes to submodules
-    git merge origin/master --no-edit
+    git merge origin/main --no-edit
     # behind - HEAD is now behind the tracked commit
     # equal - HEAD is still equal to tracked commit
     # ahead - HEAD is still ahead of the tracked commit (if git > v1.8.3)
-    git push origin master
+    git push origin main
   popd &> /dev/null
 
   # TODO Untracked file that will conflict with the submodule update
@@ -445,7 +445,7 @@ begin_test "Test safe-submodule-update"
   # Modify a tracked file in the behind submodule of the test repo
   pushd "${TEST_REPO}" &> /dev/null
     pushd "behind" &> /dev/null
-      git checkout master
+      git checkout main
       echo 3 >> readme_behind
     popd &> /dev/null
     output="$(askcontinue=y safe_git_submodule_update <<< "a" 2>&1 | \
@@ -504,8 +504,8 @@ begin_test "Test safe-submodule-update"
       # drop last commit in the behind submodule (so we don't get errors going
       # forward)
       pushd "behind" &> /dev/null
-        # Move HEAD back to master after git submodule update forcefully moved it
-        git checkout master
+        # Move HEAD back to main after git submodule update forcefully moved it
+        git checkout main
         git reset --hard HEAD~1
       popd &> /dev/null
     fi
@@ -525,10 +525,10 @@ begin_test "Test safe-submodule-update"
   # wasn't such a pain)
   cp -a "${PRETEND_URL}_behind" "${PRETEND_URL}_behind2"
   pushd "${BUILD_REPO}" &> /dev/null
-    # In git <= v1.8.3, 'git fetch origin master' amazingly does not update the
+    # In git <= v1.8.3, 'git fetch origin main' amazingly does not update the
     # remote tracking branch: https://stackoverflow.com/a/20967347
     git fetch
-    git merge origin/master
+    git merge origin/main
     git submodule update --init --recursive
     sed "${sed_flags_i[@]}" -e \
          "s|url = ${PRETEND_URL_INTERNAL}_behind|url = ${PRETEND_URL_INTERNAL}_behind2|" .gitmodules
@@ -536,19 +536,19 @@ begin_test "Test safe-submodule-update"
     git commit -m "Update submodule behind's URL"
     git submodule sync behind
     pushd behind &> /dev/null
-      git checkout master
+      git checkout main
       # Add a new commit to the new URL
       echo 4 >> readme_behind
       git add readme_behind
       git commit -m "Behind (4)"
       # We sync'd so this should be true
       assert_str_eq "$(git config remote.origin.url)" "${PRETEND_URL_INTERNAL}_behind2"
-      git push origin master
+      git push origin main
     popd &> /dev/null
     # Track the new commit at the new URL
     git add behind
     git commit -m "Update the behind submodule"
-    git push origin master
+    git push origin main
   popd &> /dev/null
 
   pushd "${TEST_REPO}" &> /dev/null
@@ -564,7 +564,7 @@ begin_test "Test safe-submodule-update"
     # In git v2.27, git pull began recommending a merge strategy
     # https://stackoverflow.com/a/62653694
     #
-    # In git <= v1.8.3, 'git fetch origin master' amazingly does not update the
+    # In git <= v1.8.3, 'git fetch origin main' amazingly does not update the
     # remote tracking branch: https://stackoverflow.com/a/20967347
     #
     # In git v2.21.0, 'git fetch' started failing if the commit of a submodule
@@ -577,7 +577,7 @@ begin_test "Test safe-submodule-update"
     # seems to inspect the submodule to ensure that each commit tracked by the
     # parent exists in the submodule, otherwise, it errors
     git fetch || :
-    git merge origin/master
+    git merge origin/main
 
     # Sync the submodules, fetches new commits, and update
     safe_git_submodule_update
@@ -708,11 +708,11 @@ begin_test "Test safe-submodule-update"
   pushd "${TEST_REPO}" &> /dev/null
     # Setup some branches to re-attach
     pushd "${DIFFICULT_PATH}" &> /dev/null
-      git checkout master
-      git checkout "$(git rev-parse master)" # Detach the head
+      git checkout main
+      git checkout "$(git rev-parse main)" # Detach the head
 
       pushd a_sub_sub_module &> /dev/null
-        git checkout master # An attached head
+        git checkout main # An attached head
       popd &> /dev/null
     popd &> /dev/null
 
@@ -721,14 +721,14 @@ begin_test "Test safe-submodule-update"
     popd &> /dev/null
 
     git_reattach_heads "${DIFFICULT_PATH}"
-    assert_str_eq "$(cd "${DIFFICULT_PATH}" && git rev-parse --abbrev-ref HEAD)" "master"
-    assert_str_eq "$(cd "${DIFFICULT_PATH}"/a_sub_sub_module && git rev-parse --abbrev-ref HEAD)" "master"
+    assert_str_eq "$(cd "${DIFFICULT_PATH}" && git rev-parse --abbrev-ref HEAD)" "main"
+    assert_str_eq "$(cd "${DIFFICULT_PATH}"/a_sub_sub_module && git rev-parse --abbrev-ref HEAD)" "main"
     assert_str_eq "$(cd behind && git rev-parse --abbrev-ref HEAD)" "HEAD"
     assert_str_eq "$(cd equal && git rev-parse --abbrev-ref HEAD)" "HEAD"
 
     git_reattach_heads
-    assert_str_eq "$(cd "${DIFFICULT_PATH}" && git rev-parse --abbrev-ref HEAD)" "master"
-    assert_str_eq "$(cd "${DIFFICULT_PATH}"/a_sub_sub_module && git rev-parse --abbrev-ref HEAD)" "master"
+    assert_str_eq "$(cd "${DIFFICULT_PATH}" && git rev-parse --abbrev-ref HEAD)" "main"
+    assert_str_eq "$(cd "${DIFFICULT_PATH}"/a_sub_sub_module && git rev-parse --abbrev-ref HEAD)" "main"
     assert_str_eq "$(cd behind && git rev-parse --abbrev-ref HEAD)" "HEAD"
     assert_str_eq "$(cd equal && git rev-parse --abbrev-ref HEAD)" "abranch"
 

--- a/tests/test-just_git_airgap_repo.bsh
+++ b/tests/test-just_git_airgap_repo.bsh
@@ -41,7 +41,7 @@ function picker()
     "origin"*)
       return "${picker_remote}"
       ;;
-    "master"*)
+    "main"*)
       return "${picker_branch}"
       ;;
   esac
@@ -110,20 +110,20 @@ begin_test "Test guided repository export"
   # specify remote, branch and output dir; don't check submodules for unpushed commits
   git_remote="origin"
   git_origin_url="https://server1.org/repo.git"
-  git_branch="master"
-  result="https://server1.org/repo.git master output_prep"
-  [ "$(relocate_git_defaultify git_export-repo-guided --remote-name origin --branch master --no-check-remote --output-dir output_prep | tail -n1)" = "${result}" ]
-  [ "$(relocate_git_defaultify git_export-repo-guided -r origin -b master --no-check-remote --output-dir output_prep | tail -n1)" = "${result}" ]
+  git_branch="main"
+  result="https://server1.org/repo.git main output_prep"
+  [ "$(relocate_git_defaultify git_export-repo-guided --remote-name origin --branch main --no-check-remote --output-dir output_prep | tail -n1)" = "${result}" ]
+  [ "$(relocate_git_defaultify git_export-repo-guided -r origin -b main --no-check-remote --output-dir output_prep | tail -n1)" = "${result}" ]
   unset git_remote git_origin_url git_branch
 
   # specify remote, branch and output dir; no unpushed submodule commits
   git_remote="origin"
   git_origin_url="https://server1.org/repo.git"
-  git_branch="master"
+  git_branch="main"
   check_sm_return=0 # submodules have all been pushed
   git_log=""
-  result="https://server1.org/repo.git master output_prep"
-  [ "$(relocate_git_defaultify git_export-repo-guided --remote-name origin --branch master --check-remote --output-dir output_prep | tail -n1)" = "${result}" ]
+  result="https://server1.org/repo.git main output_prep"
+  [ "$(relocate_git_defaultify git_export-repo-guided --remote-name origin --branch main --check-remote --output-dir output_prep | tail -n1)" = "${result}" ]
   unset git_remote git_origin_url git_branch check_sm_return git_log
 
   # provide invalid remote
@@ -137,7 +137,7 @@ begin_test "Test guided repository export"
   picker_create=1 # create a new mirror
   git_remote="origin"
   git_origin_url="https://server1.org/repo.git"
-  git_branch="master"
+  git_branch="main"
   result="ERROR Unknown git branch provided with flag --branch: bad_branch"
   [ "$(relocate_git_defaultify git_export-repo-guided --branch bad_branch | tail -n1)" = "${result}" ]
   unset picker_create git_remote git_origin_url git_branch
@@ -165,10 +165,10 @@ begin_test "Test guided repository export"
   picker_create=1 # create a new mirror
   git_remote="origin"
   git_origin_url="https://server1.org/repo.git"
-  git_branch="master"
+  git_branch="main"
   ask_check=0 # don't check for unpushed commits
   read_data="output_prep"
-  result="https://server1.org/repo.git master output_prep"
+  result="https://server1.org/repo.git main output_prep"
   [ "$(relocate_git_defaultify git_export-repo-guided | tail -n1)" = "${result}" ]
   unset picker_create git_remote git_origin_url git_branch ask_check read_data
 
@@ -176,12 +176,12 @@ begin_test "Test guided repository export"
   picker_create=1 # create a new mirror
   git_remote="origin"
   git_origin_url="https://server1.org/repo.git"
-  git_branch="master"
+  git_branch="main"
   ask_check=1 # check for unpushed commits
   check_sm_return=0 # submodules have all been pushed
   git_log="" # top-level repo has been pushed
   read_data="output_prep"
-  result="https://server1.org/repo.git master output_prep"
+  result="https://server1.org/repo.git main output_prep"
   [ "$(relocate_git_defaultify git_export-repo-guided | tail -n1)" = "${result}" ]
   unset picker_create git_remote git_origin_url git_branch ask_check \
         check_sm_return git_log read_data
@@ -190,13 +190,13 @@ begin_test "Test guided repository export"
   picker_create=1 # create a new mirror
   git_remote="origin"
   git_origin_url="https://server1.org/repo.git"
-  git_branch="master"
+  git_branch="main"
   ask_check=1 # check for unpushed commits
   check_sm_return=1 # submodules have not all been pushed
   git_log="" # top-level repo has been pushed
   ask_continue=1 # continue even though there are unpushed commits
   read_data="output_prep"
-  result="https://server1.org/repo.git master output_prep"
+  result="https://server1.org/repo.git main output_prep"
   [ "$(relocate_git_defaultify git_export-repo-guided | tail -n1)" = "${result}" ]
   unset picker_create git_remote git_origin_url git_branch ask_check \
         check_sm_return git_log ask_continue read_data
@@ -205,7 +205,7 @@ begin_test "Test guided repository export"
   picker_create=1 # create a new mirror
   git_remote="origin"
   git_origin_url="https://server1.org/repo.git"
-  git_branch="master"
+  git_branch="main"
   ask_check=1 # check for unpushed commits
   check_sm_return=1 # submodules have not all been pushed
   git_log="" # top-level repo has been pushed
@@ -218,7 +218,7 @@ begin_test "Test guided repository export"
   picker_create=1 # create a new mirror
   git_remote="origin"
   git_origin_url="https://server1.org/repo.git"
-  git_branch="master"
+  git_branch="main"
   ask_check=1 # check for unpushed commits
   check_sm_return=0 # submodules have all been pushed
   git_log="There are 2 unpushed commits"
@@ -232,11 +232,11 @@ begin_test "Test guided repository export"
   git_remote=$'origin\nupstream'
   git_origin_url="https://server1.org/repo.git"
   git_upstream_url="https://upstream1.org/repo.git"
-  git_branch="master"
+  git_branch="main"
   picker_remote=2 # choose a remote & url
   ask_check=0 # don't check for unpushed commits
   read_data="output_prep"
-  result="https://upstream1.org/repo.git master output_prep"
+  result="https://upstream1.org/repo.git main output_prep"
   [ "$(relocate_git_defaultify git_export-repo-guided | tail -n1)" = "${result}" ]
   unset picker_create git_remote git_origin_url git_branch picker_remote ask_check
 
@@ -244,11 +244,11 @@ begin_test "Test guided repository export"
   picker_create=1 # create a new mirror
   git_remote="origin"
   git_origin_url=$'https://server2.org/repo.git\nhttps://server2.org/repo.git\nhttps://server1.org/repo.git\nhttps://server2.org/repo.git'
-  git_branch="master"
+  git_branch="main"
   picker_remote=2 # choose a remote & url
   ask_check=0 # don't check for unpushed commits
   read_data="output_prep"
-  result="https://server1.org/repo.git master output_prep"
+  result="https://server1.org/repo.git main output_prep"
   [ "$(relocate_git_defaultify git_export-repo-guided | tail -n1)" = "${result}" ]
   unset picker_create git_remote git_origin_url git_branch picker_remote ask_check read_data
 
@@ -256,7 +256,7 @@ begin_test "Test guided repository export"
   picker_create=1 # create a new mirror
   git_remote="origin"
   git_origin_url="https://server1.org/repo.git"
-  git_branch=$'master\nnew_branch'
+  git_branch=$'main\nnew_branch'
   picker_branch=2 # choose a branch
   ask_check=0 # don't check for unpushed commits
   read_data="output_prep"
@@ -270,9 +270,9 @@ begin_test "Test guided repository export"
   picker_create=2 # start from a prep_dir
   git_remote="origin"
   git_origin_url="https://server1.org/repo.git"
-  git_branch="master"
+  git_branch="main"
   ask_check=0 # don't check for unpushed commits
-  result="https://server1.org/repo.git master output_prep"
+  result="https://server1.org/repo.git main output_prep"
   [ "$(relocate_git_defaultify git_export-repo-guided --prep-dir output_prep | tail -n1)" = "${result}" ]
   [ "$(relocate_git_defaultify git_export-repo-guided -p output_prep | tail -n1)" = "${result}" ]
   unset picker_create git_remote git_origin_url git_branch ask_check
@@ -285,10 +285,10 @@ begin_test "Test guided repository export"
   picker_create=2 # start from a prep_dir
   git_remote="origin"
   git_origin_url="https://server1.org/repo.git"
-  git_branch="master"
+  git_branch="main"
   ask_check=0 # don't check for unpushed commits
   read_data="../../output_prep"
-  result="https://server1.org/repo.git master ../../output_prep"
+  result="https://server1.org/repo.git main ../../output_prep"
   pushd "${TESTDIR}" &> /dev/null
     [ "$(JUST_USER_CWD="${CWD}" relocate_git_defaultify git_export-repo-guided | tail -n1)" = "${result}" ]
   popd &> /dev/null


### PR DESCRIPTION
Rename master branch to main

- Also quickly refactor all master references to main, when possible
- Fix minor bug in `docker_service_running` where behavior changed in docker-compose 1.14.1