### PR TITLE
SAST

### DIFF
--- a/linux/ci_load.py
+++ b/linux/ci_load.py
@@ -45,7 +45,7 @@ class CiLoad:
                 stdout=PIPE)
     output = pid.communicate()[0]
 
-    self.compose_yaml = yaml.load(output, Loader=yaml.Loader)
+    self.compose_yaml = yaml.safe_load(output)
     self.compose_version = self.compose_yaml.get('version', None)
 
     # Get dockerfile name
@@ -149,8 +149,7 @@ class CiLoad:
     self.restore_recipe_file = tempfile.NamedTemporaryFile(mode='w')
 
     doc = {}
-    compose_yaml = yaml.load(open(self.recipe_compose, 'r').read(),
-                             Loader=yaml.Loader)
+    compose_yaml = yaml.safe_load(open(self.recipe_compose, 'r').read())
     doc['version'] = compose_yaml['version']
 
     services = {}
@@ -239,8 +238,7 @@ class CiLoad:
 
   # 7 build
   def build_stages(self):
-    yaml_content = yaml.load(open(self.add_stages_file.name, 'r').read(),
-                             Loader=yaml.Loader)
+    yaml_content = yaml.safe_load(open(self.add_stages_file.name, 'r').read())
     main_image = self.compose_yaml['services'][self.main_service].get('image')
 
     if self.print_build:

--- a/python/vsi/tools/vdb_rpdb2.py
+++ b/python/vsi/tools/vdb_rpdb2.py
@@ -149,7 +149,6 @@ def attach(pid, ip='127.0.0.1', password='vsi', gui=False, break_exit=False):
 
   #attach must come last for some STUPID reason. Dumb parser
   sys.argv = ['', '--pwd=%s' % password, '--host=%s' % ip, '--attach', str(pid)]
-  print(sys.argv)
   if gui:
     import winpdb
     winpdb.main()

--- a/python/vsi/yarp.py
+++ b/python/vsi/yarp.py
@@ -29,4 +29,4 @@ def yarp(doc, prefix=''):
   return lines
 
 if __name__ == "__main__":
-  print('\n'.join(yarp(yaml.load(sys.stdin, Loader=yaml.Loader))))
+  print('\n'.join(yarp(yaml.safe_load(sys.stdin))))


### PR DESCRIPTION
Minor SAST changes

`yaml.load` -> `yaml.safe_load`
https://security.openstack.org/guidelines/dg_avoid-dangerous-input-parsing-libraries.html

remove print statement in `python/vsi/tools/vdb_rpdb2.py`