### PR TITLE
pre-commit pip

### DIFF
--- a/linux/just_files/just_pre-commit_functions.bsh
+++ b/linux/just_files/just_pre-commit_functions.bsh
@@ -243,12 +243,12 @@ function pre-commit::defaultify()
     pre-commit_setup) # Setup the pre-commit python
       local python_exe
 
-      # If pip is missing, install python
+      # If pip is missing, install python with pip
       if [ ! -f "$(vsi::python::virtualenv_bin "${python_dir}" pip)" ]; then
         local PYTHON_VERSION=${PYTHON_VERSION-${desired_python_version}}
         # conda-python-install sets: python_exe conda_exe python_activate python_version
         local python_exe conda_exe python_activate python_version
-        conda-python-install --dir "${python_dir}" --download
+        conda-python-install --dir "${python_dir}" --download --package pip
       fi
 
       # If pip-sync is missing, install just pip-tools


### PR DESCRIPTION
Ensure the pre-commit python environment contains `pip`.  This fixes an issue for python 3.13.13 from conda-forge which does not appear to contain pip by default.