### PR TITLE
Fix dockerfile compatibility warnings

### DIFF
--- a/docker/tests/bash_test.Dockerfile
+++ b/docker/tests/bash_test.Dockerfile
@@ -1,13 +1,13 @@
 ARG BASH_VERSION=5.0
 ARG DOCKER_BUILDX_VERSION=0.9.1
 
-FROM vsiri/recipe:gosu as gosu
-FROM vsiri/recipe:tini-musl as tini
-FROM vsiri/recipe:jq as jq
-# FROM vsiri/recipe:vsi as vsi
-FROM vsiri/recipe:docker as docker
-FROM vsiri/recipe:docker-compose as docker-compose
-FROM docker/buildx-bin:${DOCKER_BUILDX_VERSION} as buildx
+FROM vsiri/recipe:gosu AS gosu
+FROM vsiri/recipe:tini-musl AS tini
+FROM vsiri/recipe:jq AS jq
+# FROM vsiri/recipe:vsi AS vsi
+FROM vsiri/recipe:docker AS docker
+FROM vsiri/recipe:docker-compose AS docker-compose
+FROM docker/buildx-bin:${DOCKER_BUILDX_VERSION} AS buildx
 
 FROM bash:${BASH_VERSION}
 

--- a/docker/tests/os.Dockerfile
+++ b/docker/tests/os.Dockerfile
@@ -1,14 +1,14 @@
 ARG OS
 ARG DOCKER_BUILDX_VERSION=0.9.1
 
-FROM vsiri/recipe:docker as docker
-FROM vsiri/recipe:docker-compose as docker-compose
-FROM vsiri/recipe:git-lfs as git-lfs
-FROM vsiri/recipe:jq as jq
-FROM vsiri/recipe:conda-python as conda-python
-FROM docker/buildx-bin:${DOCKER_BUILDX_VERSION} as buildx
+FROM vsiri/recipe:docker AS docker
+FROM vsiri/recipe:docker-compose AS docker-compose
+FROM vsiri/recipe:git-lfs AS git-lfs
+FROM vsiri/recipe:jq AS jq
+FROM vsiri/recipe:conda-python AS conda-python
+FROM docker/buildx-bin:${DOCKER_BUILDX_VERSION} AS buildx
 
-# FROM busybox:latest as wget
+# FROM busybox:latest AS wget
 
 FROM ${OS}
 

--- a/docker/tests/python2.Dockerfile
+++ b/docker/tests/python2.Dockerfile
@@ -1,6 +1,6 @@
-FROM vsiri/recipe:pipenv as pipenv
+FROM vsiri/recipe:pipenv AS pipenv
 
-FROM python:2 as dep_stage
+FROM python:2 AS dep_stage
 SHELL ["/usr/bin/env", "bash", "-euxvc"]
 
 COPY --from=pipenv /usr/local /usr/local
@@ -15,7 +15,7 @@ ENV WORKON_HOME=/venv \
 
 ###############################################################################
 
-FROM dep_stage as pipenv_cache
+FROM dep_stage AS pipenv_cache
 
 ADD Pipfile2 Pipfile2.lock /vsi/docker/tests/
 

--- a/docker/tests/python3.Dockerfile
+++ b/docker/tests/python3.Dockerfile
@@ -1,6 +1,6 @@
-FROM vsiri/recipe:pipenv as pipenv
+FROM vsiri/recipe:pipenv AS pipenv
 
-FROM python:3 as dep_stage
+FROM python:3 AS dep_stage
 SHELL ["/usr/bin/env", "bash", "-euxvc"]
 
 # For wxPython, which I don't actually need
@@ -23,7 +23,7 @@ ENV WORKON_HOME=/venv \
 
 ###############################################################################
 
-FROM dep_stage as pipenv_cache
+FROM dep_stage AS pipenv_cache
 
 # For wxPython, which I don't actually need
 # RUN apt-get update; \

