### PR TITLE
cmake_cuda_architectures

### DIFF
--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -940,7 +940,6 @@ function cmake_cuda_flags()
   echo -n ${cmake[*]+"${cmake[*]}"}
 }
 
-
 #**
 # .. function:: cmake_cuda_architectures
 #
@@ -980,7 +979,6 @@ function cmake_cuda_architectures()
   echo -n ${result[*]+"${result[*]}"}
 }
 
-
 #**
 # .. function:: tcnn_cuda_architectures
 #
@@ -1015,7 +1013,6 @@ function tcnn_cuda_architectures()
   IFS=','
   echo -n ${result[*]+"${result[*]}"}
 }
-
 
 #**
 # .. function:: nvcc_gencodes
@@ -1073,7 +1070,6 @@ function nvcc_gencodes()
   # output
   echo -n ${gencodes[*]+"${gencodes[*]}"}
 }
-
 
 #**
 # .. function:: discover_cuda_all

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -1055,6 +1055,14 @@ function nvcc_gencodes()
       capability="${capability%+PTX}"
       arch="compute_${capability}"
       code="compute_${capability}"
+    elif [[ ${capability} = *-real ]]; then
+      capability="${capability%-real}"
+      arch="compute_${capability}"
+      code="sm_${capability}"
+    elif [[ ${capability} = *-virtual ]]; then
+      capability="${capability%-virtual}"
+      arch="compute_${capability}"
+      code="compute_${capability}"
     else
       arch="compute_${capability}"
       code="sm_${capability}"

--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -940,6 +940,47 @@ function cmake_cuda_flags()
   echo -n ${cmake[*]+"${cmake[*]}"}
 }
 
+
+#**
+# .. function:: cmake_cuda_architectures
+#
+# :Parameters: * :var:`cuda_info.bsh CUDA_SUGGESTED_ARCHES`
+#              * :var:`cuda_info.bsh CUDA_SUGGESTED_ARCHES`
+#              * [:var:`cuda_info.bsh CUDA_SUGGESTED_PTX`]
+# :Output: *stdout* - semi-colon delimited string of CUDA capabilities for cmake
+#
+# Generate CUDA capabilities suitable for the ``CMAKE_CUDA_ARCHITECTURES`` environment variable.
+# See cmake docs for more information https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html
+#
+#**
+function cmake_cuda_architectures()
+{
+  # check CUDA version
+  if meet_requirements ${CUDA_VERSION-} '<=9.0'; then
+    echo "CUDA version ${CUDA_VERSION-} must be greater than 9.0" >&2
+    local JUST_IGNORE_EXIT_CODES=1
+    return 1
+  fi
+
+  # cmake capabilties
+  # https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html
+  local result=()
+  local x=""
+
+  for x in ${CUDA_SUGGESTED_ARCHES[@]+"${CUDA_SUGGESTED_ARCHES[@]}"}; do
+    result+=( "${x}-real" )
+  done
+
+  for x in ${CUDA_SUGGESTED_PTX[@]+"${CUDA_SUGGESTED_PTX[@]}"}; do
+    result+=( "${x}-virtual" )
+  done
+
+  # output
+  local IFS=';'
+  echo -n ${result[*]+"${result[*]}"}
+}
+
+
 #**
 # .. function:: tcnn_cuda_architectures
 #

--- a/tests/test-cuda_info.bsh
+++ b/tests/test-cuda_info.bsh
@@ -374,18 +374,22 @@ begin_test "nvcc_gencodes"
   gencodes="-gencode=arch=compute_30,code=sm_30 -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_53,code=compute_53"
   assert_str_eq "$(nvcc_gencodes "3.0 3.5 5.2 5.3+PTX")" "${gencodes}"
   assert_str_eq "$(nvcc_gencodes "30;35;52;53+PTX")" "${gencodes}"
+  assert_str_eq "$(nvcc_gencodes "30-real;35-real;52-real;53-virtual")" "${gencodes}"
 
   gencodes="-gencode=arch=compute_37,code=sm_37 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_70,code=sm_70"
   assert_str_eq "$(nvcc_gencodes "3.7 5.2 7.0")" "${gencodes}"
   assert_str_eq "$(nvcc_gencodes "37;52;70")" "${gencodes}"
+  assert_str_eq "$(nvcc_gencodes "37-real;52-real;70-real")" "${gencodes}"
 
   gencodes="-gencode=arch=compute_37,code=sm_37 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_70,code=compute_70"
   assert_str_eq "$(nvcc_gencodes "3.7 5.2 7.0 7.0+PTX")" "${gencodes}"
   assert_str_eq "$(nvcc_gencodes "37;52;70;70+PTX")" "${gencodes}"
+  assert_str_eq "$(nvcc_gencodes "37-real;52-real;70-real;70-virtual")" "${gencodes}"
 
   gencodes="-gencode=arch=compute_37,code=sm_37 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_90,code=compute_90"
   assert_str_eq "$(nvcc_gencodes "3.7 5.2 7.0 9.0+PTX")" "${gencodes}"
   assert_str_eq "$(nvcc_gencodes "37;52;70;90+PTX")" "${gencodes}"
+  assert_str_eq "$(nvcc_gencodes "37-real;52-real;70-real;90-virtual")" "${gencodes}"
 
 )
 end_test

--- a/tests/test-cuda_info.bsh
+++ b/tests/test-cuda_info.bsh
@@ -276,11 +276,13 @@ begin_test "Cuda 9 test"
   assert_array_values CUDA_SUGGESTED_ARCHES 37 52 70
   assert_array_values CUDA_SUGGESTED_CODES 37 52 70
   assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0"
+  assert_str_eq "$(cmake_cuda_architectures)" "37-real;52-real;70-real"
   assert_str_eq "$(tcnn_cuda_architectures)" "37,52,70"
 
   # Test the future flag
   CUDA_SUGGESTED_PTX+=(${CUDA_SUGGESTED_PTX+"${CUDA_SUGGESTED_PTX[@]}"} "${CUDA_FORWARD_PTX}")
   assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0 7.0+PTX"
+  assert_str_eq "$(cmake_cuda_architectures)" "37-real;52-real;70-real;70-virtual"
   assert_str_eq "$(tcnn_cuda_architectures)" "37,52,70"
 
   if [ "${OS-}" = "Windows_NT" ]; then
@@ -346,11 +348,13 @@ begin_test "Cuda 11.8 test"
   assert_array_values CUDA_SUGGESTED_ARCHES 37 52 70
   assert_array_values CUDA_SUGGESTED_CODES 37 52 70
   assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0"
+  assert_str_eq "$(cmake_cuda_architectures)" "37-real;52-real;70-real"
   assert_str_eq "$(tcnn_cuda_architectures)" "37,52,70"
 
   # Test the future flag
   CUDA_SUGGESTED_PTX+=(${CUDA_SUGGESTED_PTX+"${CUDA_SUGGESTED_PTX[@]}"} "${CUDA_FORWARD_PTX}")
   assert_str_eq "$(cmake_cuda_flags)" "3.7 5.2 7.0 9.0+PTX"
+  assert_str_eq "$(cmake_cuda_architectures)" "37-real;52-real;70-real;90-virtual"
   assert_str_eq "$(tcnn_cuda_architectures)" "37,52,70,90"
 
   if [ "${OS-}" = "Windows_NT" ]; then


### PR DESCRIPTION
`cmake_cuda_architectures` semi-colon delimited string of CUDA capabilities suitable for `CMAKE_CUDA_ARCHITECTURES`

See here for more info on the `XX-real` and `XX_virtual` pattern
https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html
