### PR TITLE
Add JUST_IN_CONTAINER

### DIFF
--- a/docs/style.rst
+++ b/docs/style.rst
@@ -80,7 +80,7 @@ We like to use `>&` for file descriptors (numbers), and `&>` for filenames
      # This is actively splitting apart a string, and must not be in quotes
      bar=(${foo}) # noquotes
 
-  Quotes should not be used in ``[[]]`` expressions---there are a few corner cases where the quotes will be treated literally. ``# noquotes`` is not needed for ``[[]]`` expressions.
+  Quotes should not be used on the LHS in ``[[]]`` expressions---there are a few corner cases where the quotes will be treated literally. ``# noquotes`` is not needed for ``[[]]`` expressions. The RHS should use quotes for literal strings, and no quotes for wildcard or regex patterns.
 
   .. code-block:: bash
 

--- a/linux/compat_singularity.bsh
+++ b/linux/compat_singularity.bsh
@@ -6,6 +6,7 @@ fi
 
 source "${VSI_COMMON_DIR}/linux/requirements.bsh"
 source "${VSI_COMMON_DIR}/linux/aliases.bsh"
+source "${VSI_COMMON_DIR}/linux/versions.bsh"
 
 #*# linux/compat_singularity
 
@@ -19,18 +20,7 @@ source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 # .. file:: compat_singularity.bsh
 #
 # A collection of variables to help cope with the differences between singularity versions.
-#**
-
-function _compat_singularity_get_version()
-{
-  if [ -z "${_compat_singularity_version+set}" ]; then
-    _compat_singularity_version="$("${SINGULARITY}" --version)"
-    _compat_singularity_version="${_compat_singularity_version##* }"
-    _compat_singularity_version="${_compat_singularity_version%%-*}"
-  fi
-}
-
-#**
+#
 # .. function:: singularity_singularityenv_priority_bug
 #
 # In singularity 3.0-3.5, there is an ambiguity when it comes to the precedence of ``{VAR}`` vs ``SINGULARITYENV_{VAR}`` variables being inherited from the host.
@@ -45,8 +35,9 @@ function _compat_singularity_get_version()
 function singularity_singularityenv_priority_bug()
 {
   if [ -z "${_singularity_singularityenv_priority_bug+set}" ]; then
-    _compat_singularity_get_version
-    if meet_requirements "${_compat_singularity_version}" '>=3.0' '<3.6'; then
+    local singularity_version singularity_vendor
+    singularity_version_info
+    if meet_requirements "${singularity_version}" '>=3.0' '<3.6'; then
       _singularity_singularityenv_priority_bug=0
     else
       _singularity_singularityenv_priority_bug=1

--- a/linux/just_files/container_functions.bsh
+++ b/linux/just_files/container_functions.bsh
@@ -19,7 +19,7 @@ fi
 #
 # .. envvar:: JUST_IN_CONTAINER
 #
-# An environment variable that to be set inside of a container so that a script can know it is inside a container started by :file:`just`. It is set to the specific container technology so that scripts can adapt to the specific container technology used. (E.g. ``docker``, ``singularity``, ``podman``, etc...).
+# An environment variable that will be set inside of a container so that a script can know it is inside a container started by :file:`just`. It is set to the specific container technology so that scripts can adapt to the specific container technology used. (E.g. ``docker``, ``singularity``, ``podman``, etc...).
 #
 # .. function:: container_environment_override
 #

--- a/linux/just_files/container_functions.bsh
+++ b/linux/just_files/container_functions.bsh
@@ -17,6 +17,10 @@ fi
 #
 # Common functionality for adding extra just features to container services
 #
+# .. envvar:: JUST_IN_CONTAINER
+#
+# An environment variable that to be set inside of a container so that a script can know it is inside a container started by :file:`just`. It is set to the specific container technology so that scripts can adapt to the specific container technology used. (E.g. ``docker``, ``singularity``, ``podman``, etc...).
+#
 # .. function:: container_environment_override
 #
 # :Arguments: * ``$1`` - The name of a function that takes two arguments, variable name and variable value, and writes to the corresponding configuration file.

--- a/linux/just_files/docker_compose_override
+++ b/linux/just_files/docker_compose_override
@@ -84,10 +84,6 @@ function _docker_compose_override_var_sub()
 #**
 function _env_echo()
 {
-  if [ "${new_environment-1}" == "1" ]; then
-    echo "    environment:"
-    new_environment=0
-  fi
   echo "      - ${1}=${2}"
 }
 
@@ -287,11 +283,6 @@ function generate_docker_compose_override()
   echo "services:"
   for service_index in "${!services_name[@]}"; do
     echo "  ${services_name[service_index]}:"
-    # In docker compose v2, a service can't be empty or else it will say
-    # "services.{name} must be a mapping". This limitation should only apply to
-    # the final configuration. However this bug causes it to apply to each
-    # individual (override) file too. So clearly a docker compose v2 bug
-    echo "    x-bugfix:"
 
     # Clear list for this service
     just_docker_entrypoint_links=()
@@ -442,6 +433,9 @@ function generate_docker_compose_override()
       echo "${over_volumes[*]+${over_volumes[*]}}"
     fi
     IFS="${OLD_IFS}"
+
+    echo "    environment:"
+    echo "      - JUST_IN_CONTAINER=docker"
 
     # Initialize _env_echo command"
     new_environment=1

--- a/linux/just_files/docker_functions.bsh
+++ b/linux/just_files/docker_functions.bsh
@@ -482,8 +482,11 @@ function _Docker()
   local cmd=(${DRYRUN} "${DOCKER}")
   local extra_args_var
 
-  if [ "${docker_command}" = "run" ] && [ "${DOCKER_AUTOREMOVE-1}" == "1" ]; then
-    docker_extra_command_args+=(--rm)
+  if [ "${docker_command}" = "run" ]; then
+    if [ "${DOCKER_AUTOREMOVE-1}" == "1" ]; then
+      docker_extra_command_args+=(--rm)
+    fi
+    docker_extra_command_args+=(-e JUST_IN_CONTAINER=docker)
   fi
 
   # Indirectly append DOCKER_EXTRA_{COMMAND}_ARGS

--- a/linux/just_files/singularity_functions.bsh
+++ b/linux/just_files/singularity_functions.bsh
@@ -70,7 +70,7 @@ function _Singularity()
 
   compose_arguments "SINGULARITY_EXTRA_ARGS" "SINGULARITY_EXTRA_$(uppercase "${subcommand-none}")_ARGS"
 
-  # Add an environment variable so just scripts can know if in a just container
+  # Add an environment variable so just scripts can know if they are in a just container
   singularity_env_pass JUST_IN_CONTAINER singularity
 
   if [ "${SINGULARITY_EXEC-0}" != "1" ] || [ "${DRYRUN-}" != "" ]; then

--- a/linux/just_files/singularity_functions.bsh
+++ b/linux/just_files/singularity_functions.bsh
@@ -70,6 +70,9 @@ function _Singularity()
 
   compose_arguments "SINGULARITY_EXTRA_ARGS" "SINGULARITY_EXTRA_$(uppercase "${subcommand-none}")_ARGS"
 
+  # Add an environment variable so just scripts can know if in a just container
+  singularity_env_pass JUST_IN_CONTAINER singularity
+
   if [ "${SINGULARITY_EXEC-0}" != "1" ] || [ "${DRYRUN-}" != "" ]; then
     local JUST_IGNORE_EXIT_CODES="${SINGULARITY_IGNORE_EXIT_CODES-0}"
 
@@ -105,7 +108,21 @@ function _Singularity()
 #**
 function singularity_env_pass()
 {
-  export "SINGULARITYENV_${1}"="${2}"
+  local singularity_version singularity_vendor
+  singularity_version_info
+  if [ "${singularity_vendor}" = "apptainer" ]; then
+    function singularity_env_pass()
+    {
+      export "APPTAINERENV_${1}"="${2}"
+    }
+  else
+    function singularity_env_pass()
+    {
+      export "SINGULARITYENV_${1}"="${2}"
+    }
+  fi
+
+  singularity_env_pass ${@+"${@}"}
 }
 
 

--- a/linux/versions.bsh
+++ b/linux/versions.bsh
@@ -267,5 +267,9 @@ function singularity_version_info()
   if [[ ${version} =~ ${re} ]]; then
     singularity_version=${BASH_REMATCH[2]}
     singularity_vendor=${BASH_REMATCH[1]}
+  else
+    # Else it's the old singularity 2.x version
+    singularity_vendor=singularity
+    singularity_version=${version}
   fi
 }

--- a/tests/int/test-docker_compose_override.bsh
+++ b/tests/int/test-docker_compose_override.bsh
@@ -17,12 +17,8 @@ function head()
 function service()
 {
   echo -e "\n  ${1}:"
-  echo -e "    x-bugfix:"
-}
-
-function environment()
-{
-  echo -e "\n    environment:"
+  echo      "    environment:"
+  echo      "      - JUST_IN_CONTAINER=1"
 }
 
 function envi()