--- a/docker/vsi_common/bashcov.Dockerfile
+++ b/docker/vsi_common/bashcov.Dockerfile
@@ -1,9 +1,9 @@
-FROM vsiri/recipe:gosu as gosu
-FROM vsiri/recipe:tini as tini
-FROM vsiri/recipe:jq as jq
-FROM vsiri/recipe:vsi as vsi
-FROM vsiri/recipe:docker as docker
-FROM docker/compose:alpine-1.25.4 as docker-compose
+FROM vsiri/recipe:gosu AS gosu
+FROM vsiri/recipe:tini AS tini
+FROM vsiri/recipe:jq AS jq
+FROM vsiri/recipe:vsi AS vsi
+FROM vsiri/recipe:docker AS docker
+FROM docker/compose:alpine-1.25.4 AS docker-compose
 
 FROM ruby:2.6.5-buster
 

--- a/docker/vsi_common/makeself.Dockerfile
+++ b/docker/vsi_common/makeself.Dockerfile
@@ -1,6 +1,6 @@
-FROM vsiri/recipe:tini-musl as tini
-FROM vsiri/recipe:gosu as gosu
-FROM vsiri/recipe:vsi as vsi
+FROM vsiri/recipe:tini-musl AS tini
+FROM vsiri/recipe:gosu AS gosu
+FROM vsiri/recipe:vsi AS vsi
 
 FROM alpine:3.13
 

--- a/docker/vsi_common/pyinstaller.Dockerfile
+++ b/docker/vsi_common/pyinstaller.Dockerfile
@@ -1,7 +1,7 @@
-FROM vsiri/recipe:gosu as gosu
-FROM vsiri/recipe:tini as tini
-FROM vsiri/recipe:pipenv as pipenv
-FROM vsiri/recipe:vsi as vsi
+FROM vsiri/recipe:gosu AS gosu
+FROM vsiri/recipe:tini AS tini
+FROM vsiri/recipe:pipenv AS pipenv
+FROM vsiri/recipe:vsi AS vsi
 
 FROM centos:6
 

--- a/docker/vsi_common/sphinx.Dockerfile
+++ b/docker/vsi_common/sphinx.Dockerfile
@@ -1,7 +1,7 @@
-FROM vsiri/recipe:gosu as gosu
-FROM vsiri/recipe:tini as tini
-FROM vsiri/recipe:pipenv as pipenv
-FROM vsiri/recipe:vsi as vsi
+FROM vsiri/recipe:gosu AS gosu
+FROM vsiri/recipe:tini AS tini
+FROM vsiri/recipe:pipenv AS pipenv
+FROM vsiri/recipe:vsi AS vsi
 
 FROM python:3.10.11
 

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -385,6 +385,14 @@ function conda-python-install()
       --list list_versions \
       -- ${@+"${@}"}
 
+  local minor_version_pattern='^([0-9]+)\.([0-9]+)$'
+  local install_version="==${python_ver}"
+  local check_version=("${install_version}")
+  if [[ ${python_ver} =~ ${minor_version_pattern} ]]; then
+    check_version=(">=${BASH_REMATCH[0]}" "<${BASH_REMATCH[1]}.$((${BASH_REMATCH[2]}+1))")
+    install_version="${check_version[0]},${check_version[1]}"
+  fi
+
   if [ "${list_versions}" != "0" ]; then
     # This has worked since at least 2016, so fairly stable
     download_to_stdout https://anaconda.org/anaconda/python/files | sed -n${sed_flag_rE} 's|^ *<a href=".*/anaconda/python/files\?version=([0-9.]*)">|\1|p'
@@ -439,7 +447,7 @@ function conda-python-install()
     if [ -r "${conda_activate-}" ]; then
       source "${conda_activate}"
     fi
-    "${CONDA}" create -y -p "${python_dir}" "python==${python_ver}" ${packages[@]+"${packages[@]}"}
+    "${CONDA}" create -y -p "${python_dir}" "python${install_version}" ${packages[@]+"${packages[@]}"}
   )
   local python_exe_footer
   if [ "${OS-}" = "Windows_NT" ]; then
