### PR TITLE
wget tool: TLS v1 -> v1.2

### DIFF
--- a/python/vsi/tools/network/wget.py
+++ b/python/vsi/tools/network/wget.py
@@ -61,7 +61,7 @@ def download(url, filename=None, chunk_size=2**20, cookie={}, disable_ssl_verify
   context=None
   if disable_ssl_verify and url.startswith('https://'):
     import ssl
-    context = ssl.SSLContext(ssl.PROTOCOL_TLSv1) #disable cert checking
+    context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2) #disable cert checking
 
   try:
     response = urllib2.urlopen(request, context=context)


### PR DESCRIPTION
Upgrade the TLS protocol used in the wget python tool to avoid a security vulnerability.