### PR TITLE
Just Troubleshoot

### DIFF
--- a/linux/just_files/just_troubleshooter_functions.bsh
+++ b/linux/just_files/just_troubleshooter_functions.bsh
@@ -1,0 +1,43 @@
+#!/usr/bin/env false bash
+
+if [[ ${-} != *i* ]]; then
+  source_once &> /dev/null && return 0
+fi
+
+#*# just/plugins/just_troubleshooter_functions
+
+#**
+# .. default-domain:: bash
+#
+# =================================
+# J.U.S.T. Troubleshooter Functions
+# =================================
+#
+# .. file:: just_troubleshooter_functions.bsh
+#
+# Support plugin for running troubleshooting tests
+#
+#**
+
+JUST_DEFAULTIFY_FUNCTIONS+=(troubleshoot_defaultify)
+JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
+
+function troubleshoot_defaultify()
+{
+  local id_project_cwd="${JUST_PROJECT_PREFIX}_CWD"
+  local docs_dir="${JUST_PROJECT_PREFIX}_SPHINX_DIR"
+  docs_dir="${!docs_dir:-${!id_project_cwd}/docs}"
+
+  arg="${1}"
+  shift 1
+  case ${arg} in
+    troubleshoot)
+      "${VSI_COMMON_DIR}/linux/troubleshoot" ${@+"${@}"}
+      extra_args=${#}
+      ;;
+    *)
+      plugin_not_found=1
+      ;;
+  esac
+  return 0
+}