@@ -58,12 +54,12 @@ volumes:
   DOCKER_COMPOSE_FILES=(dc.yml)
   override="$(generate_docker_compose_override TEST dummy test_hay)"
 
-  ans="$(head)$(service dummy)$(environment)"
+  ans="$(head)$(service dummy)"
   ans+="$(envi JUST_DOCKER_ENTRYPOINT_INTERNAL_VOLUMES=/notint///notlint)"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
-  ans+="$(service test_hay)$(environment)"
+  ans+="$(service test_hay)"
   ans+="$(envi JUST_DOCKER_ENTRYPOINT_INTERNAL_VOLUMES=/int///lint)"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
@@ -123,12 +119,12 @@ volumes:
   DOCKER_COMPOSE_FILES=(dc.yml)
   override="$(generate_docker_compose_override TEST dummy test_hay)"
 
-  ans="$(head)$(service dummy)$(environment)"
+  ans="$(head)$(service dummy)"
   ans+="$(envi JUST_DOCKER_ENTRYPOINT_INTERNAL_VOLUMES=/notint///notlint)"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
-  ans+="$(service test_hay)$(environment)"
+  ans+="$(service test_hay)"
   ans+="$(envi JUST_DOCKER_ENTRYPOINT_INTERNAL_VOLUMES=/int///lint)"
   ans+="$(envi JUST_DOCKER_ENTRYPOINT_INTERNAL_RO_VOLUMES=/syntax///bar)"
   if [ "${OS-}" = "Windows_NT" ]; then

--- a/tests/int/test-docker_compose_override.bsh
+++ b/tests/int/test-docker_compose_override.bsh
@@ -18,7 +18,7 @@ function service()
 {
   echo -e "\n  ${1}:"
   echo      "    environment:"
-  echo      "      - JUST_IN_CONTAINER=1"
+  echo      "      - JUST_IN_CONTAINER=docker"
 }
 
 function envi()

--- a/tests/int/test-docker_functions.bsh
+++ b/tests/int/test-docker_functions.bsh
@@ -120,8 +120,8 @@ begin_test "Just docker compose with internal volumes"
   ans="version: '3.2'
 services:
   test_hay:
-    x-bugfix:
-    environment:"
+    environment:
+      - JUST_IN_CONTAINER=docker"
   ans+="
       - JUST_DOCKER_ENTRYPOINT_INTERNAL_VOLUMES=/int///lint"
   if [ "${OS-}" = "Windows_NT" ]; then

--- a/tests/int/test-new_just.bsh
+++ b/tests/int/test-new_just.bsh
@@ -123,14 +123,14 @@ mockd volume rm testpro_venv" ]
   ans="version: '2.4'
 services:
   yaan:
-    x-bugfix:
 "
   if [ -d "/tmp/.X11-unix" ]; then
     ans+="    volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:ro
 "
   fi
-  ans+="    environment:"
+  ans+="    environment:
+      - JUST_IN_CONTAINER=docker"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="
       - JUST_HOST_WINDOWS=1"
@@ -139,14 +139,14 @@ services:
       - JTEST_SOURCE_DIR_HOST=${TESTDIR}
       - JTEST_SOURCE_DIR=${JUST_PATH_ESC}/src
   yaan_pipenv:
-    x-bugfix:
 "
   if [ -d "/tmp/.X11-unix" ]; then
     ans+="    volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:ro
 "
   fi
-  ans+="    environment:"
+  ans+="    environment:
+      - JUST_IN_CONTAINER=docker"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="
       - JUST_HOST_WINDOWS=1"
@@ -220,14 +220,14 @@ mockd compose -f ${TESTDIR}/docker-compose.yml build" ]
   ans="version: '2.4'
 services:
   example:
-    x-bugfix:
 "
   if [ -d "/tmp/.X11-unix" ]; then
     ans+="    volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:ro
 "
   fi
-  ans+="    environment:"
+  ans+="    environment:
+      - JUST_IN_CONTAINER=docker"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="
       - JUST_HOST_WINDOWS=1"

--- a/tests/test-compat_singularity.bsh
+++ b/tests/test-compat_singularity.bsh
@@ -10,32 +10,6 @@ source "${VSI_COMMON_DIR}/linux/compat_singularity.bsh"
 source "${TESTLIB_DIR}/test_utils.bsh"
 
 
-begin_test "Singularity version"
-(
-  setup_test
-
-  ans=(2.4.6 2.6.0 2.6.1 3.6.4)
-  samples=("2.4.6-vault/release-2.4.g9ca70f5c5"
-           "2.6.0-dist"
-           "2.6.1"
-           "singularity version 3.6.4")
-
-  function singularity()
-  {
-    echo "${version}"
-  }
-
-  for i in "${!ans[@]}"; do
-    version="${samples[i]}"
-    _compat_singularity_get_version
-
-    [ "${_compat_singularity_version}" = "${ans[i]}" ]
-
-    unset _compat_singularity_version
-  done
-)
-end_test
-
 begin_test "SINGULARITYENV_ priority bug"
 (
   setup_test
@@ -47,15 +21,15 @@ begin_test "SINGULARITYENV_ priority bug"
 
   version=2.6
   not singularity_singularityenv_priority_bug
-  unset _compat_singularity_version _singularity_singularityenv_priority_bug
+  unset _singularity_singularityenv_priority_bug
 
   version=3.0.1
   singularity_singularityenv_priority_bug
-  unset _compat_singularity_version _singularity_singularityenv_priority_bug
+  unset _singularity_singularityenv_priority_bug
 
   version=3.5.1
   singularity_singularityenv_priority_bug
-  unset _compat_singularity_version _singularity_singularityenv_priority_bug
+  unset _singularity_singularityenv_priority_bug
 
   version=3.6
   not singularity_singularityenv_priority_bug

--- a/tests/test-docker_compose_override.bsh
+++ b/tests/test-docker_compose_override.bsh
@@ -16,7 +16,6 @@ function head()
 function service()
 {
   echo $'\n'"  ${1}:"
-  echo "    x-bugfix:"
 }
 
 function volumes()
@@ -36,6 +35,7 @@ function vol()
 function environment()
 {
   echo $'\n'"    environment:"
+  echo      "      - JUST_IN_CONTAINER=docker"
 }
 
 function envi()
@@ -46,70 +46,69 @@ function envi()
 function nvidia()
 {
   echo $'\n'"    deploy:"
-  echo "      resources:"
-  echo "        reservations:"
-  echo "          devices:"
-  echo "            - driver: nvidia"
-  echo "              capabilities: [${2// /,}]"
-  echo "              device_ids: [\"${1// /,}\"]"
+  echo      "      resources:"
+  echo      "        reservations:"
+  echo      "          devices:"
+  echo      "            - driver: nvidia"
+  echo      "              capabilities: [${2// /,}]"
+  echo      "              device_ids: [\"${1// /,}\"]"
 }
 
 begin_test "Docker compose override variable substitution"
 (
   setup_test
-  [ "$(_docker_compose_override_var_sub 'x')" = "" ]
-  [ "$(_docker_compose_override_var_sub '$foo_bar')" = "foo_bar" ] # nobraces
-  [ "$(_docker_compose_override_var_sub '${FOO_BAR}')" = "FOO_BAR" ]
+  assert_str_eq "$(_docker_compose_override_var_sub 'x')" ""
+  assert_str_eq "$(_docker_compose_override_var_sub '$foo_bar')" "foo_bar" # nobraces
+  assert_str_eq "$(_docker_compose_override_var_sub '${FOO_BAR}')" "FOO_BAR"
 )
 end_test
 
 begin_test "Environment echo"
 (
   setup_test
-  ans="    environment:"
-  ans+=$'\n      - test=15'
-  [ "$(_env_echo test 15)" = "${ans}" ]
+  ans+="      - test=15"
+  assert_str_eq "$(_env_echo test 15)" "${ans}"
   ans+=$'\n      - foo=bar'
-  [ "$(_env_echo test 15;
-       _env_echo foo bar)" = "${ans}" ]
+  assert_str_eq "$(_env_echo test 15;
+       _env_echo foo bar)" "${ans}"
 )
 end_test
 
 begin_test "No services"
 (
   setup_test
-  [ "$(generate_docker_compose_override PROJECT)" = "$(head)" ]
+  assert_str_eq "$(generate_docker_compose_override PROJECT)" "$(head)"
 )
 end_test
 
 begin_test "CLI"
 (
   setup_test
-  ans="$(head)$(service test1)"
+  ans="$(head)$(service test1)$(environment)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    ans+="$(environment)$(envi "JUST_HOST_WINDOWS=1")"
+    ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
   # TEST_VOLUMES="/tmp:/temp:ro"
   # ans+="$(vol /tmp /temp:ro)"
   # don't redirect this, could hide errors
   "${VSI_COMMON_DIR}/linux/just_files/docker_compose_override" PROJECT test1
-  [ "$("${VSI_COMMON_DIR}/linux/just_files/docker_compose_override" PROJECT test1)" = "${ans}" ]
+  assert_str_eq "$("${VSI_COMMON_DIR}/linux/just_files/docker_compose_override" PROJECT test1)" "${ans}"
 )
 end_test
 
 begin_test "COMPOSE_VERSION 2.3"
 (
   setup_test
-  ans="$(head 2.3)$(service test1)"
+  ans="$(head 2.3)$(service test1)$(environment)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    ans+="$(environment)$(envi "JUST_HOST_WINDOWS=1")"
+    ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
-  ans+="$(service test2)"
+  ans+="$(service test2)$(environment)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    ans+="$(environment)$(envi "JUST_HOST_WINDOWS=1")"
+    ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
   COMPOSE_VERSION=2.3
-  [ "$(generate_docker_compose_override PROJECT test1 test2)" = "${ans}" ]
+  assert_str_eq "$(generate_docker_compose_override PROJECT test1 test2)" "${ans}"
 )
 end_test
 
