### PR TITLE
Replace hacky patch with 'wheel pack'

### DIFF
--- a/python/vsi/tools/patch_wheel.py
+++ b/python/vsi/tools/patch_wheel.py
@@ -7,14 +7,16 @@ import tempfile
 import subprocess
 import re
 from wheel.wheelfile import WHEEL_INFO_RE
+from wheel.cli.pack import DIST_INFO_RE
+from wheel.cli import WheelError
 
 def get_parser():
   parser = argparse.ArgumentParser(
     description="Patch a wheel to change the package name or version in the "
                 "wheel metatdata. Note: This will also change any filenames or "
                 "versions in the rest of the file namess (e.g. dist-info "
-                "directory name) but will not change versions strings "
-                "hardcoded in .py files")
+                "directory name) but will not change hardcoded strings "
+                "like __version__ in .py files")
   parser.add_argument('filename', help="Wheel (.whl) file")
   parser.add_argument('--name', help="The package name")
   group = parser.add_mutually_exclusive_group()
@@ -29,61 +31,89 @@ def main(filename, name=None, version=None):
   filename = Path(filename)
 
   parsed_name = WHEEL_INFO_RE.match(filename.name)
-  original_name, original_version = parsed_name.group('name', 'ver')
-
-  # These values will be replaced
-  patch = {}
-  if name is not None:
-    patch['Name'] = f'Name: {name}\n'
-  else:
-    name = original_name
-  if version is not None:
-    patch['Version'] = f'Version: {version}\n'
-  else:
-    version = original_version
-
-  # https://peps.python.org/pep-0491/#escaping-and-unicode
-  normalized_name = re.sub(r"[^\w\d.]+", "_", name).lower()
-  normalized_version = re.sub(r"[^\w\d.+]+", "_", version).lower()
-
-  if name == original_name and version == original_version:
-    raise Exception('No change detected. Package name and version are '
-                    'identical')
 
   with tempfile.TemporaryDirectory() as temp_extract:
     # Extract Wheel
-    subprocess.Popen(['wheel', 'unpack', '--dest', temp_extract,
-                      filename]).wait()
+    (pid := subprocess.Popen(['wheel', 'unpack', '--dest', temp_extract,
+                      filename])).wait()
+
+    if pid.returncode != 0:
+      raise RuntimeError('Wheel unpack failed. Is the wheel is bad?')
+
+    # Find the .dist-info directory
+    dist_info_dirs = [
+      fn
+      for fn in Path(temp_extract).glob('*/*.dist-info/')
+      if os.path.isdir(os.path.join(temp_extract, fn)) and DIST_INFO_RE.match(str(fn))
+    ]
+    if len(dist_info_dirs) > 1:
+      raise WheelError(f"Multiple .dist-info's found in {temp_extract}")
+    elif not dist_info_dirs:
+      raise WheelError(f"No .dist-info's found in {temp_extract}")
+    metadata = (Path(dist_info_dirs[0]) / 'METADATA')
+
+    with open(metadata, 'r') as fid:
+      meta_lines = fid.readlines()
+
+    original_name = next(line_split[1].strip() for line in meta_lines if (line_split := line.split(':',1))[0] == 'Name')
+    original_version = next(line_split[1].strip() for line in meta_lines if (line_split := line.split(':',1))[0] == 'Version')
+
+    print(original_name)
+    print(original_version)
+
+    meta_lines = (patch[key]
+                  if (key := line.split(':',1)[0]) in patch.keys()
+                  else line
+                  for line in meta_lines)
+
+    # original_name = next(
+    # original_name, original_version = parsed_name.group('name', 'ver')
+
+
+    # These values will be replaced
+    patch = {}
+    if name is not None:
+      patch['Name'] = f'Name: {name}\n'
+    else:
+      name = original_name
+    if version is not None:
+      patch['Version'] = f'Version: {version}\n'
+    else:
+      version = original_version
+
+    if name == original_name and version == original_version:
+      raise WheelError('No change detected. Package name and version are '
+                       'identical')
+
 
     # Patch metadata
-    metadata = (Path(temp_extract) /
-                f'{original_name}-{original_version}' /
-                f'{original_name}-{original_version}.dist-info/METADATA')
-    with open(metadata, 'r+') as fid:
-      meta_lines = (patch[key]
-                    if (key := line.split(':',1)[0]) in patch.keys()
-                    else line
-                    for line in fid.readlines())
-      fid.seek(0)
+
+    with open(metadata, 'w') as fid:
       fid.writelines(meta_lines)
 
 
     # Rename  files
