### PR TITLE
Fix error when pushing withhout setup.env

### DIFF
--- a/linux/pre-commit_filter_lines
+++ b/linux/pre-commit_filter_lines
@@ -4,6 +4,10 @@ if [[ ${-} != *i* ]]; then
   source_once &> /dev/null && return 0
 fi
 
+if [ -z "${VSI_COMMON_DIR+set}" ]; then
+  VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+fi
+
 source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 
 function precommit::filter_line()


### PR DESCRIPTION
If you 'git push' without setup.env, you can get an error:

```
external/vsi_common/linux/pre-commit_filter_lines: line 7: /linux/aliases.bsh: No such file or directory
external/vsi_common/linux/pre-commit_filter_lines: line 15: : command not found
```

It should have had a default for `VSI_COMMON_DIR` in the first place