@@ -118,9 +117,9 @@ begin_test "Just docker compose dynamic volumes"
   setup_test
   ans="$(head)$(service test1)$(volumes)"
 
-  ans1="${ans}$(vol "$(real_path "${TESTDIR}")" /trash:z)"
+  ans1="${ans}$(vol "$(real_path "${TESTDIR}")" /trash:z)$(environment)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    ans1+="$(environment)$(envi "JUST_HOST_WINDOWS=1")"
+    ans1+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
   TEST_VOLUMES=(".:/trash:z")
   override="$(generate_docker_compose_override TEST test1)"
@@ -130,9 +129,9 @@ begin_test "Just docker compose dynamic volumes"
   ans+="$(vol "$(real_path "/tmp")" /temp:ro)"
   override="$(generate_docker_compose_override TEST test1)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
+    assert_str_eq "${override}" "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")"
   else
-    assert_str_eq "${override}" "${ans}"
+    assert_str_eq "${override}" "${ans}$(environment)"
   fi
 
   TEST_TEST1_VOLUMES=("${TESTDIR}/src:/source:rw")
@@ -140,54 +139,54 @@ begin_test "Just docker compose dynamic volumes"
   ans+="$(vol "$(real_path "${TESTDIR}/src")" /source:rw)"
   override="$(generate_docker_compose_override TEST test1)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
+    assert_str_eq "${override}" "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")"
   else
-    assert_str_eq "${override}" "${ans}"
+    assert_str_eq "${override}" "${ans}$(environment)"
   fi
 
   TEST_VOLUME_1="${TESTDIR}/foo:/bar"
   ans+="$(vol "$(real_path "${TESTDIR}/foo")" /bar)"
   override="$(generate_docker_compose_override TEST test1)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
+    assert_str_eq "${override}" "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")"
   else
-    assert_str_eq "${override}" "${ans}"
+    assert_str_eq "${override}" "${ans}$(environment)"
   fi
 
   TEST_VOLUME_2="${TESTDIR}/foo2:/bar3"
   ans+="$(vol "$(real_path "${TESTDIR}/foo2")" /bar3)"
   override="$(generate_docker_compose_override TEST test1)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
+    assert_str_eq "${override}" "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")"
   else
-    assert_str_eq "${override}" "${ans}"
+    assert_str_eq "${override}" "${ans}$(environment)"
   fi
 
   TEST_TEST1_VOLUME_1="${TESTDIR}/bar:/foo"
   ans+="$(vol "$(real_path "${TESTDIR}/bar")" /foo)"
   override="$(generate_docker_compose_override TEST test1)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
+    assert_str_eq "${override}" "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")"
   else
-    assert_str_eq "${override}" "${ans}"
+    assert_str_eq "${override}" "${ans}$(environment)"
   fi
 
   TEST_TEST1_VOLUME_2="${TESTDIR}/bar2:/foo5"
   ans+="$(vol "$(real_path "${TESTDIR}/bar2")" /foo5)"
   override="$(generate_docker_compose_override TEST test1)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
+    assert_str_eq "${override}" "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")"
   else
-    assert_str_eq "${override}" "${ans}"
+    assert_str_eq "${override}" "${ans}$(environment)"
   fi
 
   # Make sure readonly doesn't shadow a read-write
   TEST_TEST1_VOLUME_3="${TESTDIR}/bar2:/foo5:ro"
   override="$(generate_docker_compose_override TEST test1)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    [ "${override}" = "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")" ]
+    assert_str_eq "${override}" "${ans}$(environment)$(envi "JUST_HOST_WINDOWS=1")"
   else
-    assert_str_eq "${override}" "${ans}"
+    assert_str_eq "${override}" "${ans}$(environment)"
   fi
 )
 end_test
@@ -217,9 +216,9 @@ begin_test "Just docker compose dynamic environment"
   assert_str_eq "${override}" "${ans}"
 
   # Ignores non-project variables
-  ans="$(head)$(service test1)"
+  ans="$(head)$(service test1)$(environment)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    ans+="$(environment)$(envi "JUST_HOST_WINDOWS=1")"
+    ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
   override="$(TEST_ONE_HOST=1 TEST_ONE_DOCKER=2 \
               generate_docker_compose_override TEST2 test1)"
@@ -232,9 +231,9 @@ begin_test "Just docker compose dynamic nvidia"
   setup_test
 
   # Basic test
-  ans="$(head)$(service test1)"
+  ans="$(head)$(service test1)$(environment)"
   if [ "${OS-}" = "Windows_NT" ]; then
-    ans+="$(environment)$(envi "JUST_HOST_WINDOWS=1")"
+    ans+="$(envi "JUST_HOST_WINDOWS=1")"
   fi
   override="$(generate_docker_compose_override TEST test1)"
   assert_str_eq "${override}" "${ans}"

--- a/tests/test-docker_functions.bsh
+++ b/tests/test-docker_functions.bsh
@@ -67,7 +67,7 @@ begin_test "Test DOCKER var"
   setup_test
   DRYRUN=echo
   DOCKER="DoCkEr"
-  [ "$(Docker run test)" = "DoCkEr run --rm test" ]
+  assert_str_eq "$(Docker run test)" "DoCkEr run --rm -e JUST_IN_CONTAINER=docker test"
 )
 end_test
 
@@ -123,9 +123,9 @@ begin_test "docker host dir"
   setup_test
 
   if [ "${OS-}" = "Windows_NT" ]; then
-    [ "$(docker_host_dir /tmp)" = "$(cygpath -w /tmp)" ]
+    assert_str_eq "$(docker_host_dir /tmp)" "$(cygpath -w /tmp)"
   else
-    [ "$(docker_host_dir /tmp)" = "/tmp" ]
+    assert_str_eq "$(docker_host_dir /tmp)" "/tmp"
   fi
 )
 end_test
@@ -161,9 +161,9 @@ begin_test "Docker volume string parsing"
     for docker_path in "${docker_paths[@]}"; do
       for test_volume_flag in "${test_volume_flags[@]}"; do
         docker_parse_volume_string "${host_path}:${docker_path}${test_volume_flag}"
-        [ "${volume_host}" = "${host_path}" ]
-        [ "${volume_docker}" = "${docker_path}" ]
-        [ "${volume_flags}" = "${test_volume_flag}" ]
+        assert_str_eq "${volume_host}" "${host_path}"
+        assert_str_eq "${volume_docker}" "${docker_path}"
+        assert_str_eq "${volume_flags}" "${test_volume_flag}"
       done
     done
   done
@@ -179,11 +179,11 @@ begin_test "Sanitize Volumes"
   [ ! -e "${temp_dir}" ]
 
   if [ "${OS-notwindows}" = "Windows_NT" ]; then
-    [ "$(docker_sanitize_volume "${temp_dir}" 2>/dev/null)" = "$(cygpath -w "${temp_dir}"):/${temp_dir}" ]
-    [ "$(docker_sanitize_volume "${temp_dir}" /foo)" = "$(cygpath -w "${temp_dir}")://foo" ]
+    assert_str_eq "$(docker_sanitize_volume "${temp_dir}" 2>/dev/null)" "$(cygpath -w "${temp_dir}"):/${temp_dir}"
+    assert_str_eq "$(docker_sanitize_volume "${temp_dir}" /foo)" "$(cygpath -w "${temp_dir}")://foo"
   else
-    [ "$(docker_sanitize_volume "${temp_dir}" 2>/dev/null)" = "${temp_dir}:${temp_dir}" ]
-    [ "$(docker_sanitize_volume "${temp_dir}" /bar)" = "${temp_dir}:/bar" ]
+    assert_str_eq "$(docker_sanitize_volume "${temp_dir}" 2>/dev/null)" "${temp_dir}:${temp_dir}"
+    assert_str_eq "$(docker_sanitize_volume "${temp_dir}" /bar)" "${temp_dir}:/bar"
   fi
 
   [ -e "${temp_dir}" ]