+    # https://peps.python.org/pep-0491/#escaping-and-unicode
+    normalized_name = re.sub(r"[^\w\d.]+", "_", name).lower()
+    normalized_version = re.sub(r"[^\w\d.+]+", "_", version).lower()
+    normalized_original_name = re.sub(r"[^\w\d.]+", "_", original_name).lower()
+    normalized_original_version = re.sub(r"[^\w\d.+]+", "_", original_version).lower()
+
     os.rename(Path(temp_extract) /
-              f'{original_name}-{original_version}' /
-              f'{original_name}-{original_version}.dist-info',
+              f'{normalized_original_name}-{normalized_original_version}' /
+              f'{normalized_original_name}-{normalized_original_version}.dist-info',
               Path(temp_extract) /
-              f'{original_name}-{original_version}' /
+              f'{normalized_original_name}-{normalized_original_version}' /
               f'{normalized_name}-{normalized_version}.dist-info')
     os.rename(Path(temp_extract) /
-              f'{original_name}-{original_version}',
+              f'{normalized_original_name}-{normalized_original_version}',
               Path(temp_extract) /
               f'{normalized_name}-{normalized_version}')
 
     # Save new wheel
     with tempfile.TemporaryDirectory() as temp_wheel:
       subprocess.Popen(['wheel', 'pack', '--dest', temp_wheel,
-                        Path(temp_extract) / f'{name}-{version}']).wait()
+                        Path(temp_extract) / f'{normalized_name}-{normalized_version}']).wait()
 
       new_wheel = next(Path(temp_wheel).glob('*.whl'))
 
@@ -92,7 +122,7 @@ def main(filename, name=None, version=None):
 
       # It would be possible for the package name/version to change but the
       # whl name to rename unchanged due to filename normalization (e.g.: -➡️_)
-      if new_wheel != filename:
+      if new_wheel.name != filename.name:
         os.remove(filename)
 
 if __name__ == '__main__':
@@ -111,4 +141,4 @@ if __name__ == '__main__':
     else:
       version = f'{version}+{args.add_local}'
 
-  main(filename, version=version)
+  main(filename, name=args.name, version=version)

--- a/python/vsi/tools/patch_wheel.py
+++ b/python/vsi/tools/patch_wheel.py
@@ -38,7 +38,7 @@ def main(filename, name=None, version=None):
                       filename])).wait()
 
     if pid.returncode != 0:
-      raise RuntimeError('Wheel unpack failed. Is the wheel is bad?')
+      raise RuntimeError('Wheel unpack failed. Is the wheel bad?')
 
     # Find the .dist-info directory
     dist_info_dirs = [
@@ -58,17 +58,10 @@ def main(filename, name=None, version=None):
     original_name = next(line_split[1].strip() for line in meta_lines if (line_split := line.split(':',1))[0] == 'Name')
     original_version = next(line_split[1].strip() for line in meta_lines if (line_split := line.split(':',1))[0] == 'Version')
 
-    print(original_name)
-    print(original_version)
-
     meta_lines = (patch[key]
                   if (key := line.split(':',1)[0]) in patch.keys()
                   else line
                   for line in meta_lines)
-
-    # original_name = next(
-    # original_name, original_version = parsed_name.group('name', 'ver')
-
 
     # These values will be replaced
     patch = {}
@@ -85,12 +78,9 @@ def main(filename, name=None, version=None):
       raise WheelError('No change detected. Package name and version are '
                        'identical')
 
-
     # Patch metadata
-
     with open(metadata, 'w') as fid:
       fid.writelines(meta_lines)
-
 
     # Rename  files
     # https://peps.python.org/pep-0491/#escaping-and-unicode

--- a/python/vsi/tools/patch_wheel.py
+++ b/python/vsi/tools/patch_wheel.py
@@ -14,7 +14,7 @@ def get_parser():
                 "wheel metatdata. Note: This will also change any filenames or "
                 "versions in the rest of the file namess (e.g. dist-info "
                 "directory name) but will not change versions strings "
-                "hardcodeded in .py files")
+                "hardcoded in .py files")
   parser.add_argument('filename', help="Wheel (.whl) file")
   parser.add_argument('--name', help="The package name")
   group = parser.add_mutually_exclusive_group()
@@ -90,7 +90,7 @@ def main(filename, name=None, version=None):
       # Replace wheel
       os.rename(new_wheel, filename.parent / new_wheel.name)
 
-      # It would be possible for the package name/version  to change but the
+      # It would be possible for the package name/version to change but the
       # whl name to rename unchanged due to filename normalization (e.g.: -➡️_)
       if new_wheel != filename:
         os.remove(filename)