--- a/linux/troubleshoot
+++ b/linux/troubleshoot
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+if [[ ${-} != *i* ]]; then
+  source_once &> /dev/null && return 0
+fi
+
+set -eu
+
+if [ -z "${VSI_COMMON_DIR+set}" ]; then
+  VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+fi
+
+source "${VSI_COMMON_DIR}/tests/testlib.bsh"
+source "${VSI_COMMON_DIR}/linux/colors.bsh"
+
+function run_troubleshoot_file()
+{
+  if [ -r "${1}" ]; then
+  (
+    source "${1}"
+    for test_name in $(compgen -A function troubleshoot_); do
+      begin_test "${test_name}"
+      xtrace=/dev/null
+      (
+          setup_test
+          "${test_name}"
+      )
+      end_test
+      if [ "${test_status}" != "0" ]; then
+        error_name=error_${test_name#troubleshoot_}
+        "${error_name}"
+      fi
+    done
+    TESTLIB_TEST_FILENAME=$(basename "${1}") atexit
+  ) || :
+  else
+    echo "Skipping ${1}, cannot read"
+  fi
+}
+
+function run_troubleshooter()
+{
+  files=()
+
+  if [ -r ".troubleshoot" ]; then
+    while IFS=$'\n' read -r file || [ -n "${file}" ]; do
+      files+=("${file}")
+    done < ".troubleshoot"
+  fi
+
+  if [ -d ".troubleshoot.d" ]; then
+    set_optflag nullglob
+    files+=(".troubleshoot.d"/*)
+    reset_optflag nullglob
+  fi
+
+  if (( ${#} )); then
+    all_files=(${files[@]+"${files[@]}"})
+    files=()
+    while (( ${#} )); do
+      for file in ${all_files[@]+"${all_files[@]}"}; do
+        if [ "$(basename "${file}")" == "${1}" ]; then
+          files+=("${file}")
+        fi
+      done
+      shift 1
+    done
+  fi
+
+  for file in ${files+"${files[@]}"}; do
+    run_troubleshoot_file "${file}"
+  done
+
+  trap -- exit
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ "$(basename "${BASH_SOURCE[0]}")" = "${0}" ]; then
+  run_troubleshooter ${@+"${@}"}
+fi

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -330,7 +330,7 @@ function atexit_part2()
   fi
 
   printf "%s summary: %d tests, ${BOLD_COLOR}%d failures${TESTLIB_RESET_COLOR}, %d unexpected successes, %d expected failures, %d required failures, %d skipped\n" \
-         "${0}" "${tests}" "${failures}" "${unexpected_successes}" "${expected_failures}" "${required_failures}" "${skipped}"
+         "${TESTLIB_TEST_FILENAME-${0}}" "${tests}" "${failures}" "${unexpected_successes}" "${expected_failures}" "${required_failures}" "${skipped}"
 
   if [ -d "${TESTLIB_SUMMARY_DIR-}" ]; then
     echo "${tests} ${failures} ${unexpected_successes} ${expected_failures} ${required_failures} ${skipped}" > "${TESTLIB_SUMMARY_DIR}/$(basename "${0}")"

--- a/tests/troubleshoot/docker_buildx
+++ b/tests/troubleshoot/docker_buildx
@@ -1,0 +1,14 @@
+#!/usr/bin/env false
+
+# Not done. TODO: Finish this
+
+function troubleshoot_docker_buildx_found()
+{
+  [ "$(docker buildx inspect | head -n 1 | awk '{print $2}')" = "default" ]
+}
+
+function error_docker_buildx_found()
+{
+  echo "${RED}You do not appear to be using the 'default' builder. This can cause"
+  echo "unexpected behavior. To fix this run ${YELLOW}docker buildx use default${NC}"
+}

--- a/tests/troubleshoot/git-lfs
+++ b/tests/troubleshoot/git-lfs
@@ -1,0 +1,23 @@
+#!/usr/bin/env false
+
+function troubleshoot_git_lfs_found()
+{
+  git lfs
+}
+
+function error_git_lfs_found()
+{
+  echo "${RED}You do not appear to have git lfs installed. You may need to contact"
+  echo "a system admin. See: ${YELLOW}https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md${NC}"
+}
+
+function troubleshoot_git_lfs_setup_correctly()
+{
+  ! git lfs env | grep 'filter.*""'
+}
+
+function error_git_lfs_setup_correctly()
+{
+  echo "${RED}You do not appear to have git lfs setup correctly. Either have an admin run"
+  echo "'git lfs install --system' or you can run: '${YELLOW}git lfs install --global${NC}'"
+}

--- a/tests/troubleshoot/nvidia_docker
+++ b/tests/troubleshoot/nvidia_docker
@@ -1,0 +1,15 @@
+#!/usr/bin/env false
+
+function troubleshoot_nvidia_docker()
+{
+  docker run -it --rm --gpus=all "${TERRA_WRIVA_BASE_IMAGE}" nvidia-smi
+}
+
+function error_nvidia_docker()
+{
+  echo "${RED}NVIDIA docker does not appear to be working. If you have NVIDIA"
+  echo "GPUs that you expect to be working, you may have 'no-cgroups=true' in"
+  echo "/etc/nvidia-container-runtime/config.toml. Either have an admin revert"
+  echo "this to false, or set ${YELLOW}TERRA_WRIVA_PRIVILEGED_MODE=true"
+  echo "${RED}in your ${YELLOW}local.env ${RED}file.${NC}"
+}

--- a/tests/troubleshoot/nvidia_docker
+++ b/tests/troubleshoot/nvidia_docker
@@ -1,8 +1,10 @@
 #!/usr/bin/env false
 
+: ${NVIDIA_TEST_IMAGE=debian:latest}
+
 function troubleshoot_nvidia_docker()
 {
-  docker run -it --rm --gpus=all "${TERRA_WRIVA_BASE_IMAGE}" nvidia-smi
+  docker run --rm --gpus=all "${NVIDIA_TEST_IMAGE}" nvidia-smi
 }
 
 function error_nvidia_docker()
@@ -10,6 +12,20 @@ function error_nvidia_docker()
   echo "${RED}NVIDIA docker does not appear to be working. If you have NVIDIA"
   echo "GPUs that you expect to be working, you may have 'no-cgroups=true' in"
   echo "/etc/nvidia-container-runtime/config.toml. Either have an admin revert"
-  echo "this to false, or set ${YELLOW}TERRA_WRIVA_PRIVILEGED_MODE=true"
-  echo "${RED}in your ${YELLOW}local.env ${RED}file.${NC}"
+  echo "this to false, or set run the container in privileged mode"
+  additional_nvidia_docker
+}
+
+# Override ``additional_nvidia_docker`` to add additional information specific to your project by creating your own ``.troubleshoot.d/nvidia_docker``:
+#
+# .. code: bash
+#
+#    source ${VSI_COMMON_DIR}/tests/troubleshoot/nvidia_docker
+#    function additional_nvidia_docker()
+#    {
+#      echo "${RED}You can set privileged mode be setting the flag ${YELLOW}{PROJECT_PREFIX}_PRIV_MODE${RED} to true in your ${YELLOW}local.env${NC}"
+#    }
+function additional_nvidia_docker()
+{
+  :
 }


### PR DESCRIPTION
Added new just troubleshoot feature. In your main project, you can:

1. Create a `.troubleshoot` file that points to other troubleshoot tests
2. Create a `.troubleshoot.d` directory containing troubleshoot tests

A troubleshoot test file contains pairs of functions:

- `troubleshoot_{test_name}` - Test to run (under `set -eu`), returns true when everything is ok. False when an issue is detected
- `error_{test_name}` - Prints _helpful_ error message when troubleshoot test fails