@@ -197,7 +197,7 @@ begin_test "Parse docker args"
   # Normal case
   parse-docker --config=blah.json -D -v run -v /foo:/bar debian:9 bash
   assert_array_values docker_args --config=blah.json -D -v
-  [ "${docker_command}" = "run" ]
+  assert_str_eq "${docker_command}" "run"
   assert_array_values docker_command_args -v /foo:/bar debian:9 bash
 
   # Test all args that take an argument
@@ -205,13 +205,13 @@ begin_test "Parse docker args"
     parse-docker "${arg}" foobar
     declare -p docker_args docker_command docker_command_args
     assert_array_values docker_args "${arg}" foobar
-    [ "${docker_command-}" = "" ]
+    assert_str_eq "${docker_command-}" ""
     assert_array_values docker_command_args
 
     # Test = notation
     parse-docker "${arg}=foobar"
     assert_array_values docker_args "${arg}=foobar"
-    [ "${docker_command-}" = "" ]
+    assert_str_eq "${docker_command-}" ""
     assert_array_values docker_command_args
   done
 
@@ -219,7 +219,7 @@ begin_test "Parse docker args"
   for arg in -H -l; do
     parse-docker "${arg}foobar"
     assert_array_values docker_args "${arg}foobar"
-    [ "${docker_command-}" = "" ]
+    assert_str_eq "${docker_command-}" ""
     assert_array_values docker_command_args
   done
 
@@ -227,7 +227,7 @@ begin_test "Parse docker args"
   for arg in -v --version --tls -D --debug --tlsverify; do
     parse-docker "${arg}"
     assert_array_values docker_args "${arg}"
-    [ "${docker_command-}" = "" ]
+    assert_str_eq "${docker_command-}" ""
     assert_array_values docker_command_args
   done
 )
@@ -239,10 +239,10 @@ begin_test "Docker command"
   export DRYRUN=print_command
 
   DOCKER_AUTOREMOVE=0
-  a=("${DOCKER}" run -v '/test  this/:blah' 'debian:9')
+  a=("${DOCKER}" run '-e' 'JUST_IN_CONTAINER=docker' -v '/test  this/:blah' 'debian:9')
   r="$(Docker run -v "/test  this/:blah" debian:9)"
   eval "r=(${r})" # noquotes
-  cmp_elements_a a r
+  assert_array_eq a r
 )
 end_test
 
@@ -251,16 +251,16 @@ begin_test "DOCKER_AUTOREMOVE and DOCKER_EXTRA_*_ARGS"
   setup_test
   export DRYRUN=print_command
 
-  a=("${DOCKER}" run --rm -v '/test  this/:blah' 'debian:9')
+  a=("${DOCKER}" run --rm '-e' 'JUST_IN_CONTAINER=docker' -v '/test  this/:blah' 'debian:9')
   r="$(Docker run -v "/test  this/:blah" debian:9)"
   eval "r=(${r})" # noquotes
-  cmp_elements_a a r
+  assert_array_eq a r
 
   DOCKER_EXTRA_RUN_ARGS=('aaa' 'bbb')
-  a=("${DOCKER}" run --rm aaa bbb -v '/test  this/:blah' 'debian:9')
+  a=("${DOCKER}" run --rm '-e' 'JUST_IN_CONTAINER=docker' aaa bbb -v '/test  this/:blah' 'debian:9')
   r="$(Docker run -v "/test  this/:blah" debian:9)"
   eval "r=(${r})" # noquotes
-  cmp_elements_a a r
+  assert_array_eq a r
 )
 end_test
 
@@ -274,7 +274,7 @@ begin_test "DOCKER_EXTRA_ARGS"
   a=("${DOCKER}" --tls "${DOCKER_EXTRA_ARGS[@]}" build aaa bbb -v '/test  this/:blah' 'debian:9')
   r="$(Docker --tls build -v "/test  this/:blah" debian:9)"
   eval "r=(${r})" # noquotes
-  cmp_elements_a a r
+  assert_array_eq a r
 )
 end_test
 
@@ -284,9 +284,9 @@ begin_test "Test DOCKER_COMPOSE var"
   DRYRUN=echo
   unset DOCKER_COMPOSE
   DOCKER_COMPOSE="DoCkErCoMpOsE"
-  [ "$(JUSTFILE="${TESTDIR}/Justfile" Docker compose run test)" = "DoCkErCoMpOsE run --rm test" ]
+  assert_str_eq "$(JUSTFILE="${TESTDIR}/Justfile" Docker compose run test)" "DoCkErCoMpOsE run --rm test"
   DOCKER_COMPOSE=("DoCkEr" "CoMpOsE")
-  [ "$(JUSTFILE="${TESTDIR}/Justfile" Docker compose run test)" = "DoCkEr CoMpOsE run --rm test" ]
+  assert_str_eq "$(JUSTFILE="${TESTDIR}/Justfile" Docker compose run test)" "DoCkEr CoMpOsE run --rm test"
 )
 end_test
 
@@ -300,7 +300,7 @@ begin_test "parse docker compose volumes"
        "Lsource: internal" "ltarget: /src" "ltype: volume"
        "Ltarget: /tmp2" "ltype: tmpfs")
   parse_docker_compose_volumes nb <<< "${compose_file_long}"
-  cmp_elements_a DOCKER_VOLUME_LINES ans
+  assert_array_eq DOCKER_VOLUME_LINES ans
 
   ans=("S/tmp:/mnt"
        "Lsource: /home/user/src" "ltarget: /src" "ltype: bind"
@@ -308,17 +308,17 @@ begin_test "parse docker compose volumes"
        "Lsource: test_prefix_internal" "ltarget: /src" "ltype: volume"
        "Ltarget: /tmp2" "ltype: tmpfs")
   parse_docker_compose_volumes nb test_prefix_ <<< "${compose_file_long}"
-  cmp_elements_a DOCKER_VOLUME_LINES ans
+  assert_array_eq DOCKER_VOLUME_LINES ans
 
   ans=()
   parse_docker_compose_volumes foo <<< "${compose_file_long}"
-  cmp_elements_a DOCKER_VOLUME_LINES ans
+  assert_array_eq DOCKER_VOLUME_LINES ans
 
   parse_docker_compose_volumes bar <<< "${compose_file_long}"
-  cmp_elements_a DOCKER_VOLUME_LINES ans
+  assert_array_eq DOCKER_VOLUME_LINES ans
 
   parse_docker_compose_volumes none <<< "${compose_file_long}"
-  cmp_elements_a DOCKER_VOLUME_LINES ans
+  assert_array_eq DOCKER_VOLUME_LINES ans
 )
 end_test
 
@@ -349,21 +349,22 @@ begin_test "docker compose volumes"
                          "lvolume:"
                          "l  nocopy: true")
   docker_compose_volumes
-  sources=("/test1" "test3" "internal")
-  targets=("/test2" "/test4" "/src")
-  flags=(":ro" ":Z" $'volume:\n  nocopy: true')
-  cmp_elements_a DOCKER_VOLUME_SOURCES sources
-  cmp_elements_a DOCKER_VOLUME_TARGETS targets
-  cmp_elements_a DOCKER_VOLUME_FLAGS flags
+  sources=("" "/test1" "test3" "internal")
+  targets=("" "/test2" "/test4" "/src")
+  flags=("" ":ro" ":Z" $'volume:\n  nocopy: true')
+  unset sources[0] targets[0] flags[0]
+  assert_array_eq DOCKER_VOLUME_SOURCES sources
+  assert_array_eq DOCKER_VOLUME_TARGETS targets
+  assert_array_eq DOCKER_VOLUME_FLAGS flags
 
   DOCKER_VOLUME_LINES+=("S/test5:/test6:rw")
   docker_compose_volumes
   sources+=("/test5")
   targets+=("/test6")
   flags+=(":rw")
-  cmp_elements_a DOCKER_VOLUME_SOURCES sources
-  cmp_elements_a DOCKER_VOLUME_TARGETS targets
-  cmp_elements_a DOCKER_VOLUME_FLAGS flags
+  assert_array_eq DOCKER_VOLUME_SOURCES sources
+  assert_array_eq DOCKER_VOLUME_TARGETS targets
+  assert_array_eq DOCKER_VOLUME_FLAGS flags
 )
 end_test
 
@@ -409,7 +410,7 @@ begin_test "Parse docker compose args"
 
   parse_docker_compose run test
   assert_array_values docker_compose_args
-  [ "${docker_compose_command}" = "run" ]
+  assert_str_eq "${docker_compose_command}" "run"
   assert_array_values docker_compose_command_args test
 
   # Test all args that take an argument
@@ -417,13 +418,13 @@ begin_test "Parse docker compose args"
              --tlscacert --tlscert --tlskey --project-directory --env-file; do
     parse_docker_compose "${arg}" foobar
     assert_array_values docker_compose_args "${arg}" foobar
