### PR TITLE
torch_cuda_arch_list_from_cmake & tcnn_cuda_architectures_from_cmake

### DIFF
--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -1032,6 +1032,47 @@ function torch_cuda_arch_list()
 }
 
 #**
+# .. function:: torch_cuda_arch_list_from_cmake
+#
+# :Arguments: * ``$1`` - delimited string of cuda architectures
+# :Output: *stdout* - string containing ``TORCH_CUDA_ARCH_LIST`` statement
+#
+# Create ``TORCH_CUDA_ARCH_LIST`` from ``CMAKE_CUDA_ARCHITECTURES`` statement.
+#
+# .. rubric:: Example
+#
+# For example, an input of ``"80-real 86-virtual"`` would produce the output ``"8.0 8.6+PTX"``
+#**
+function torch_cuda_arch_list_from_cmake()
+{
+  # input as space delimited string
+  local input="${1//[,;]/ }"
+
+  # generate TORCH_CUDA_ARCH_LIST statements
+  local x=""
+  local capability=""
+  local result=()
+  for x in ${input}; do
+
+    # X.Y capability
+    capability="${x//[!0-9]/}"
+    capability="${capability::1}.${capability:1}"
+
+    # append PTX
+    if [[ ${x} = *+PTX ]]; then
+      capability+="+PTX"
+    elif [[ ${x} = *-virtual ]]; then
+      capability+="+PTX"
+    fi
+
+    result+=( "${capability}" )
+  done
+
+  # output
+  echo -n ${result[*]+"${result[*]}"}
+}
+
+#**
 # .. function:: tcnn_cuda_architectures
 #
 # :Parameters: * :var:`cuda_info.bsh CUDA_SUGGESTED_ARCHES`
@@ -1062,6 +1103,39 @@ function tcnn_cuda_architectures()
 
   # output
   IFS=','
+  echo -n ${result[*]+"${result[*]}"}
+}
+
+#**
+# .. function:: tcnn_cuda_architectures_from_cmake
+#
+# :Arguments: * ``$1`` - delimited string of cuda architectures
+# :Output: *stdout* - string containing ``TCNN_CUDA_ARCHITECTURES`` statement
+#
+# Create ``TCNN_CUDA_ARCHITECTURES`` from ``CMAKE_CUDA_ARCHITECTURES`` statement.
+#
+# .. rubric:: Example
+#
+# For example, an input of ``"80-real 86-virtual"`` would produce the output ``"80 86"``
+#**
+function tcnn_cuda_architectures_from_cmake()
+{
+  # input as space delimited string
+  local input="${1//[,;]/ }"
+
+  # generate TCNN_CUDA_ARCHITECTURES statements
+  local x=""
+  local result=()
+  for x in ${input}; do
+    result+=( "${x//[!0-9]/}" )
+  done
+
+  # unique sorted values
+  local IFS=$'\n'
+  result=($(sort -u <<< ${result[*]+"${result[*]}"}))
+
+  # output
+  IFS=' '
   echo -n ${result[*]+"${result[*]}"}
 }
 

--- a/tests/test-cuda_info.bsh
+++ b/tests/test-cuda_info.bsh
@@ -371,6 +371,60 @@ begin_test "Cuda 11.8 test"
 )
 end_test
 