@@ -460,7 +468,7 @@ function conda-python-install()
   echo "Python ${python_version} installed at \"${python_exe}\"" >&2
 
   # Make sure python meets request
-  if ! meet_requirements "${python_version}" "==${python_ver}"; then
+  if ! meet_requirements "${python_version}" "${check_version[@]}"; then
     echo "Python version ${python_version} is not the requested version ${python_ver}" >&2
     JUST_IGNORE_EXIT_CODES=1
     return 1

--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -289,7 +289,7 @@ function conda-install()
 
     # install conda
     bash "${CONDA_INSTALLER}" -b -p "${conda_dir}" -s
-    # Conda installer doesn't support spacer, PERIOD!
+    # Conda installer doesn't support spaces, PERIOD!
     # ERROR: Cannot install into directories with spaces
 
     # conda executable

--- a/tests/test-docker_functions.bsh
+++ b/tests/test-docker_functions.bsh
@@ -837,15 +837,15 @@ EOF
   assert_str_eq "${stage_names[*]-}" ""
 
   cat - << EOF > Dockerfile
-FROM image1 as foo
+FROM image1 AS foo
 FROM foo
 EOF
   stage_names=($(get_docker_stage_names Dockerfile))
   assert_str_eq "${stage_names[*]}" "foo"
 
   cat - << EOF > Dockerfile
-FROM image1 as foo
-FROM image2 as bar
+FROM image1 AS foo
+FROM image2 AS bar
 FROM foo
 EOF
   stage_names=($(get_docker_stage_names Dockerfile))
@@ -853,9 +853,9 @@ EOF
 
   # Comments and spaces
   cat - << EOF > Dockerfile
-FROM image1 as foo
-# FROM image2 as bar
- # FROM image3 as car
+FROM image1 AS foo
+# FROM image2 AS bar
+ # FROM image3 AS car
  FROM foo
 EOF
   stage_names=($(get_docker_stage_names Dockerfile))

--- a/tests/test-just_docker_functions.bsh
+++ b/tests/test-just_docker_functions.bsh
@@ -70,9 +70,9 @@ begin_test "docker-compose restore from cache"
       dockerfile: foo.Dockerfile
 version: '2.5'"
 
-  echo "FROM vsiri/recipe:foo as bar
+  echo "FROM vsiri/recipe:foo AS bar
 from vsiri/recipe:boo AS far
-FROM alpine:3 as stuff
+FROM alpine:3 AS stuff
 RUN something
 FROM stuff
 RUN more things
@@ -98,7 +98,7 @@ D compose -f ${TESTDIR}/tmp3 push"
   [ "${cmd}" = "${ans}" ]
 
   # No recipes
-  echo "FROM alpine:3 as stuff
+  echo "FROM alpine:3 AS stuff
 RUN something
 FROM stuff
 RUN more things
@@ -133,7 +133,7 @@ D compose -f ${TESTDIR}/tmp3 push"
 version: '2.5'"
 
   mkdir bar
-  echo "FROM alpine:3 as stuff
+  echo "FROM alpine:3 AS stuff
 RUN something
 FROM stuff
 RUN more things
@@ -286,8 +286,8 @@ begin_test "get docker recipes"
 (
   setup_test
     cat - << EOF > Something.Dockerfile
-FROM vsiri/recipe:gosu as foo
-# FROM vsiri/recipe:commented as out
+FROM vsiri/recipe:gosu AS foo
+# FROM vsiri/recipe:commented AS out
 RUN stuff
 from vsiri/recipe:tini as bar
 FROM alpine
@@ -296,7 +296,7 @@ EOF
   [ "$(get_docker_recipes Something.Dockerfile)" = $'gosu\ntini' ]
 
     cat - << EOF > Something.Dockerfile
-FROM not_recipe:gosu as foo
+FROM not_recipe:gosu AS foo
 RUN stuff
 from not_recipe:tini as bar
 FROM alpine


### PR DESCRIPTION
Replace `as` with `AS` to stop warnings and future risk of errors.