-    [ "${docker_compose_command-}" = "" ]
+    assert_str_eq "${docker_compose_command-}" ""
     assert_array_values docker_compose_command_args
 
     # Test = notation
     parse_docker_compose "${arg}=foobar"
     assert_array_values docker_compose_args "${arg}=foobar"
-    [ "${docker_compose_command-}" = "" ]
+    assert_str_eq "${docker_compose_command-}" ""
     assert_array_values docker_compose_command_args
   done
 
@@ -431,7 +432,7 @@ begin_test "Parse docker compose args"
   for arg in -f -p -H -c; do
     parse_docker_compose "${arg}foobar"
     assert_array_values docker_compose_args "${arg}foobar"
-    [ "${docker_compose_command-}" = "" ]
+    assert_str_eq "${docker_compose_command-}" ""
     assert_array_values docker_compose_command_args
   done
 
@@ -439,13 +440,13 @@ begin_test "Parse docker compose args"
   for arg in --no-ansi -v --verbose --tls --skip-hostname-check --tlsverify --compatibility; do
     parse_docker_compose "${arg}"
     assert_array_values docker_compose_args "${arg}"
-    [ "${docker_compose_command-}" = "" ]
+    assert_str_eq "${docker_compose_command-}" ""
     assert_array_values docker_compose_command_args
   done
 
   parse_docker_compose --no-ansi -H=blah.json --verbose run -v /foo:/bar debian bash
   assert_array_values docker_compose_args --no-ansi -H=blah.json --verbose
-  [ "${docker_compose_command}" = "run" ]
+  assert_str_eq "${docker_compose_command}" "run"
   assert_array_values docker_compose_command_args -v /foo:/bar debian bash
 )
 end_test
@@ -455,18 +456,18 @@ begin_test "Parse docker compose project name"
   setup_test
 
   parse_docker_compose --project-name foo
-  [ "${docker_compose_project_name}" = "foo" ]
+  assert_str_eq "${docker_compose_project_name}" "foo"
 
   parse_docker_compose --project-name foo run alpine
-  [ "${docker_compose_project_name}" = "foo" ]
+  assert_str_eq "${docker_compose_project_name}" "foo"
   parse_docker_compose -p bar run alpine
-  [ "${docker_compose_project_name}" = "bar" ]
+  assert_str_eq "${docker_compose_project_name}" "bar"
   parse_docker_compose -p foobar run alpine
-  [ "${docker_compose_project_name}" = "foobar" ]
+  assert_str_eq "${docker_compose_project_name}" "foobar"
 
   # Make sure -p/--project-name wins
   COMPOSE_PROJECT_NAME=foo parse_docker_compose -p bar run alpine
-  [ "${docker_compose_project_name}" = "bar" ]
+  assert_str_eq "${docker_compose_project_name}" "bar"
 )
 end_test
 
@@ -484,44 +485,44 @@ begin_test "Parse docker compose file args"
 
   parse_docker_compose run alpine
   # No docker compose
-  [ "${docker_compose_project_name}" = "default" ]
-  [ "${#docker_compose_files[@]}" -eq "0" ]
+  assert_str_eq "${docker_compose_project_name}" "default"
+  assert_str_eq "${#docker_compose_files[@]}" "0"
 
   # Make sure COMPOSE_FILE works
   COMPOSE_FILE=docker-compose2.yml parse_docker_compose run alpine
-  [ "${docker_compose_project_name}" = "$(basename "$(pwd)")" ]
-  [ "${#docker_compose_files[@]}" -eq "1" ]
-  [ "${docker_compose_files[0]}" = "docker-compose2.yml" ]
+  assert_str_eq "${docker_compose_project_name}" "$(basename "$(pwd)")"
+  assert_str_eq "${#docker_compose_files[@]}" "1"
+  assert_str_eq "${docker_compose_files[0]}" "docker-compose2.yml"
 
   # Make sure COMPOSE_FILE overrides docker-compose.yml
   touch docker-compose.yml
   COMPOSE_FILE=docker-compose2.yml parse_docker_compose run alpine
-  [ "${docker_compose_project_name}" = "$(basename "$(pwd)")" ]
-  [ "${#docker_compose_files[@]}" -eq "1" ]
-  [ "${docker_compose_files[0]}" = "docker-compose2.yml" ]
+  assert_str_eq "${docker_compose_project_name}" "$(basename "$(pwd)")"
+  assert_str_eq "${#docker_compose_files[@]}" "1"
+  assert_str_eq "${docker_compose_files[0]}" "docker-compose2.yml"
 
   # Make sure docker-compose.yml works
   parse_docker_compose run alpine
-  [ "${docker_compose_project_name}" = "$(basename "$(pwd)")" ]
-  [ "${#docker_compose_files[@]}" -eq "1" ]
-  [ "${docker_compose_files[0]}" = "${TESTDIR}/docker-compose.yml" ]
+  assert_str_eq "${docker_compose_project_name}" "$(basename "$(pwd)")"
+  assert_str_eq "${#docker_compose_files[@]}" "1"
+  assert_str_eq "${docker_compose_files[0]}" "${TESTDIR}/docker-compose.yml"
 
   # Make sure override works
   touch docker-compose.override.yaml
   parse_docker_compose run alpine
-  [ "${docker_compose_project_name}" = "$(basename "$(pwd)")" ]
-  [ "${#docker_compose_files[@]}" -eq "2" ]
-  [ "${docker_compose_files[0]}" = "${TESTDIR}/docker-compose.yml" ]
-  [ "${docker_compose_files[1]}" = "${TESTDIR}/docker-compose.override.yaml" ]
+  assert_str_eq "${docker_compose_project_name}" "$(basename "$(pwd)")"
+  assert_str_eq "${#docker_compose_files[@]}" "2"
+  assert_str_eq "${docker_compose_files[0]}" "${TESTDIR}/docker-compose.yml"
+  assert_str_eq "${docker_compose_files[1]}" "${TESTDIR}/docker-compose.override.yaml"
 
   # Make sure -f/--file wins
   COMPOSE_FILE=docker-compose2.yml parse_docker_compose -f test3.yml run alpine
-  [ "${docker_compose_project_name}" = "$(basename "$(pwd)")" ]
-  [ "${#docker_compose_files[@]}" -eq "1" ]
-  [ "${docker_compose_files[0]}" = "test3.yml" ]
+  assert_str_eq "${docker_compose_project_name}" "$(basename "$(pwd)")"
+  assert_str_eq "${#docker_compose_files[@]}" "1"
+  assert_str_eq "${docker_compose_files[0]}" "test3.yml"
 
   parse_docker_compose -f test1.yml -ftest2 --file test3 --file=test4 run debian:9 bash
-  [ "${#docker_compose_files[@]}" -eq "4" ]
+  assert_str_eq "${#docker_compose_files[@]}" "4"
 )
 end_test
 
@@ -529,7 +530,7 @@ begin_test "Compose IFS non-Windows"
 (
   setup_test
   unset OS
-  [ "$(compose_path_separator)" = ":" ]
+  assert_str_eq "$(compose_path_separator)" ":"
 )
 end_test
 
@@ -537,7 +538,7 @@ begin_test "Compose IFS Windows"
 (
   setup_test
   OS="Windows_NT"
-  [ "$(compose_path_separator)" = ";" ]
+  assert_str_eq "$(compose_path_separator)" ";"
 )
 end_test
 
@@ -546,9 +547,9 @@ begin_test "Custom IFS"
   setup_test
   COMPOSE_PATH_SEPARATOR='|'
   OS="Windows_NT"
-  [ "$(compose_path_separator)" = "|" ]
+  assert_str_eq "$(compose_path_separator)" "|"
   unset OS
-  [ "$(compose_path_separator)" = "|" ]
+  assert_str_eq "$(compose_path_separator)" "|"
 )
 end_test
 
@@ -563,7 +564,7 @@ begin_test "Docker compose command"
   a=("${DOCKER_COMPOSE[@]}" run -v '/test  this/:blah' 'debian:9')
   r="$(Docker compose run -v "/test  this/:blah" debian:9)"
   eval "r=(${r})" # noquotes
-  cmp_elements_a a r
+  assert_array_eq a r
 )
 end_test
 
@@ -576,13 +577,13 @@ begin_test "DOCKER_COMPOSE_AUTOREMOVE and DOCKER_COMPOSE_EXTRA_*_ARGS"
   a=("${DOCKER_COMPOSE[@]}" run --rm -v '/test  this/:blah' 'debian')
   r="$(Docker compose run -v "/test  this/:blah" debian)"
   eval "r=(${r})" # noquotes
-  cmp_elements_a a r
+  assert_array_eq a r
 
   DOCKER_COMPOSE_EXTRA_RUN_ARGS=('aaa' 'bbb')
   a=("${DOCKER_COMPOSE[@]}" run --rm aaa bbb -v '/test  this/:blah' 'debian')
   r="$(Docker compose run -v "/test  this/:blah" debian)"
   eval "r=(${r})" # noquotes
