### PR TITLE
Fix Extra Args bug

### DIFF
--- a/linux/just_files/Just_wrap
+++ b/linux/just_files/Just_wrap
@@ -4,9 +4,9 @@ if [ -z "${VSI_COMMON_DIR+set}" ]; then
   VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
 fi
 
-if [ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -le "41" ]; then
-  declare -i extra_args
-  declare -i get_args_args_used
+if [ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -le "41" ] && ! declare -p extra_args get_args_args_used &> /dev/null; then
+  declare -i extra_args=0
+  declare -i get_args_args_used=0
 fi
 source "${VSI_COMMON_DIR}/linux/just"
 # Because sourcing just no longer loads a just project, calling just _null will

--- a/linux/just_files/Just_wrap
+++ b/linux/just_files/Just_wrap
@@ -4,6 +4,10 @@ if [ -z "${VSI_COMMON_DIR+set}" ]; then
   VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
 fi
 
+if [ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -le "41" ]; then
+  declare -i extra_args
+  declare -i get_args_args_used
+fi
 source "${VSI_COMMON_DIR}/linux/just"
 # Because sourcing just no longer loads a just project, calling just _null will
 # load a just project, but not call justify.

--- a/linux/just_files/Just_wrap
+++ b/linux/just_files/Just_wrap
@@ -4,9 +4,9 @@ if [ -z "${VSI_COMMON_DIR+set}" ]; then
   VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
 fi
 
-if [ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -le "41" ] && ! declare -p extra_args get_args_args_used &> /dev/null; then
+if [ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -le "41" ] && ! declare -p extra_args &> /dev/null; then
   declare -i extra_args=0
-  declare -i get_args_args_used=0
+  declare -i get_args_args_used
 fi
 source "${VSI_COMMON_DIR}/linux/just"
 # Because sourcing just no longer loads a just project, calling just _null will

--- a/linux/just_files/just_entrypoint.sh
+++ b/linux/just_files/just_entrypoint.sh
@@ -155,6 +155,11 @@ function load_just_settings()
   done
 }
 
+if [ "${bash_feature_declare_global}" = "1" ]; then
+  declare -i extra_args
+  declare -i get_args_args_used
+fi
+
 if [ "${ALREADY_RUN_ONCE+set}" != "set" ]; then
 
   if [ -n "${BASH_SOURCE+set}" ]; then

--- a/linux/just_files/just_entrypoint.sh
+++ b/linux/just_files/just_entrypoint.sh
@@ -158,7 +158,7 @@ PS4=$'+\x1b[0m${BASH_SOURCE[1]+}${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:$
 # set -xv
 if [ "${bash_feature_declare_global}" = "1" ]; then
   declare -i extra_args=0
-  declare -i get_args_args_used=0
+  declare -i get_args_args_used
 fi
 
 if [ "${ALREADY_RUN_ONCE+set}" != "set" ]; then

--- a/linux/just_files/just_entrypoint.sh
+++ b/linux/just_files/just_entrypoint.sh
@@ -154,10 +154,11 @@ function load_just_settings()
     source "${VSI_COMMON_DIR}/linux/just_files/just_env" "${just_settings}"
   done
 }
-
+PS4=$'+\x1b[0m${BASH_SOURCE[1]+}${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}()}\t'
+# set -xv
 if [ "${bash_feature_declare_global}" = "1" ]; then
-  declare -i extra_args
-  declare -i get_args_args_used
+  declare -i extra_args=0
+  declare -i get_args_args_used=0
 fi
 
 if [ "${ALREADY_RUN_ONCE+set}" != "set" ]; then

--- a/linux/just_files/just_functions.bsh
+++ b/linux/just_files/just_functions.bsh
@@ -1074,15 +1074,16 @@ function unknownify()
 #**
 
 if [ "${bash_feature_declare_global}" = "0" ]; then
