### PR TITLE
source_once just_entrypoint

### DIFF
--- a/linux/just_files/just_entrypoint.sh
+++ b/linux/just_files/just_entrypoint.sh
@@ -97,7 +97,7 @@ set -eu
 # Making sure we are in / prevents this issue altogether
 cd /
 
-source "${VSI_COMMON_DIR}/linux/source_once.bsh"
+# source "${VSI_COMMON_DIR}/linux/source_once.bsh"
 source "${VSI_COMMON_DIR}/linux/elements.bsh"
 
 #**


### PR DESCRIPTION
remove source_once from just_entrypoint as its causing problems with the `makeself` docker.  @andyneff is working on a more permanent fix.