-  cmp_elements_a a r
+  assert_array_eq a r
 )
 end_test
 
@@ -597,7 +598,7 @@ begin_test "DOCKER_COMPOSE_EXTRA_ARGS"
   a=("${DOCKER_COMPOSE[@]}" --tls "${DOCKER_COMPOSE_EXTRA_ARGS[@]}" build aaa bbb -v '/test  this/:blah' 'debian')
   r="$(Docker compose --tls build -v "/test  this/:blah" debian)"
   eval "r=(${r})" # noquotes
-  cmp_elements_a a r
+  assert_array_eq a r
 )
 end_test
 
@@ -627,9 +628,9 @@ begin_test "Docker compose sanitize project names"
 (
   setup_test
 
-  [ "$(docker_compose_sanitize_project_name 'project/A@1.1_2')" = "a112" ]
-  [ "$(docker_compose_sanitize_project_name 'project/A@1.1_2' 'auser:7')" = "auser7a112" ]
-  [ "$(docker_compose_sanitize_project_name '' 'a-user:7')" = "auser7" ]
+  assert_str_eq "$(docker_compose_sanitize_project_name 'project/A@1.1_2')"  "a112"
+  assert_str_eq "$(docker_compose_sanitize_project_name 'project/A@1.1_2' 'auser:7')"  "auser7a112"
+  assert_str_eq "$(docker_compose_sanitize_project_name '' 'a-user:7')"  "auser7"
 )
 end_test
 
@@ -641,10 +642,10 @@ begin_test "Just docker compose override files"
   ans="version: '3.2'
 services:
   test_hay:
-    x-bugfix:"
+    environment:
+      - JUST_IN_CONTAINER=docker"
   if [ "${OS-}" = "Windows_NT" ]; then
     ans+="
-    environment:
       - JUST_HOST_WINDOWS=1"
   fi
 
@@ -654,14 +655,14 @@ services:
   override_file="$(Just-docker-compose -f "${TESTDIR}/dc.yml" run test_hay|tail -n1)"
   override_file="${override_file#rm *}"
   ttouch "${override_file}"
-  [ "$(cat "${override_file}")" = "${ans}" ]
+  assert_str_eq "$(cat "${override_file}")" "${ans}"
 
   # Test when two docker compose files reference the same service
   echo "${compose_file_hay}" > "${TESTDIR}/dc2.yml"
   override_file="$(Just-docker-compose -f "${TESTDIR}/dc.yml" -f "${TESTDIR}/dc2.yml" run test_hay|tail -n1)"
   override_file="${override_file#rm *}"
   ttouch "${override_file}"
-  [ "$(cat "${override_file}")" = "${ans}" ]
+  assert_str_eq "$(cat "${override_file}")" "${ans}"
 )
 end_test
 
@@ -718,11 +719,11 @@ begin_test "docker cp image"
     fi
   }
 
-  [ "$(docker_cp_image my_image:foo /bar/test.txt "${TESTDIR}/dst.txt")" = \
+  assert_str_eq "$(docker_cp_image my_image:foo /bar/test.txt "${TESTDIR}/dst.txt")" \
     "mock_docker: cp mock_container_name_my_image:foo:/bar/test.txt ${TESTDIR}/dst.txt
 mock_docker: rm mock_container_name_my_image:foo" ]
 
-  [ "$(docker_cp_image -L -a my_image:foo /bar/test.txt "${TESTDIR}/dst.txt")" = \
+  assert_str_eq "$(docker_cp_image -L -a my_image:foo /bar/test.txt "${TESTDIR}/dst.txt")" \
     "mock_docker: cp -L -a mock_container_name_my_image:foo:/bar/test.txt ${TESTDIR}/dst.txt
 mock_docker: rm mock_container_name_my_image:foo" ]
 )
@@ -774,12 +775,12 @@ begin_test "get docker compose version"
   echo "noversion:" > file2
   echo "version: \"3.5\"" > file3
 
-  [ "$(get_docker_compose_version file1)" = "2.3" ]
-  [ "$(get_docker_compose_version file2)" = "" ]
-  [ "$(get_docker_compose_version file3)" = "3.5" ]
+  assert_str_eq "$(get_docker_compose_version file1)" "2.3"
+  assert_str_eq "$(get_docker_compose_version file2)" ""
+  assert_str_eq "$(get_docker_compose_version file3)" "3.5"
 
-  [ "$(get_docker_compose_version file2 file1)" = "2.3" ]
-  [ "$(get_docker_compose_version file3 file1)" = "3.5" ]
+  assert_str_eq "$(get_docker_compose_version file2 file1)" "2.3"
+  assert_str_eq "$(get_docker_compose_version file3 file1)" "3.5"
 )
 end_test
 
@@ -791,14 +792,14 @@ begin_test "get docker stage names"
 FROM foo
 EOF
   stage_names=($(get_docker_stage_names Dockerfile))
-  [ "${stage_names[*]-}" = "" ]
+  assert_str_eq "${stage_names[*]-}" ""
 
   cat - << EOF > Dockerfile
 FROM image1 as foo
 FROM foo
 EOF
   stage_names=($(get_docker_stage_names Dockerfile))
-  [ "${stage_names[*]}" = "foo" ]
+  assert_str_eq "${stage_names[*]}" "foo"
 
   cat - << EOF > Dockerfile
 FROM image1 as foo
@@ -806,7 +807,7 @@ FROM image2 as bar
 FROM foo
 EOF
   stage_names=($(get_docker_stage_names Dockerfile))
-  [ "${stage_names[*]}" = "foo bar" ]
+  assert_str_eq "${stage_names[*]}" "foo bar"
 
   # Comments and spaces
   cat - << EOF > Dockerfile
@@ -816,7 +817,7 @@ FROM image1 as foo
  FROM foo
 EOF
   stage_names=($(get_docker_stage_names Dockerfile))
-  [ "${stage_names[*]}" = "foo" ]
+  assert_str_eq "${stage_names[*]}" "foo"
 )
 end_test
 
@@ -830,7 +831,7 @@ services:
   foo:
     build: boo
 EOF
-  [ "$(get_dockerfile_from_compose /some/dir/file.yml foo "$(yarp < compose.yml)")" = "/some/dir/boo/Dockerfile" ]
+  assert_str_eq "$(get_dockerfile_from_compose /some/dir/file.yml foo "$(yarp < compose.yml)")" "/some/dir/boo/Dockerfile"
 
     cat - << EOF > compose.yml
 version: '2.2'
@@ -839,7 +840,7 @@ services:
     build:
       context: /bar
 EOF
-  [ "$(get_dockerfile_from_compose "${TESTDIR}/compose.yml" foo)" = "/bar/Dockerfile" ]
+  assert_str_eq "$(get_dockerfile_from_compose "${TESTDIR}/compose.yml" foo)" "/bar/Dockerfile"
 
     cat - << EOF > compose.yml
 version: '2.2'
@@ -850,7 +851,7 @@ services:
       contest: .
 EOF
 
-  [ "$(get_dockerfile_from_compose compose.yml foo)" = "./some.Dockerfile" ]
-  [ "$(get_dockerfile_from_compose "${TESTDIR}/compose.yml" foo)" = "${TESTDIR}/some.Dockerfile" ]
+  assert_str_eq "$(get_dockerfile_from_compose compose.yml foo)" "./some.Dockerfile"
+  assert_str_eq "$(get_dockerfile_from_compose "${TESTDIR}/compose.yml" foo)" "${TESTDIR}/some.Dockerfile"
 )
 end_test

--- a/tests/test-just_singularity_functions.bsh
+++ b/tests/test-just_singularity_functions.bsh
@@ -53,7 +53,8 @@ begin_test "singular-compose"
   ( # Put in subprocess because loading singular-compose.env files can contaminate each other
     singular_defaultify singular-compose run foo3
     source "${TESTDIR}/tappoint.txt"
-    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO)
+    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO
+              SINGULARITYENV_JUST_IN_CONTAINER)
     if [ "${OS-}" = "Windows_NT" ]; then
       env_vars+=(SINGULARITYENV_JUST_HOST_WINDOWS)
     fi
@@ -71,7 +72,8 @@ begin_test "singular-compose"
     export SINGULARITY_ADD_TMP_DIR=0
     singular_defaultify singular-compose run foo3
     source "${TESTDIR}/tappoint.txt"
-    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO)
+    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO
+              SINGULARITYENV_JUST_IN_CONTAINER)
     if [ "${OS-}" = "Windows_NT" ]; then
       env_vars+=(SINGULARITYENV_JUST_HOST_WINDOWS)
     fi
