### PR TITLE
nvcc_gencodes 

### DIFF
--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -977,6 +977,56 @@ function tcnn_cuda_architectures()
 
 
 #**
+# .. function:: nvcc_gencodes
+#
+# :Arguments: * ``$1`` - delimited string of cuda architectures
+# :Output: *stdout* - string containing nvcc gencode statements
+#
+# Create nvcc gencode statements from input array of cuda capabilities.
+#
+# .. rubric:: Example
+#
+# For example, an input of ``"75 86+PTX"`` would produce the output
+#
+# .. code-block:: bash
+#
+#   -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_86,code=compute_86
+#
+#**
+function nvcc_gencodes()
+{
+  # input as space delimited string
+  local input="${1//[,;]/ }"
+
+  # remove any periods from cuda architectures (e.g., 7.5->75)
+  input="${input//./}"
+
+  # input as array
+  local capabilities=( ${input} )
+
+  # generate gencode statements
+  local gencodes=()
+  local capability=""
+  local arch=""
+  local code=""
+  for capability in "${capabilities[@]}"; do
+    if [[ "${capability}" == *"+PTX" ]]; then
+      capability="${capability%+PTX}"
+      arch="compute_${capability}"
+      code="compute_${capability}"
+    else
+      arch="compute_${capability}"
+      code="sm_${capability}"
+    fi
+    gencodes+=( "-gencode=arch=${arch},code=${code}" )
+  done
+
+  # output
+  echo -n ${gencodes[*]+"${gencodes[*]}"}
+}
+
+
+#**
 # .. function:: discover_cuda_all
 #
 # Helper function to call all the discovery code in one call.

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -1002,7 +1002,7 @@ function nvcc_gencodes()
   input="${input//./}"
 
   # input as array
-  local capabilities=( ${input} )
+  local capabilities=( ${input} ) # noquotes
 
   # generate gencode statements
   local gencodes=()
@@ -1010,7 +1010,7 @@ function nvcc_gencodes()
   local arch=""
   local code=""
   for capability in "${capabilities[@]}"; do
-    if [[ "${capability}" == *"+PTX" ]]; then
+    if [[ ${capability} = *+PTX ]]; then
       capability="${capability%+PTX}"
       arch="compute_${capability}"
       code="compute_${capability}"

--- a/tests/test-cuda_info.bsh
+++ b/tests/test-cuda_info.bsh
@@ -363,6 +363,29 @@ begin_test "Cuda 11.8 test"
 )
 end_test
 
+begin_test "nvcc_gencodes"
+(
+  setup_test
+
+  gencodes="-gencode=arch=compute_30,code=sm_30 -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_53,code=compute_53"
+  assert_str_eq "$(nvcc_gencodes "3.0 3.5 5.2 5.3+PTX")" "${gencodes}"
+  assert_str_eq "$(nvcc_gencodes "30;35;52;53+PTX")" "${gencodes}"
+
+  gencodes="-gencode=arch=compute_37,code=sm_37 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_70,code=sm_70"
+  assert_str_eq "$(nvcc_gencodes "3.7 5.2 7.0")" "${gencodes}"
+  assert_str_eq "$(nvcc_gencodes "37;52;70")" "${gencodes}"
+
+  gencodes="-gencode=arch=compute_37,code=sm_37 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_70,code=compute_70"
+  assert_str_eq "$(nvcc_gencodes "3.7 5.2 7.0 7.0+PTX")" "${gencodes}"
+  assert_str_eq "$(nvcc_gencodes "37;52;70;70+PTX")" "${gencodes}"
+
+  gencodes="-gencode=arch=compute_37,code=sm_37 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_90,code=compute_90"
+  assert_str_eq "$(nvcc_gencodes "3.7 5.2 7.0 9.0+PTX")" "${gencodes}"
+  assert_str_eq "$(nvcc_gencodes "37;52;70;90+PTX")" "${gencodes}"
+
+)
+end_test
+
 if [[ ${OSTYPE} != darwin* ]]; then
  skip_next_test
 fi


### PR DESCRIPTION
`cuda_info::nvcc_gencodes` to create an nvcc gencode string from a delimited cuda capabilities string.  The intent here is to use the output of other cuda capability discovery functions (for example, `cmake_cuda_flags`) as input to this function.