### PR TITLE
tcnn_cuda_architectures_from_cmake delimiter

### DIFF
--- a/linux/cuda_info.bsh
+++ b/linux/cuda_info.bsh
@@ -1135,7 +1135,7 @@ function tcnn_cuda_architectures_from_cmake()
   result=($(sort -u <<< ${result[*]+"${result[*]}"}))
 
   # output
-  IFS=' '
+  IFS=','
   echo -n ${result[*]+"${result[*]}"}
 }
 

--- a/tests/test-cuda_info.bsh
+++ b/tests/test-cuda_info.bsh
@@ -375,22 +375,22 @@ begin_test "tcnn_cuda_architectures_from_cmake"
 (
   setup_test
 
-  result="30 35 52 53"
+  result="30,35,52,53"
   assert_str_eq "$(tcnn_cuda_architectures_from_cmake "3.0 3.5 5.2 5.3+PTX")" "${result}"
   assert_str_eq "$(tcnn_cuda_architectures_from_cmake "30;35;52;53+PTX")" "${result}"
   assert_str_eq "$(tcnn_cuda_architectures_from_cmake "30-real;35-real;52-real;53-virtual")" "${result}"
 
-  result="37 52 70"
+  result="37,52,70"
   assert_str_eq "$(tcnn_cuda_architectures_from_cmake "3.7 5.2 7.0")" "${result}"
   assert_str_eq "$(tcnn_cuda_architectures_from_cmake "37;52;70")" "${result}"
   assert_str_eq "$(tcnn_cuda_architectures_from_cmake "37-real;52-real;70-real")" "${result}"
 
-  result="37 52 70"
+  result="37,52,70"
   assert_str_eq "$(tcnn_cuda_architectures_from_cmake "3.7 5.2 7.0 7.0+PTX")" "${result}"
   assert_str_eq "$(tcnn_cuda_architectures_from_cmake "37;52;70;70+PTX")" "${result}"
   assert_str_eq "$(tcnn_cuda_architectures_from_cmake "37-real;52-real;70-real;70-virtual")" "${result}"
 
-  result="37 52 70 90"
+  result="37,52,70,90"
   assert_str_eq "$(tcnn_cuda_architectures_from_cmake "3.7 5.2 7.0 9.0+PTX")" "${result}"
   assert_str_eq "$(tcnn_cuda_architectures_from_cmake "37;52;70;90+PTX")" "${result}"
   assert_str_eq "$(tcnn_cuda_architectures_from_cmake "37-real;52-real;70-real;90-virtual")" "${result}"


### PR DESCRIPTION
`TCNN_CUDA_ARCHITECTURES` expects a comma delimiter.

https://github.com/NVlabs/tiny-cuda-nn/blob/212104156403bd87616c1a4f73a1c5f2c2e172a9/bindings/torch/setup.py#L43-L45
```
if "TCNN_CUDA_ARCHITECTURES" in os.environ and os.environ["TCNN_CUDA_ARCHITECTURES"]:
	compute_capabilities = [int(x) for x in os.environ["TCNN_CUDA_ARCHITECTURES"].replace(";", ",").split(",")]
	print(f"Obtained compute capabilities {compute_capabilities} from environment variable TCNN_CUDA_ARCHITECTURES")
```