@@ -91,7 +93,8 @@ begin_test "singular-compose"
     singular_defaultify singular-compose -f "${TESTDIR}/singular-compose2.env" \
         --file "${TESTDIR}/singular-compose3.env" run foo1
     source "${TESTDIR}/tappoint.txt"
-    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO)
+    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO
+              SINGULARITYENV_JUST_IN_CONTAINER)
     if [ "${OS-}" = "Windows_NT" ]; then
       env_vars+=(SINGULARITYENV_JUST_HOST_WINDOWS)
     fi
@@ -113,7 +116,8 @@ begin_test "singular-compose"
 
     singular_defaultify singular-compose run foo3
     source "${TESTDIR}/tappoint.txt"
-    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO)
+    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO
+              SINGULARITYENV_JUST_IN_CONTAINER)
     if [ "${OS-}" = "Windows_NT" ]; then
       env_vars+=(SINGULARITYENV_JUST_HOST_WINDOWS)
     fi

--- a/tests/test-just_singularity_functions.bsh
+++ b/tests/test-just_singularity_functions.bsh
@@ -53,11 +53,11 @@ begin_test "singular-compose"
   ( # Put in subprocess because loading singular-compose.env files can contaminate each other
     singular_defaultify singular-compose run foo3
     source "${TESTDIR}/tappoint.txt"
-    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO
-              SINGULARITYENV_JUST_IN_CONTAINER)
+    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO)
     if [ "${OS-}" = "Windows_NT" ]; then
       env_vars+=(SINGULARITYENV_JUST_HOST_WINDOWS)
     fi
+    env_vars+=(SINGULARITYENV_JUST_IN_CONTAINER)
     assert_array_values env "${env_vars[@]}"
     [ "${SINGULARITYENV_BAR}" = "12345" ]
     [ "${SINGULARITYENV_FOO}" = "BAR FAR  BOO " ]
@@ -72,11 +72,11 @@ begin_test "singular-compose"
     export SINGULARITY_ADD_TMP_DIR=0
     singular_defaultify singular-compose run foo3
     source "${TESTDIR}/tappoint.txt"
-    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO
-              SINGULARITYENV_JUST_IN_CONTAINER)
+    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO)
     if [ "${OS-}" = "Windows_NT" ]; then
       env_vars+=(SINGULARITYENV_JUST_HOST_WINDOWS)
     fi
+    env_vars+=(SINGULARITYENV_JUST_IN_CONTAINER)
     assert_array_values env "${env_vars[@]}"
     [ "${SINGULARITYENV_BAR}" = "12345" ]
     [ "${SINGULARITYENV_FOO}" = "BAR FAR  BOO " ]
@@ -93,11 +93,11 @@ begin_test "singular-compose"
     singular_defaultify singular-compose -f "${TESTDIR}/singular-compose2.env" \
         --file "${TESTDIR}/singular-compose3.env" run foo1
     source "${TESTDIR}/tappoint.txt"
-    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO
-              SINGULARITYENV_JUST_IN_CONTAINER)
+    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO)
     if [ "${OS-}" = "Windows_NT" ]; then
       env_vars+=(SINGULARITYENV_JUST_HOST_WINDOWS)
     fi
+    env_vars+=(SINGULARITYENV_JUST_IN_CONTAINER)
     assert_array_values env "${env_vars[@]}"
     [ "${SINGULARITYENV_BAR}" = "12345" ]
     [ "${SINGULARITYENV_FOO}" = "BAR FAR  BOO " ]
@@ -116,11 +116,11 @@ begin_test "singular-compose"
 
     singular_defaultify singular-compose run foo3
     source "${TESTDIR}/tappoint.txt"
-    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO
-              SINGULARITYENV_JUST_IN_CONTAINER)
+    env_vars=(SINGULARITYENV_BAR SINGULARITYENV_FOO)
     if [ "${OS-}" = "Windows_NT" ]; then
       env_vars+=(SINGULARITYENV_JUST_HOST_WINDOWS)
     fi
+    env_vars+=(SINGULARITYENV_JUST_IN_CONTAINER)
     env_vars+=(SINGULARITYENV_STUFF_DIR SINGULARITYENV_STUFF_DIR_HOST SINGULARITYENV_STUFF_OK)
     assert_array_values env "${env_vars[@]}"
     [ "${SINGULARITYENV_STUFF_DIR}" = "/bar" ]

--- a/tests/test-test_utils.bsh
+++ b/tests/test-test_utils.bsh
@@ -26,12 +26,15 @@ function common_check_array_test()
   not "${1}" a1 "" &> /dev/null
   ans="${ans0}a1=()"
   ans+="${NL}Array had 1 too few values"
+  ans+="${NL}declare -a Reference=${bq}([0]=\"\")${bq}"
   ans+="${NL}Actual: declare -a a1=${bq}()${bq}"
-  [[ $("${1}" a1 "" 2>&1) = *${ans}* ]] || false
+  [[ $("${1}" a1 "" 2>&1) = *"${ans}"* ]] || false
+  echo wtf3
 
   not "${1}" a2 11 22 33 44 &> /dev/null
   ans="${ans0}a2=(11 22 33)"
   ans+=$'\nArray had 1 too few values'
+  ans+="${NL}declare -a Reference=${bq}([0]=\"11\" [1]=\"22\" [2]=\"44\")${bq}"
   ans+=$'\nActual: declare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
   [[ $("${1}" a2 11 22 33 44 2>&1) = *"${ans}"* ]] || false
   # When ans has a literal " in it, do you have to put quotes around it in [[]]
@@ -39,18 +42,21 @@ function common_check_array_test()
   not "${1}" a2 22 33 &> /dev/null
   ans="${ans0}Element 0 (a2[0]) is different:"
   ans+=$'\n11 !='"${2-} 22"
+  ans+="${NL}declare -a Reference=${bq}([0]=\"22\" [1]=\"33\")${bq}"
   ans+=$'\nActual: declare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
   [[ $("${1}" a2 22 33 2>&1) = *"${ans}"* ]] || false
 
   not "${1}" a2 11 33 &> /dev/null
   ans="${ans0}Element 1 (a2[1]) is different:"
   ans+=$'\n22 !='"${2-} 33"
+  ans+="${NL}declare -a Reference=${bq}([0]=\"11\" [1]=\"33\")${bq}"
   ans+=$'\nActual: declare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
   [[ $("${1}" a2 11 33 2>&1) = *"${ans}"* ]] || false
 
   not "${1}" a2 11 22 &> /dev/null
   ans="${ans0}a2=(11 22 33)"
   ans+=$'\nArray had 1 too many values'
+  ans+="${NL}declare -a Reference=${bq}([0]=\"11\" [1]=\"22\")${bq}"
   ans+=$'\nActual: declare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
   [[ $("${1}" a2 11 22 2>&1) = *"${ans}"* ]] || false
 
@@ -59,6 +65,7 @@ function common_check_array_test()
   not "${1}" a2 11 22
   ans="${ans0}Element 1 (a2[2]) is different:"
   ans+=$'\n33 !='"${2-} 22"
+  ans+="${NL}declare -a Reference=${bq}([0]=\"11\" [1]=\"22\")${bq}"
   ans+=$'\nActual: declare -a a2='"${bq}"'([0]="11" [2]="33")'"${bq}"
   [[ $("${1}" a2 11 22 2>&1) = *"${ans}"* ]] || false
 }
@@ -83,6 +90,7 @@ begin_test "Assert array regex values"
   not assert_array_regex_values a2 1+ '^[0-9]+$' 4 &> /dev/null
   ans="${ans0}Element 2 (a2[2]) is different:"
   ans+=$'\n33 !=~ 4'
+  ans+="${NL}declare -a Reference=${bq}([0]=\"11\" [1]=\"22\" [2]=\"4\")${bq}"
   ans+=$'\nActual: declare -a a2='"${bq}"'([0]="11" [1]="22" [2]="33")'"${bq}"
   [[ $(assert_array_regex_values a2 1+ '^[0-9]+$' 4 2>&1) = *"${ans}"* ]] || false
 )

--- a/tests/test_utils.bsh
+++ b/tests/test_utils.bsh
@@ -84,8 +84,8 @@ function assert_array_values()
     echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
     echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
     echo "Array had ${#} too few values" >&2
-      local Reference=(${assert_array_values_values[@]+"${assert_array_values_values[@]:0:assert_array_values_index}"} ${@+"${@}"})
-      declare -p Reference >&2
+    local Reference=(${assert_array_values_values[@]+"${assert_array_values_values[@]:0:assert_array_values_index}"} ${@+"${@}"})
+    declare -p Reference >&2
     echo -n "Actual: " >&2
     declare -p "${assert_array_values_name}" >&2
     set -xv

--- a/tests/test_utils.bsh
+++ b/tests/test_utils.bsh
@@ -54,7 +54,7 @@ function assert_array_values()
       echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
       echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
       echo "Array had $((${#assert_array_values_values[@]} - assert_array_values_index)) too many values" >&2
