### PR TITLE
Add arguments with value to parse-generic

### DIFF
--- a/linux/command_tools.bsh
+++ b/linux/command_tools.bsh
@@ -92,6 +92,7 @@ function get_array_from_environment()
 # .. function:: parse-generic
 #
 # :Arguments: ``$1``.. - Arguments to be sent to some command
+# :Parameters: [``arguments_with_value``] - An array of command arguments that must take one argument
 # :Output: * command_args - Arguments to some command, before the subcommand (run, build, do_something, etc...)
 #          * subcommand - The subcommand specified
 #          * subcommand_args - Arguments for the specified subcommand
@@ -116,7 +117,17 @@ function parse-generic()
   while (( ${#} )); do
     case "${1}" in
       -*)
-      # Everything takes zero arguments, so no need to enumerate -d --debug -h --help --nocolor -q --quiet -s --silent -v --verbose --version
+        # Anything that takes one arguments from the array arguments_with_value
+        for arg in ${arguments_with_value[@]+"${arguments_with_value[@]}"}; do
+          # No need to check "${arg}=", that will be handled as taking "zero argument" below
+          if [ "${1}" = "${arg}" ]; then
+            command_args+=("${1}" "${2}")
+            shift 2
+            # Break out of the case
+            continue 2
+          fi
+        done
+        # Everything takes zero arguments, so no need to enumerate examples like: -d --debug -h --help
         command_args+=("${1}")
         shift 1
         ;;

--- a/tests/test-command_tools.bsh
+++ b/tests/test-command_tools.bsh
@@ -118,6 +118,8 @@ begin_test "Generic command argument parse"
   [ -z "${subcommand+set}" ]
   unset command_args subcommand_args subcommand
 
+  arguments_with_value=(-a --append)
+
   # Command and command_args
   parse-generic do -something else
   assert_array_values command_args
@@ -128,6 +130,31 @@ begin_test "Generic command argument parse"
   # A little of everything
   parse-generic -try --to do -something else
   assert_array_values command_args -try --to
+  assert_array_values subcommand_args -something else
+  [ "${subcommand}" = "do" ]
+  unset command_args subcommand_args subcommand
+
+  # Add args with a value into the mix
+  parse-generic -a ok do -a "not ok"
+  assert_array_values command_args -a ok
+  assert_array_values subcommand_args -a "not ok"
+  [ "${subcommand}" = "do" ]
+  unset command_args subcommand_args subcommand
+
+  parse-generic -try --to -a do -something else
+  assert_array_values command_args -try --to -a do -something
+  assert_array_values subcommand_args
+  [ "${subcommand}" = "else" ]
+  unset command_args subcommand_args subcommand
+
+  parse-generic -try --to -a= do -something else
+  assert_array_values command_args -try --to -a=
+  assert_array_values subcommand_args -something else
+  [ "${subcommand}" = "do" ]
+  unset command_args subcommand_args subcommand
+
+  parse-generic -try --to --append stuff do -something else
+  assert_array_values command_args -try --to --append stuff
   assert_array_values subcommand_args -something else
   [ "${subcommand}" = "do" ]
   unset command_args subcommand_args subcommand


### PR DESCRIPTION
A simple addition to `parse-generic` to support arguments that require one argument.

This is still far less strict than previous implementations like the docker compose parse which strictly only allows arguments that are defined in the code, but it opens up the use cases that `generic-parser` can work with by adding very little lift for the dev.