-  declare -ig extra_args
-  declare -ig get_args_args_used
+  declare -ig extra_args=0
+  declare -ig get_args_args_used=0
 else
   # A very complicated bug will arise if another file (e.g. `just_env` or `just_functions.bsh` itself) is sourced _inside_ a function. This will result in declaring extra_args/get_args_args_used as local variables that that function, and thus losing their integer status when the function returns. The best solution is setting global, but there is no known way to set a global _and_ integer variable (with eval) in bash 4.1 and older. So just print this message.
-  if ! declare -p extra_args get_args_args_used &> /dev/null && [ "${#BASH_SOURCE[@]}" -gt "2" ] ; then
+  if [ "${#BASH_SOURCE[@]}" -gt "2" ] && ! declare -p extra_args get_args_args_used &> /dev/null; then
     echo "Warning: Your bash is too old to load just_functions from within a function." >&2
     echo "Either source ${BASH_SOURCE[0]} at the top level script or declare the following:" >&2
-    echo "  declare -i extra_args" >&2
-    echo "  declare -i get_args_args_used" >&2
+    echo "  declare -i extra_args=0" >&2
+    echo "  declare -i get_args_args_used=0" >&2
+    set +xv
     false
   fi
   declare -i extra_args

--- a/linux/just_files/just_functions.bsh
+++ b/linux/just_files/just_functions.bsh
@@ -1073,7 +1073,21 @@ function unknownify()
 # In this case, there is no need to add :var:`extra_args`, :func:`get_args` does this already
 #**
 
-declare -i extra_args
+if [ "${bash_feature_declare_global}" = "0" ]; then
+  declare -ig extra_args
+  declare -ig get_args_args_used
+else
+  # A very complicated bug will arise if another file (e.g. `just_env` or `just_functions.bsh` itself) is sourced _inside_ a function. This will result in declaring extra_args/get_args_args_used as local variables that that function, and thus losing their integer status when the function returns. The best solution is setting global, but there is no known way to set a global _and_ integer variable (with eval) in bash 4.1 and older. So just print this message.
+  if ! declare -p extra_args get_args_args_used &> /dev/null && [ "${#BASH_SOURCE[@]}" -gt "2" ] ; then
+    echo "Warning: Your bash is too old to load just_functions from within a function." >&2
+    echo "Either source ${BASH_SOURCE[0]} at the top level script or declare the following:" >&2
+    echo "  declare -i extra_args" >&2
+    echo "  declare -i get_args_args_used" >&2
+    false
+  fi
+  declare -i extra_args
+  declare -i get_args_args_used
+fi
 
 #**
 # .. function:: justify
@@ -1238,7 +1252,6 @@ function callify()
 #   behavior
 #**
 