-      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" ${@+"${@}"})
+      local Reference=(${assert_array_values_values[@]+"${assert_array_values_values[@]:0:assert_array_values_index}"} ${@+"${@}"})
       declare -p Reference >&2
       echo -n "Actual: " >&2
       declare -p "${assert_array_values_name}" >&2
@@ -68,7 +68,7 @@ function assert_array_values()
       echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
       echo "Expected: Element ${assert_array_values_index} (${assert_array_values_name}[${assert_array_values_indicies[assert_array_values_index]}]) is different:" >&2
       echo "${assert_array_values_values[assert_array_values_index]} != ${1}" >&2
-      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" ${@+"${@}"})
+      local Reference=(${assert_array_values_values[@]+"${assert_array_values_values[@]:0:assert_array_values_index}"} ${@+"${@}"})
       declare -p Reference >&2
       echo -n "Actual: " >&2
       declare -p "${assert_array_values_name}" >&2
@@ -84,7 +84,7 @@ function assert_array_values()
     echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
     echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
     echo "Array had ${#} too few values" >&2
-      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" ${@+"${@}"})
+      local Reference=(${assert_array_values_values[@]+"${assert_array_values_values[@]:0:assert_array_values_index}"} ${@+"${@}"})
       declare -p Reference >&2
     echo -n "Actual: " >&2
     declare -p "${assert_array_values_name}" >&2
@@ -116,7 +116,7 @@ function assert_array_regex_values()
       echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
       echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
       echo "Array had $((${#assert_array_values_values[@]} - assert_array_values_index)) too many values" >&2
-      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" ${@+"${@}"})
+      local Reference=(${assert_array_values_values[@]+"${assert_array_values_values[@]:0:assert_array_values_index}"} ${@+"${@}"})
       declare -p Reference >&2
       echo -n "Actual: " >&2
       declare -p "${assert_array_values_name}" >&2
@@ -128,7 +128,7 @@ function assert_array_regex_values()
       echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
       echo "Expected: Element ${assert_array_values_index} (${assert_array_values_name}[${assert_array_values_indicies[assert_array_values_index]}]) is different:" >&2
       echo "${assert_array_values_values[assert_array_values_index]} !=~ ${1}" >&2
-      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" ${@+"${@}"})
+      local Reference=(${assert_array_values_values[@]+"${assert_array_values_values[@]:0:assert_array_values_index}"} ${@+"${@}"})
       declare -p Reference >&2
       echo -n "Actual: " >&2
       declare -p "${assert_array_values_name}" >&2
@@ -144,7 +144,7 @@ function assert_array_regex_values()
     echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
     echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
     echo "Array had ${#} too few values" >&2
-    local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" ${@+"${@}"})
+    local Reference=(${assert_array_values_values[@]+"${assert_array_values_values[@]:0:assert_array_values_index}"} ${@+"${@}"})
     declare -p Reference >&2
     echo -n "Actual: " >&2
     declare -p "${assert_array_values_name}" >&2

--- a/tests/test_utils.bsh
+++ b/tests/test_utils.bsh
@@ -54,7 +54,9 @@ function assert_array_values()
       echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
       echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
       echo "Array had $((${#assert_array_values_values[@]} - assert_array_values_index)) too many values" >&2
-      echo -n "Actual: "
+      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" "${@}")
+      declare -p Reference >&2
+      echo -n "Actual: " >&2
       declare -p "${assert_array_values_name}" >&2
       set -xv
       return 3
@@ -66,7 +68,9 @@ function assert_array_values()
       echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
       echo "Expected: Element ${assert_array_values_index} (${assert_array_values_name}[${assert_array_values_indicies[assert_array_values_index]}]) is different:" >&2
       echo "${assert_array_values_values[assert_array_values_index]} != ${1}" >&2
-      echo -n "Actual: "
+      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" "${@}")
+      declare -p Reference >&2
+      echo -n "Actual: " >&2
       declare -p "${assert_array_values_name}" >&2
       set -xv
       return 1
@@ -80,7 +84,9 @@ function assert_array_values()
     echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
     echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
     echo "Array had ${#} too few values" >&2
-    echo -n "Actual: "
+      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" "${@}")
+      declare -p Reference >&2
+    echo -n "Actual: " >&2
     declare -p "${assert_array_values_name}" >&2
     set -xv
     return 2
@@ -110,7 +116,9 @@ function assert_array_regex_values()
       echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
       echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
       echo "Array had $((${#assert_array_values_values[@]} - assert_array_values_index)) too many values" >&2
-      echo -n "Actual: "
+      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" "${@}")
+      declare -p Reference >&2
+      echo -n "Actual: " >&2
       declare -p "${assert_array_values_name}" >&2
       set -xv
       return 3
@@ -120,7 +128,9 @@ function assert_array_regex_values()
       echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
       echo "Expected: Element ${assert_array_values_index} (${assert_array_values_name}[${assert_array_values_indicies[assert_array_values_index]}]) is different:" >&2
       echo "${assert_array_values_values[assert_array_values_index]} !=~ ${1}" >&2
-      echo -n "Actual: "
+      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" "${@}")
+      declare -p Reference >&2
+      echo -n "Actual: " >&2
       declare -p "${assert_array_values_name}" >&2
       set -xv
       return 1
@@ -134,7 +144,9 @@ function assert_array_regex_values()
     echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
     echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
     echo "Array had ${#} too few values" >&2
-    echo -n "Actual: "
+    local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" "${@}")
+    declare -p Reference >&2
+    echo -n "Actual: " >&2
     declare -p "${assert_array_values_name}" >&2
     set -xv
     return 2

--- a/tests/test_utils.bsh
+++ b/tests/test_utils.bsh
@@ -54,7 +54,7 @@ function assert_array_values()
       echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
       echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
       echo "Array had $((${#assert_array_values_values[@]} - assert_array_values_index)) too many values" >&2
-      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" "${@}")
+      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" ${@+"${@}"})
       declare -p Reference >&2
       echo -n "Actual: " >&2
       declare -p "${assert_array_values_name}" >&2
@@ -68,7 +68,7 @@ function assert_array_values()
       echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
       echo "Expected: Element ${assert_array_values_index} (${assert_array_values_name}[${assert_array_values_indicies[assert_array_values_index]}]) is different:" >&2
       echo "${assert_array_values_values[assert_array_values_index]} != ${1}" >&2
-      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" "${@}")
+      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" ${@+"${@}"})
       declare -p Reference >&2
       echo -n "Actual: " >&2
       declare -p "${assert_array_values_name}" >&2
@@ -84,7 +84,7 @@ function assert_array_values()
     echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
     echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
     echo "Array had ${#} too few values" >&2
-      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" "${@}")
+      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" ${@+"${@}"})
       declare -p Reference >&2
     echo -n "Actual: " >&2
     declare -p "${assert_array_values_name}" >&2
@@ -116,7 +116,7 @@ function assert_array_regex_values()
       echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
       echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
       echo "Array had $((${#assert_array_values_values[@]} - assert_array_values_index)) too many values" >&2
-      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" "${@}")
+      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" ${@+"${@}"})
       declare -p Reference >&2
       echo -n "Actual: " >&2
       declare -p "${assert_array_values_name}" >&2
@@ -128,7 +128,7 @@ function assert_array_regex_values()
       echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
       echo "Expected: Element ${assert_array_values_index} (${assert_array_values_name}[${assert_array_values_indicies[assert_array_values_index]}]) is different:" >&2
       echo "${assert_array_values_values[assert_array_values_index]} !=~ ${1}" >&2
-      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" "${@}")
+      local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" ${@+"${@}"})
       declare -p Reference >&2
       echo -n "Actual: " >&2
       declare -p "${assert_array_values_name}" >&2
@@ -144,7 +144,7 @@ function assert_array_regex_values()
     echo "${ERR_C}ASSERT ERROR: Arrays differ${NC}" >&2
     echo "Expected: ${assert_array_values_name}=(${assert_array_values_values[@]+${assert_array_values_values[@]}})" >&2
     echo "Array had ${#} too few values" >&2
-    local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" "${@}")
+    local Reference=("${assert_array_values_values[@]:0:assert_array_values_index}" ${@+"${@}"})
     declare -p Reference >&2
     echo -n "Actual: " >&2
     declare -p "${assert_array_values_name}" >&2


### PR DESCRIPTION
In order to absolutely identify when you are in a container started by just, the environment variable `JUST_IN_CONTAINER` is now set. This is to distinguish between: e.g. "You are in a container due to CI" and "you are in a container started by just"

All just wrapped commands will add this environment variable, including:
- `Docker`
- `Just-docker-compose`
- `Singular-compose`
- `Singularity`

And in the future `Podman`, etc...

Other minor fixes include:

- Fixing singularity version check for apptainer, etc... 
- No longer need x-bugfix in `environment` since `JUST_IN_CONTAINER` will always be there.