### PR TITLE
bash_test GNU tar

### DIFF
--- a/docker/tests/bash_test.Dockerfile
+++ b/docker/tests/bash_test.Dockerfile
@@ -32,6 +32,8 @@ RUN apk add --no-cache \
       git \
       # For git_mirror
       git-lfs \
+      # GNU tar that supports --concatenate
+      tar \
       # unit test interactive shells
       screen \
       # Make typeing in the docker easier (for debugging)


### PR DESCRIPTION
Add GNU tar to `bash_test.Dockerfile`.  Updated docker images have already been pushed to `vsiri/test_vsi_common`