### PR TITLE
tcnn_cuda_architectures 

### DIFF
--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -12,6 +12,7 @@ source "${VSI_COMMON_DIR}/linux/web_tools.bsh"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
 source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 source "${VSI_COMMON_DIR}/linux/versions.bsh"
+source "${VSI_COMMON_DIR}/linux/requirements.bsh"
 
 #*# linux/cuda_info
 
@@ -937,6 +938,42 @@ function cmake_cuda_flags()
 
   echo -n ${cmake[*]+"${cmake[*]}"}
 }
+
+#**
+# .. function:: tcnn_cuda_architectures
+#
+# :Parameters: * :var:`cuda_info.bsh CUDA_SUGGESTED_ARCHES`
+#              * :var:`cuda_info.bsh CUDA_SUGGESTED_ARCHES`
+#              * [:var:`cuda_info.bsh CUDA_SUGGESTED_PTX`]
+# :Output: *stdout* - comma delimited string of CUDA architectures for tiny-cuda-nn
+#
+# Generate CUDA architectures for tiny-cuda-nn, suitable for the ``TCNN_CUDA_ARCHITECTURES`` environment variable. Note tiny-cuda-nn will always builds both binaries and PTX intermediate code for each specified architecture.
+#
+#**
+function tcnn_cuda_architectures()
+{
+  # check CUDA version
+  if meet_requirements ${CUDA_VERSION-} '<=9.0'; then
+    echo "CUDA version ${CUDA_VERSION-} must be greater than 9.0" >&2
+    local JUST_IGNORE_EXIT_CODES=1
+    return 1
+  fi
+
+  # append suggested arches & ptx
+  local result=(
+    ${CUDA_SUGGESTED_ARCHES[@]+"${CUDA_SUGGESTED_ARCHES[@]}"}
+    ${CUDA_SUGGESTED_PTX[@]+"${CUDA_SUGGESTED_PTX[@]}"}
+  )
+
+  # unique sorted values
+  local IFS=$'\n'
+  result=($(sort -u <<< ${result[*]+"${result[*]}"}))
+
+  # output
+  IFS=','
+  echo -n ${result[*]+"${result[*]}"}
+}
+
 
 #**
 # .. function:: discover_cuda_all

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -947,7 +947,7 @@ function cmake_cuda_flags()
 #              * [:var:`cuda_info.bsh CUDA_SUGGESTED_PTX`]
 # :Output: *stdout* - comma delimited string of CUDA architectures for tiny-cuda-nn
 #
-# Generate CUDA architectures for tiny-cuda-nn, suitable for the ``TCNN_CUDA_ARCHITECTURES`` environment variable. Note tiny-cuda-nn will always builds both binaries and PTX intermediate code for each specified architecture.
+# Generate CUDA architectures for tiny-cuda-nn, suitable for the ``TCNN_CUDA_ARCHITECTURES`` environment variable. Note tiny-cuda-nn will always build both binaries and PTX intermediate code for each specified architecture.
 #
 #**
 function tcnn_cuda_architectures()

--- a/tests/test-cuda_info.bsh
+++ b/tests/test-cuda_info.bsh
@@ -276,10 +276,12 @@ begin_test "Cuda 9 test"
   assert_array_values CUDA_SUGGESTED_ARCHES 37 52 70
   assert_array_values CUDA_SUGGESTED_CODES 37 52 70
   assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0"
+  assert_str_eq "$(tcnn_cuda_architectures)" "37,52,70"
 
   # Test the future flag
   CUDA_SUGGESTED_PTX+=(${CUDA_SUGGESTED_PTX+"${CUDA_SUGGESTED_PTX[@]}"} "${CUDA_FORWARD_PTX}")
   assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0 7.0+PTX"
+  assert_str_eq "$(tcnn_cuda_architectures)" "37,52,70"
 
   if [ "${OS-}" = "Windows_NT" ]; then
     assert_str_eq "${CUDA_MINIMAL_DRIVER_VERSION}" 385.54
@@ -310,10 +312,12 @@ begin_test "Cuda 11.8 test"
   assert_array_values CUDA_SUGGESTED_ARCHES 37 52 70
   assert_array_values CUDA_SUGGESTED_CODES 37 52 70
   assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0"
+  assert_str_eq "$(tcnn_cuda_architectures)" "37,52,70"
 
   # Test the future flag
   CUDA_SUGGESTED_PTX+=(${CUDA_SUGGESTED_PTX+"${CUDA_SUGGESTED_PTX[@]}"} "${CUDA_FORWARD_PTX}")
   assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0 9.0+PTX"
+  assert_str_eq "$(tcnn_cuda_architectures)" "37,52,70,90"
 
   if [ "${OS-}" = "Windows_NT" ]; then
     assert_str_eq "${CUDA_MINIMAL_DRIVER_VERSION}" 522.06


### PR DESCRIPTION
`tcnn_cuda_architectures` to produce a comma delimited string of CUDA architectures for tiny-cuda-nn