--- a/tests/int/test-python_script_patch_wheel.bsh
+++ b/tests/int/test-python_script_patch_wheel.bsh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+if [ -z "${VSI_COMMON_DIR+set}" ]; then
+  VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+fi
+
+source "${VSI_COMMON_DIR}/tests/testlib.bsh"
+source "${VSI_COMMON_DIR}/tests/test_utils.bsh"
+
+if ! command -v pip &> /dev/null &> /dev/null ; then
+  skip_next_test
+fi
+begin_test "Test wheel patch"
+(
+  setup_test
+  python -m venv "${TESTDIR}"
+  . "${TESTDIR}/bin/activate"
+  pip install wheel
+  pip download --find-links https://download.pytorch.org/whl/torchrec --no-deps torchrec==0.7.0+cpu
+
+  cp torchrec-0.7.0+cpu-py3-none-any.whl torchrec-0.7.0+cpu-py3-none-any.whl.orig
+
+  # Add to the existing local version
+  python "${VSI_COMMON_DIR}/python/vsi/tools/patch_wheel.py" torchrec-0.7.0+cpu-py3-none-any.whl --add-local foobar
+  # check filename and if wheel is happy
+  wheel unpack torchrec-0.7.0+cpu.foobar-py3-none-any.whl
+  # Double check paths and value is what we expected
+  grep 'Name: torchrec' torchrec-0.7.0+cpu.foobar/torchrec-0.7.0+cpu.foobar.dist-info/METADATA
+  grep 'Version: 0.7.0+cpu.foobar' torchrec-0.7.0+cpu.foobar/torchrec-0.7.0+cpu.foobar.dist-info/METADATA
+  rm -r torchrec-0.7.0+cpu.foobar-py3-none-any.whl torchrec-0.7.0+cpu.foobar
+
+  # Change name and version
+  cp torchrec-0.7.0+cpu-py3-none-any.whl.orig torchrec-0.7.0+cpu-py3-none-any.whl
+  python "${VSI_COMMON_DIR}/python/vsi/tools/patch_wheel.py" torchrec-0.7.0+cpu-py3-none-any.whl --name foobar --version 1.2.3
+  wheel unpack foobar-1.2.3-py3-none-any.whl
+  grep 'Name: foobar' foobar-1.2.3/foobar-1.2.3.dist-info/METADATA
+  grep 'Version: 1.2.3' foobar-1.2.3/foobar-1.2.3.dist-info/METADATA
+  rm -r foobar-1.2.3
+
+  # Add local with no previous local version
+  python "${VSI_COMMON_DIR}/python/vsi/tools/patch_wheel.py" foobar-1.2.3-py3-none-any.whl --add-local local-test
+  wheel unpack foobar-1.2.3+local_test-py3-none-any.whl
+  grep 'Name: foobar' foobar-1.2.3+local_test/foobar-1.2.3+local_test.dist-info/METADATA
+  grep 'Version: 1.2.3+local-test' foobar-1.2.3+local_test/foobar-1.2.3+local_test.dist-info/METADATA
+  rm -r foobar-1.2.3+local_test
+
+  # Nothing changes, should fail
+  not python "${VSI_COMMON_DIR}/python/vsi/tools/patch_wheel.py" foobar-1.2.3+local_test-py3-none-any.whl --name foobar --version 1.2.3+local-test
+
+  # Version change, but filenames do not due to normalization
+  python "${VSI_COMMON_DIR}/python/vsi/tools/patch_wheel.py" foobar-1.2.3+local_test-py3-none-any.whl --name foobar --version 1.2.3+local_test
+  wheel unpack foobar-1.2.3+local_test-py3-none-any.whl
+  grep 'Name: foobar' foobar-1.2.3+local_test/foobar-1.2.3+local_test.dist-info/METADATA
+  grep 'Version: 1.2.3+local_test' foobar-1.2.3+local_test/foobar-1.2.3+local_test.dist-info/METADATA
+
+  # No args should fail
+  not python "${VSI_COMMON_DIR}/python/vsi/tools/patch_wheel.py" foobar-1.2.3+local_test-py3-none-any.whl
+  # Nothing changed should fail
+  not python "${VSI_COMMON_DIR}/python/vsi/tools/patch_wheel.py" foobar-1.2.3+local_test-py3-none-any.whl --name foobar --version 1.2.3+local_test
+  # No wheel should fail
+  not python "${VSI_COMMON_DIR}/python/vsi/tools/patch_wheel.py" badfile-1.2.3+cpu-py3-none-any.whl --name foobar --version 1.2.3
+)
+end_test


### PR DESCRIPTION
Use the wheel package to properly repackage a wheel, regenerating the `RECORDS` file and making pip and pip-tools happy when using the resulting wheel.

Since the `RECORDS` file is being regenerated now, I re-enabled the option to change the package name too.