-declare -i get_args_args_used
 function get_args()
 {
   local next_break

--- a/linux/just_files/just_functions.bsh
+++ b/linux/just_files/just_functions.bsh
@@ -1075,14 +1075,14 @@ function unknownify()
 
 if [ "${bash_feature_declare_global}" = "0" ]; then
   declare -ig extra_args=0
-  declare -ig get_args_args_used=0
+  declare -ig get_args_args_used
 else
   # A very complicated bug will arise if another file (e.g. `just_env` or `just_functions.bsh` itself) is sourced _inside_ a function. This will result in declaring extra_args/get_args_args_used as local variables that that function, and thus losing their integer status when the function returns. The best solution is setting global, but there is no known way to set a global _and_ integer variable (with eval) in bash 4.1 and older. So just print this message.
-  if [ "${#BASH_SOURCE[@]}" -gt "2" ] && ! declare -p extra_args get_args_args_used &> /dev/null; then
+  if [ "${#BASH_SOURCE[@]}" -gt "2" ] && ! declare -p extra_args &> /dev/null; then
     echo "Warning: Your bash is too old to load just_functions from within a function." >&2
     echo "Either source ${BASH_SOURCE[0]} at the top level script or declare the following:" >&2
     echo "  declare -i extra_args=0" >&2
-    echo "  declare -i get_args_args_used=0" >&2
+    echo "  declare -i get_args_args_used" >&2
     set +xv
     false
   fi

--- a/tests/test-new_just.bsh
+++ b/tests/test-new_just.bsh
@@ -116,8 +116,10 @@ begin_test "new_just write no_docker_version"
   [ "$(sed -n '/^#include/p;q' hi.cpp)" ]
   #Justfile
   (
-    declare -i extra_args=0
-    declare -i get_args_args_used
+    if [ "${bash_feature_declare_global}" = "1" ] && ! declare -p extra_args &> /dev/null; then
+      declare -i extra_args=0
+      declare -i get_args_args_used
+    fi
     . Justfile
     uwecho '#!/usr/bin/env bash
             echo foo "${@}"' > g++
@@ -184,8 +186,10 @@ begin_test "new_just write docker_pipenv_version"
       echo "user-name"
     }
 
-    declare -i extra_args=0
-    declare -i get_args_args_used
+    if [ "${bash_feature_declare_global}" = "1" ] && ! declare -p extra_args &> /dev/null; then
+      declare -i extra_args=0
+      declare -i get_args_args_used
+    fi
 
     . Justfile
     ans="docker buildx bake gosu pipenv tini vsi

--- a/tests/test-new_just.bsh
+++ b/tests/test-new_just.bsh
@@ -116,6 +116,8 @@ begin_test "new_just write no_docker_version"
   [ "$(sed -n '/^#include/p;q' hi.cpp)" ]
   #Justfile
   (
+    declare -i extra_args=0
+    declare -i get_args_args_used
     . Justfile
     uwecho '#!/usr/bin/env bash
             echo foo "${@}"' > g++
@@ -181,6 +183,9 @@ begin_test "new_just write docker_pipenv_version"
     { # Make id so the username has a character that would be sanitized out.
       echo "user-name"
     }
+
+    declare -i extra_args=0
+    declare -i get_args_args_used
 
     . Justfile
     ans="docker buildx bake gosu pipenv tini vsi

--- a/tests/test-singularity_functions.bsh
+++ b/tests/test-singularity_functions.bsh
@@ -57,13 +57,30 @@ begin_test "Singularity environment pass"
 (
   setup_test
 
+  singularity_version_info()
+  {
+    singularity_vendor=apptainer
+  }
+
+  # Empty
+  (
+    singularity_env_pass foo ""
+    [ "${APPTAINERENV_foo}" = "" ]
+    singularity_env_pass BAR " s  tuf f "
+    [ "${APPTAINERENV_BAR}" = " s  tuf f " ]
+  )
+
+
+  singularity_version_info()
+  {
+    singularity_vendor=singularity
+  }
+
   # Empty
   singularity_env_pass foo ""
   [ "${SINGULARITYENV_foo}" = "" ]
-
   singularity_env_pass BAR " s  tuf f "
   [ "${SINGULARITYENV_BAR}" = " s  tuf f " ]
-
 )
 end_test
 


### PR DESCRIPTION
TL;DR Now `extra_args` is properly set as a global variable in `just_entrypoint.sh`

---

We don't declare variables at the top level of a source able script very often (`colors.bsh` was the only other instance I saw), but in the case of `just_functions.bsh`, `extra_args` (et. al.) are declared as global variables, which is usually not a problem, but if this file is sourced inside a function (again, uncommon), then the variables that defined as integers, will be unset and lose their integer status.

Unfortunately once `source_once` was implemented correctly, `just_functions.bsh` was no longer being sourced multiple times covering up this mistake, and as soon as an internal just target uses `+=`, this problem finally manifests itself into a failure.

There are a few solutions considered:

1. Pre-`source` `just_functions.bsh` in `just_entrypoint.sh`, but this only fixes this one use, and potentially another script down the road could run into the same issue.
2. Pre `decalre` `extra_args` et. al., but this has the same problem as 1
3. Make it global, but that only works on bash 4.2 or newer
4. Just error on bash 4.1 or older, but this would have severe consequences on macos, and it works most of the time, so there's no reason to go that drastic

So I went with a combination of option 3 and detecting when the stack depth is greater than 2 and `extra_args` is not defined, and just printing a warning instead.