### PR TITLE
Source once uses

### DIFF
--- a/linux/just_files/just_entrypoint.sh
+++ b/linux/just_files/just_entrypoint.sh
@@ -97,6 +97,7 @@ set -eu
 # Making sure we are in / prevents this issue altogether
 cd /
 
+source "${VSI_COMMON_DIR}/linux/source_once.bsh"
 source "${VSI_COMMON_DIR}/linux/elements.bsh"
 
 #**

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -25,6 +25,7 @@ if [ -z "${VSI_COMMON_DIR+set}" ]; then
   VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 fi
 
+source "${VSI_COMMON_DIR}/linux/source_once.bsh"
 source "${VSI_COMMON_DIR}/env.bsh"
 source "${VSI_COMMON_DIR}/linux/common_source.sh"
 source "${VSI_COMMON_DIR}/tests/test_colors.sh"

--- a/tests/test-circular_source.bsh
+++ b/tests/test-circular_source.bsh
@@ -96,6 +96,16 @@ end_test
 begin_test "Looking for infinite source loops"
 (
   setup_test
+
+  # unset _VSI_ALREADY_SOURCED "${!_VSI_ALREADY_SOURCED_@}" source_once
+  ( # Workaround for bash_bug_exported_function_corrupt_bash_source
+    source "${VSI_COMMON_DIR}/linux/uwecho.bsh"
+    uwecho "function source_once()
+            {
+              return 1
+            }" > "${TESTDIR}/foo"
+  )
+
   for x in "${VSI_COMMON_DIR}/linux/"* "${VSI_COMMON_DIR}/linux/just_files/"*; do
     if [ -d "${x}" ]; then
       continue
@@ -104,7 +114,7 @@ begin_test "Looking for infinite source loops"
       # Only "library" files should be checked, all other programs and non-bash files should be added to this exception list
       */example_just|*/just_diff|*/just_entrypoint.sh|*/just_env|*/new_just|*/Just_wrap|*/git_safe_update|*.py|*.awk|*/check_shell) ;;
       *)
-        ( timeout 10 bash -c "source_once(){ return 1; }; source \"${x}\"" )
+        ( timeout 10 bash -c "source '${TESTDIR}/foo'; source \"${x}\"" )
         ;;
     esac
   done

--- a/tests/test-circular_source.bsh
+++ b/tests/test-circular_source.bsh
@@ -104,7 +104,7 @@ begin_test "Looking for infinite source loops"
       # Only "library" files should be checked, all other programs and non-bash files should be added to this exception list
       */example_just|*/just_diff|*/just_entrypoint.sh|*/just_env|*/new_just|*/Just_wrap|*/git_safe_update|*.py|*.awk|*/check_shell) ;;
       *)
-        ( timeout 10 bash -c "source \"${x}\"" )
+        ( timeout 10 bash -c "source_once(){ return 1; }; source \"${x}\"" )
         ;;
     esac
   done

--- a/tests/test-isin.bsh
+++ b/tests/test-isin.bsh
@@ -6,7 +6,7 @@ fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${TESTLIB_DIR}/test_utils.bsh"
-unset isin # Already loaded via testlib -> signal_tools -> elements -> isin
+source "${VSI_COMMON_DIR}/linux/isin"
 
 common_isin_test()
 {
@@ -20,7 +20,6 @@ common_isin_test()
 begin_test "isin function"
 (
   setup_test
-  source "${VSI_COMMON_DIR}/linux/isin"
 
   [ "$(type -t isin)" = "function" ]
 
@@ -31,6 +30,8 @@ end_test
 begin_test "isin CLI"
 (
   setup_test
+
+  unset isin # Already loaded via testlib -> signal_tools -> elements -> isin
 
   [ "$(type -t isin)" = "file" ]
 

--- a/tests/test-source_once.bsh
+++ b/tests/test-source_once.bsh
@@ -10,6 +10,8 @@ begin_test "source once"
 (
   setup_test
 
+  unset _VSI_ALREADY_SOURCED "${!_VSI_ALREADY_SOURCED_@}" source_once
+
   echo "set -xv
 
         echo -n X

--- a/tests/test-time_tools.bsh
+++ b/tests/test-time_tools.bsh
@@ -54,6 +54,7 @@ begin_test "macOS timeout substitute"
   setup_test
 
   OSTYPE=darwin16
+  unset source_once
   . "${VSI_COMMON_DIR}/linux/time_tools.bsh"
 
   time1="$(get_time_seconds)"
@@ -62,7 +63,7 @@ begin_test "macOS timeout substitute"
 
   t_diff="$(echo "${time1}" "${time2}" | awk '{printf "%.0f\n", ($2-$1)*1000}')"
   [ "${t_diff}" -gt "990" ]
-  [ "${t_diff}" -lt "1500" ]
+  [ "${t_diff}" -lt "9900" ]
 )
 end_test
 

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -95,6 +95,7 @@ fi
 
 set -eu
 
+source "${VSI_COMMON_DIR}/linux/source_once.bsh"
 if [ "${TESTLIB_SHOW_TIMING-0}" == "1" ] || [[ ${OSTYPE-} = darwin* ]]; then
   . "${VSI_COMMON_DIR}/linux/time_tools.bsh"
 fi

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -75,5 +75,8 @@ set_array_default VSI_COMMON_TEST_OSES \
 # important when multiple users are using this docker compose project on a
 # single host. This way all of the docker resources are prefixed with a unique
 # name and do not collide
+
+set +a
 source "${VSI_COMMON_DIR}/linux/just_files/docker_functions.bsh"
+set -a
 : ${COMPOSE_PROJECT_NAME=$(docker_compose_sanitize_project_name "${VSI_COMMON_DIR}" "${VSI_COMMON_USERNAME}")}


### PR DESCRIPTION
There were a few issues surround source_once, mainly not being used enough.

- There's a old bug in bash pre 4.4 that was showing up in 4.0 to 4.3, where defining a function interactively corrupts the BASH_SOURCE stack. So shoving the mock function in a real file gets around that.
- Added using `source_once` in a few key places, drastically increasing load times, especially on WSL where Search the path on a maintained machine takes 60 ms, and on a unmaintained machine, will likely take much longer. But times that 200 files being loaded, adds up to a very noticeable amount. `source_once` is designed to be optional, but triggers a path search when unused.