### PR TITLE
tar compat.bsh

### DIFF
--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -949,6 +949,69 @@ function load_vsi_compat()
   }
 
   #**
+  # .. function:: tar_feature_delete
+  #
+  # Does tar support ``tar --delete``
+  #
+  # :Return Value: * ``0`` - ``tar`` supports delete
+  #                * ``1`` - ``tar`` does not support delete
+  #**
+  function tar_feature_delete()
+  {
+    if [ -z "${__tar_feature_delete+set}" ]; then
+      source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
+      local temp_dir
+      make_temp_path temp_dir -d
+      pushd ${temp_dir} &> /dev/null
+
+        # create test tarball
+        mkdir -p foo
+        touch foo/A.txt foo/B.txt
+        ${TAR-tar} cf foo.tar foo
+
+        # test delete
+        if ${TAR-tar} -f foo.tar --delete foo/B.txt &> /dev/null; then
+          __tar_feature_delete=0
+        else
+          __tar_feature_delete=1
+        fi
+      popd &> /dev/null
+    fi
+
+    return "${__tar_feature_delete}"
+  }
+
+  #**
+  # .. function:: tar_feature_concatenate
+  #
+  # Does tar support ``tar --concatenate``
+  #
+  # :Return Value: * ``0`` - ``tar`` supports concatenate
+  #                * ``1`` - ``tar`` does not support concatenate
+  #**
+  function tar_feature_concatenate()
+  {
+    if [ -z "${__tar_feature_concatenate+set}" ]; then
+      source "${VSI_COMMON_DIR}/linux/dir_tools.bsh"
+      local temp_dir
+      make_temp_path temp_dir -d
+      pushd ${temp_dir} &> /dev/null
+        mkdir -p "foo" "bar"
+        touch "foo/foo.txt" "bar/bar.txt"
+        ${TAR-tar} cf foo.tar foo
+        ${TAR-tar} cf bar.tar bar
+        if ${TAR-tar} -f foo.tar --concatenate bar.tar &> /dev/null; then
+          __tar_feature_concatenate=0
+        else
+          __tar_feature_concatenate=1
+        fi
+      popd &> /dev/null
+    fi
+
+    return "${__tar_feature_concatenate}"
+  }
+
+  #**
   # readlink
   # ========
   # The following variables will help cope with the difference in readlink versions as seamlessly as possible.

--- a/tests/test-compat.bsh
+++ b/tests/test-compat.bsh
@@ -545,6 +545,60 @@ begin_test "Tar flags"
 )
 end_test
 
+begin_test "Tar delete"
+(
+  setup_test
+
+  # enter test directory
+  cd "${TESTDIR}"
+
+  # create tarball
+  mkdir -p foo
+  touch foo/A.txt foo/B.txt
+  ${TAR-tar} cf foo.tar foo
+
+  # test delete
+  if tar_feature_delete; then
+    ${TAR-tar} -f foo.tar --delete foo/B.txt &> /dev/null
+
+    # confirm file was deleted
+    RESULT="$(${TAR-tar} -tf foo.tar)"
+    EXPECTED=$(echo -e "foo/\nfoo/A.txt")
+    assert_str_eq "${RESULT}" "${EXPECTED}"
+  else
+    not ${TAR-tar} -f foo.tar --delete foo/B.txt &> /dev/null
+  fi
+)
+end_test
+
+begin_test "Tar concatenate"
+(
+  setup_test
+
+  # enter test directory
+  cd "${TESTDIR}"
+
+  # create two tarballs
+  mkdir -p "A" "B"
+  touch "A/A.txt" "B/B.txt"
+  ${TAR-tar} cf A.tar A
+  ${TAR-tar} cf B.tar B
+
+  # test concatenate
+  if tar_feature_concatenate; then
+    ${TAR-tar} -f A.tar --concatenate B.tar &> /dev/null
+
+    # confirm files were concatenated
+    RESULT="$(${TAR-tar} -tf A.tar)"
+    EXPECTED=$(echo -e "A/\nA/A.txt\nB/\nB/B.txt")
+    assert_str_eq "${RESULT}" "${EXPECTED}"
+
+  else
+    not ${TAR-tar} -f A.tar --concatenate B.tar &> /dev/null
+  fi
+)
+end_test
+
 begin_test "Singularity flags"
 (
   setup_test


### PR DESCRIPTION
New `compat.bsh` commands for `tar` features:
- `tar_feature_delete` test availability of `tar --delete`
- `tar_feature_concatenate` test availability of `tar --concatenate`