### PR TITLE
Buildx invoke on docker-compose

### DIFF
--- a/linux/just_files/just_docker_functions.bsh
+++ b/linux/just_files/just_docker_functions.bsh
@@ -530,9 +530,9 @@ function docker_defaultify()
 
     docker-compose_debug) # Run docker buildx debug build against a \
         # docker-compose service. $1 - service name (required) $2 - docker context, defaults to "."
-      # These are not a perfect parse? Won't handle yaml strings that aren't the same syntax as bash strings
+      # This is not a perfect parser. Won't handle yaml strings that aren't the same syntax as bash strings
       local compose_config=$(docker-compose config | yarp)
-      # This shouldn't be blank, as if it's absent in the compose file, docker-compose will report "Dockerfile" still
+      # This shouldn't be blank, because docker-compose will report "Dockerfile" even if it's absent in the compose file```
       local dockerfile=$(sed -nE 's|^services\.'"$1"'\.build\.dockerfile = "?(.*[^"])"?|\1|p' <<< "${compose_config}")
       if [ -z "${dockerfile}" ]; then
         echo "Dockerfile is empty, either you forgot to specify a service name or specified the wrong service" >&2

--- a/linux/just_files/just_docker_functions.bsh
+++ b/linux/just_files/just_docker_functions.bsh
@@ -535,7 +535,7 @@ function docker_defaultify()
       # This shouldn't be blank, as if it's absent in the compose file, docker-compose will report "Dockerfile" still
       local dockerfile=$(sed -nE 's|^services\.'"$1"'\.build\.dockerfile = "?(.*[^"])"?|\1|p' <<< "${compose_config}")
       if [ -z "${dockerfile}" ]; then
-        echo "Dockerfile is empty, either you forgot to or specified the wrong service name" >&2
+        echo "Dockerfile is empty, either you forgot to specify a service name or specified the wrong service" >&2
         JUST_IGNORE_EXIT_CODES=1
         return 1
       fi

--- a/linux/just_files/just_docker_functions.bsh
+++ b/linux/just_files/just_docker_functions.bsh
@@ -340,6 +340,17 @@ function get_docker_recipes()
 #
 # In the case of the ``delete`` strategy, an optional label, ``com.vsi.just.clean_setup``, can be specified to designate what just target to run to repopulate a volume. Typically this just target should run ``sh -c ":"`` or similar. This allows the entrypoint or another command to properly setup the volume, and set permissions, etc...
 #
+# .. command:: docker-compose_debug
+#
+# :Arguments: ``$1`` - service name to build.
+#             [``$2``] - Stages to disable caching on. See [here](https://docs.docker.com/reference/cli/docker/buildx/build/#no-cache-filter) for the syntax
+#
+# This will use information from ``docker-compose config`` to craft a ``docker buildx debug build`` command with the invoke command to help debug a failing build. As this is an experimental command, support is fairly limited:
+#
+# * Always uses /usr/bin/bash
+# * Requires docker buildx 0.12
+# * Any complicated build args (spaces and special characters) will likely fail
+# * Uses ``.`` as the build context
 #**
 function docker_defaultify()
 {
@@ -515,6 +526,39 @@ function docker_defaultify()
       trap - INT
       trap - TERM
       extra_args=${#}
+      ;;
+
+    docker-compose_debug) # Run docker buildx debug build against a \
+        # docker-compose service. $1 - service name (required) $2 - docker context, defaults to "."
+      # These are not a perfect parse? Won't handle yaml strings that aren't the same syntax as bash strings
+      local compose_config=$(docker-compose config | yarp)
+      # This shouldn't be blank, as if it's absent in the compose file, docker-compose will report "Dockerfile" still
+      local dockerfile=$(sed -nE 's|^services\.'"$1"'\.build\.dockerfile = "?(.*[^"])"?|\1|p' <<< "${compose_config}")
+      if [ -z "${dockerfile}" ]; then
+        echo "Dockerfile is empty, either you forgot to or specified the wrong service name" >&2
+        JUST_IGNORE_EXIT_CODES=1
+        return 1
+      fi
+      # This won't even handle spaces
+      local build_args=($(sed -nE 's|^services\.'"$1"'\.build\.args\.([^ ]*) = "?(.*[^"])"?|--build-arg \1=\2|p' <<< "${compose_config}"))
+
+      if [ -n "${2+set}" ]; then
+        if [ "${2}" = "*" ]; then
+          build_args+=(--no-cache)
+        else
+          build_args+=(--no-cache-filter "${2}")
+        fi
+      fi
+
+      # Requires buildx 0.12 or ?newer? (syntax may change, as this is an experimental feature)
+      # In 0.11 it was docker buildx build --invoke ...\ but I will not be supporting
+      # multiple experimental versions.
+      BUILDX_EXPERIMENTAL=1 Docker buildx debug --invoke /usr/bin/bash \
+        build ${build_args[@]+"${build_args[@]}"} \
+        -f "${dockerfile}" \
+        "." # You can't use JUST_PROJECT_PREFIX+_CWD because of how terra works.
+
+      extra_args=1
       ;;
 
     docker) # Run generic docker command

--- a/linux/just_files/just_docker_functions.bsh
+++ b/linux/just_files/just_docker_functions.bsh
@@ -532,7 +532,7 @@ function docker_defaultify()
         # docker-compose service. $1 - service name (required) $2 - docker context, defaults to "."
       # This is not a perfect parser. Won't handle yaml strings that aren't the same syntax as bash strings
       local compose_config=$(docker-compose config | yarp)
-      # This shouldn't be blank, because docker-compose will report "Dockerfile" even if it's absent in the compose file```
+      # This shouldn't be blank because docker-compose will report "Dockerfile" even if it's absent in the compose file```
       local dockerfile=$(sed -nE 's|^services\.'"$1"'\.build\.dockerfile = "?(.*[^"])"?|\1|p' <<< "${compose_config}")
       if [ -z "${dockerfile}" ]; then
         echo "Dockerfile is empty, either you forgot to specify a service name or specified the wrong service" >&2


### PR DESCRIPTION
This is a first attempt to get the new invoke debug command to run against a docker-compose project.

This is currently not a feature of docker compose, so we have to roll our own wrapper for this. Think of this as a 60% solution against an experimental API that is likely to change again.

Hopefully this is good enough to work most of the time when we need something like this. Example:

```
just build # fails
```

Now we want to easily debug the issue, without a bunch of commenting out Dockerfile, which stages are being built, etc...

```
just docker-compose debug my_service_name
```

And if we are running against an intermittent issue and want to clear the cache for that stage specifically:

```
just docker-compose debug runner dep_common
```