+begin_test "tcnn_cuda_architectures_from_cmake"
+(
+  setup_test
+
+  result="30 35 52 53"
+  assert_str_eq "$(tcnn_cuda_architectures_from_cmake "3.0 3.5 5.2 5.3+PTX")" "${result}"
+  assert_str_eq "$(tcnn_cuda_architectures_from_cmake "30;35;52;53+PTX")" "${result}"
+  assert_str_eq "$(tcnn_cuda_architectures_from_cmake "30-real;35-real;52-real;53-virtual")" "${result}"
+
+  result="37 52 70"
+  assert_str_eq "$(tcnn_cuda_architectures_from_cmake "3.7 5.2 7.0")" "${result}"
+  assert_str_eq "$(tcnn_cuda_architectures_from_cmake "37;52;70")" "${result}"
+  assert_str_eq "$(tcnn_cuda_architectures_from_cmake "37-real;52-real;70-real")" "${result}"
+
+  result="37 52 70"
+  assert_str_eq "$(tcnn_cuda_architectures_from_cmake "3.7 5.2 7.0 7.0+PTX")" "${result}"
+  assert_str_eq "$(tcnn_cuda_architectures_from_cmake "37;52;70;70+PTX")" "${result}"
+  assert_str_eq "$(tcnn_cuda_architectures_from_cmake "37-real;52-real;70-real;70-virtual")" "${result}"
+
+  result="37 52 70 90"
+  assert_str_eq "$(tcnn_cuda_architectures_from_cmake "3.7 5.2 7.0 9.0+PTX")" "${result}"
+  assert_str_eq "$(tcnn_cuda_architectures_from_cmake "37;52;70;90+PTX")" "${result}"
+  assert_str_eq "$(tcnn_cuda_architectures_from_cmake "37-real;52-real;70-real;90-virtual")" "${result}"
+
+)
+end_test
+
+begin_test "torch_cuda_arch_list_from_cmake"
+(
+  setup_test
+
+  result="3.0 3.5 5.2 5.3+PTX"
+  assert_str_eq "$(torch_cuda_arch_list_from_cmake "3.0 3.5 5.2 5.3+PTX")" "${result}"
+  assert_str_eq "$(torch_cuda_arch_list_from_cmake "30;35;52;53+PTX")" "${result}"
+  assert_str_eq "$(torch_cuda_arch_list_from_cmake "30-real;35-real;52-real;53-virtual")" "${result}"
+
+  result="3.7 5.2 7.0"
+  assert_str_eq "$(torch_cuda_arch_list_from_cmake "3.7 5.2 7.0")" "${result}"
+  assert_str_eq "$(torch_cuda_arch_list_from_cmake "37;52;70")" "${result}"
+  assert_str_eq "$(torch_cuda_arch_list_from_cmake "37-real;52-real;70-real")" "${result}"
+
+  result="3.7 5.2 7.0 7.0+PTX"
+  assert_str_eq "$(torch_cuda_arch_list_from_cmake "3.7 5.2 7.0 7.0+PTX")" "${result}"
+  assert_str_eq "$(torch_cuda_arch_list_from_cmake "37;52;70;70+PTX")" "${result}"
+  assert_str_eq "$(torch_cuda_arch_list_from_cmake "37-real;52-real;70-real;70-virtual")" "${result}"
+
+  result="3.7 5.2 7.0 9.0+PTX"
+  assert_str_eq "$(torch_cuda_arch_list_from_cmake "3.7 5.2 7.0 9.0+PTX")" "${result}"
+  assert_str_eq "$(torch_cuda_arch_list_from_cmake "37;52;70;90+PTX")" "${result}"
+  assert_str_eq "$(torch_cuda_arch_list_from_cmake "37-real;52-real;70-real;90-virtual")" "${result}"
+
+)
+end_test
+
 begin_test "nvcc_gencodes"
 (
   setup_test


### PR DESCRIPTION
cuda_info utilities to transform a `CMAKE_CUDA_ARCHITECTURES` statement into a `TORCH_CUDA_ARCH_LIST` or `TCNN_CUDA_ARCHITECTURES` statement.  

This allows projects to derive all application specific cuda architecture statements from a common source, which could be defined either by the user or  `cmake_cuda_architectures`.

For example:

```
if [ -z "${FOO_CMAKE_CUDA_ARCHITECTURES+set}" ]; then
  CUDA_VERSION="${FOO_CUDA_VERSION}" discover_cuda_all
  FOO_CMAKE_CUDA_ARCHITECTURES="$(cmake_cuda_architectures)"
fi
: ${FOO_TORCH_CUDA_ARCH_LIST="$(torch_cuda_arch_list_from_cmake "${FOO_CMAKE_CUDA_ARCHITECTURES}")"}
: ${FOO_TCNN_CUDA_ARCHITECTURES="$(tcnn_cuda_architectures_from_cmake "${FOO_CMAKE_CUDA_ARCHITECTURES}")"}
```