### PR TITLE
Update env.bsh

### DIFF
--- a/env.bsh
+++ b/env.bsh
@@ -14,7 +14,7 @@ if [ "${BASH_VERSION+set}" = "set" ]; then
   function unsetup_vsi_common()
   {
     export PATH="${PRE_VSI_COMMON_PATH}"
-    complete -r just
+    complete -r just &> /dev/null
     unset unsetup_vsi_common
   }
 


### PR DESCRIPTION
- Prevent "bash: complete: just: no completion specification" message if just tab complete has already been disabled