### PR TITLE
Yarp rewrite

### DIFF
--- a/linux/yarp.awk
+++ b/linux/yarp.awk
@@ -62,7 +62,7 @@ function process_line(str)
   # Calculate the amount of indent on the current line
   indent = get_indent(str)
 
-  # Splint the line into key and the remainder after the colon
+  # Split the line into key and the remainder after the colon
   remain = substr(str, 1+max(RLENGTH, indent))
   key = match(remain, /^[^ '":]+ *: */)   #"# VS Code parser error
   if ( key )
@@ -105,11 +105,11 @@ function process_line(str)
         sequence_indexes[path_depth] = 0
     }
     else
-      # -1 means not an sequence
+      # -1 means not a sequence
       sequence_indexes[path_depth] = -1
     ++path_depth
   } # Same indent
-  else if (indent == last_indent )
+  else if ( indent == last_indent )
   {
     paths[path_depth-1] = key
     if (is_sequence)
@@ -195,14 +195,14 @@ BEGIN {
   # Initialize empty arrays
   # Stores the individual parts of the yaml path
   delete paths[0]
-  # How much an an indent each path detph has
+  # How much of an indent each path depth has
   delete indents[0]
-  # The index in a sequence. -1 is not a sequence, then 0, 1, ... for an sequence
+  # Track the index in the sequence for this path element. -1 means this path segment is not a sequence, then 0, 1, ... for an sequence
   delete sequence_indexes[0]
-  # Tracks length of theses three arrays
+  # Tracks length of these three arrays
   path_depth = 0
 
-  # Indent of the last line. Start at -1 so that the root node trigger as the
+  # Indent of the last line. Start at -1 so that the root node triggers as the
   # first indent
   last_indent = -1
 }

--- a/tests/test-yarp.bsh
+++ b/tests/test-yarp.bsh
@@ -10,7 +10,6 @@ source "${VSI_COMMON_DIR}/tests/test_utils.bsh"
 check_ans()
 {
   assert_str_eq "$(yarp <<< "${doc}")" "${ans}"
-  echo "===========">&2
 }
 
 common_yarp_test()
@@ -162,6 +161,17 @@ d:
 - food: true
   cool: cat
 - fruit: loop"
+  check_ans
+
+  doc="\
+- 1
+- a:
+- b: foo
+"
+  ans="\
+[0] = 1
+[1].a =
+[2].b = foo"
   check_ans
 }
 

--- a/tests/test-yarp.bsh
+++ b/tests/test-yarp.bsh
@@ -5,10 +5,12 @@ if [ -z "${VSI_COMMON_DIR+set}" ]; then
 fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
+source "${VSI_COMMON_DIR}/tests/test_utils.bsh"
 
 check_ans()
 {
-  [ "$(yarp <<< "${doc}")" = "${ans}" ]
+  assert_str_eq "$(yarp <<< "${doc}")" "${ans}"
+  echo "===========">&2
 }
 
 common_yarp_test()
@@ -92,6 +94,75 @@ a.b.c =
 a.b.c[0] = d
 a.b.c[1] = e
 f ="
+  check_ans
+
+  doc="\
+a:
+  - kit
+  - kat
+b:
+  c:
+    - car
+    - bar
+d:
+  - food: true
+    cool: cat
+  - fruit: loop"
+  ans="\
+a =
+a[0] = kit
+a[1] = kat
+b =
+b.c =
+b.c[0] = car
+b.c[1] = bar
+d =
+d[0].food = true
+d[0].cool = cat
+d[1].fruit = loop"
+  check_ans
+
+  doc="\
+a:
+ - kit
+ - kat
+b:
+ c:
+   - car
+   - bar
+d:
+ - food: true
+   cool: cat
+ - fruit: loop"
+  check_ans
+
+doc="\
+a:
+- kit
+- kat
+b:
+  c:
+  - car
+  - bar
+d:
+- food: true
+  cool: cat
+- fruit: loop"
+  check_ans
+
+doc="\
+a:
+- kit
+- kat
+b:
+ c:
+ - car
+ - bar
+d:
+- food: true
+  cool: cat
+- fruit: loop"
+  check_ans
 }
 
 begin_test "yarp function"


### PR DESCRIPTION
Yarp did not correctly count sequences as 2 spaces of indent. At some point in docker-compose 1.x they started using the "unindented sequences". This apparently didn't break anything we noticed, but we will need this moving forward.