### PR TITLE
5.3 compat

### DIFF
--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -154,17 +154,17 @@ function load_vsi_compat()
   #**
   # .. var:: bash_behavior_null_pushd
   #
-  # In bash version 5.3 and older, pushd on an empty string now returns an error instead of true. Additionally it does not push the cwd onto the directory stack.
+  # In bash version 5.3 and newer, pushd on an empty string now returns an error instead of true. Additionally it does not push the CWD onto the directory stack.
   #
   # :Value: * ``0`` ``pushd ""`` returns 0
   #         * ``1`` ``pushd ""`` returns 1
   #
   # .. var:: bash_behavior_multiline_caller
   #
-  # In bash version 5.3 and older, caller returns the first line of a multiline command, whereas before it returned the last line.
+  # In bash version 5.3 and newer, caller returns the first line of a multiline command, whereas before it returned the last line.
   #
-  # :Value: * ``0`` ``pushd ""`` returns 0
-  #         * ``1`` ``pushd ""`` returns 1
+  # :Value: * ``0`` ``caller`` returns the last line of a multiline command
+  #         * ``1`` ``caller`` returns the first line of a multiline command
   #**
   if [ "${bash_minor_version}" -ge "53" ]; then
     bash_behavior_null_pushd=1

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -158,11 +158,20 @@ function load_vsi_compat()
   #
   # :Value: * ``0`` ``pushd ""`` returns 0
   #         * ``1`` ``pushd ""`` returns 1
+  #
+  # .. var:: bash_behavior_multiline_caller
+  #
+  # In bash version 5.3 and older, caller returns the first line of a multiline command, whereas before it returned the last line.
+  #
+  # :Value: * ``0`` ``pushd ""`` returns 0
+  #         * ``1`` ``pushd ""`` returns 1
   #**
   if [ "${bash_minor_version}" -ge "53" ]; then
     bash_behavior_null_pushd=1
+    bash_behavior_multiline_caller=1
   else
     bash_behavior_null_pushd=0
+    bash_behavior_multiline_caller=0
   fi
 
   #**

--- a/linux/compat.bsh
+++ b/linux/compat.bsh
@@ -150,6 +150,21 @@ function load_vsi_compat()
   local bash_major_version="${BASH_VERSINFO[0]}"
   local bash_minor_version="${bash_major_version}${BASH_VERSINFO[1]}"
 
+
+  #**
+  # .. var:: bash_behavior_null_pushd
+  #
+  # In bash version 5.3 and older, pushd on an empty string now returns an error instead of true. Additionally it does not push the cwd onto the directory stack.
+  #
+  # :Value: * ``0`` ``pushd ""`` returns 0
+  #         * ``1`` ``pushd ""`` returns 1
+  #**
+  if [ "${bash_minor_version}" -ge "53" ]; then
+    bash_behavior_null_pushd=1
+  else
+    bash_behavior_null_pushd=0
+  fi
+
   #**
   # .. var:: bash_feature_posix_process_substitution
   #

--- a/linux/git_functions.bsh
+++ b/linux/git_functions.bsh
@@ -365,7 +365,7 @@ function _http_to_git_protocol()
 }
 
 #**
-# .. fucntion:: git_helper_cdup
+# .. function:: git_helper_cdup
 #
 # Helper function to get consistent relative paths from ``--show-cdup``
 #**
@@ -380,7 +380,7 @@ function git_helper_cdup()
 }
 
 #**
-# .. fucntion:: git_helper_toplevel
+# .. function:: git_helper_toplevel
 #
 # Helper function to get consistent relative paths from ``--show-toplevel``
 #**

--- a/linux/git_functions.bsh
+++ b/linux/git_functions.bsh
@@ -365,6 +365,36 @@ function _http_to_git_protocol()
 }
 
 #**
+# .. fucntion:: git_helper_cdup
+#
+# Helper function to get consistent relative paths from ``--show-cdup``
+#**
+function git_helper_cdup()
+{
+  # Relative path from the CWD to the root of the current repository
+  local up_path="$("${GIT}" rev-parse --show-cdup)"
+  # Remove trailing / which might be inconsistently added
+  up_path="${up_path%/}"
+  # handle empty string as .
+  echo "${up_path:-.}"
+}
+
+#**
+# .. fucntion:: git_helper_toplevel
+#
+# Helper function to get consistent relative paths from ``--show-toplevel``
+#**
+function git_helper_toplevel()
+{
+  # The absolute path to the current repository/submodule work tree; e.g.,
+  # from /src/vsi_common/docker/recipes/hooks, this command prints
+  # /src/vsi_common/docker/recipes
+  local toplevel="$("${GIT}" rev-parse --show-toplevel 2> /dev/null)"
+  # Strip trailing / (this may be guaranteed by --show-toplevel)
+  echo "${toplevel%/}"
+}
+
+#**
 # .. function:: is_submodule
 #
 # :Output: - Returns ``0`` if the PWD is in a submodule, ``1`` for it is not
@@ -372,19 +402,14 @@ function _http_to_git_protocol()
 
 function is_submodule()
 {
-  local toplevel="$("${GIT}" rev-parse --show-toplevel 2> /dev/null)"
-  # Strip trailing / (this may be guaranteed by --show-toplevel)
-  toplevel="${toplevel%/}"
+  local toplevel="$(git_helper_toplevel)"
   local sm_basename="$(basename "${toplevel}")"
   local is_submod=1
   pushd "${toplevel}/../" &> /dev/null
     # Are we still in a git repo
-    local superlevel="$("${GIT}" rev-parse --show-toplevel 2> /dev/null)"
+    local superlevel="$(git_helper_toplevel)"
     if [ -n "${superlevel:+set}" ]; then
-      local prefix="$("${GIT}" rev-parse --show-prefix)"
-      # Guarantee a trailing / or empty string (this may be guaranteed by
-      # --show-prefix)
-      prefix="${prefix:+"${prefix%/}/"}"
+      local prefix=$("${GIT}" rev-parse --show-prefix)
       pushd "${superlevel}" &> /dev/null
         # In git v1.8.3, git submodule must be run in the toplevel of the
         # working tree
@@ -404,28 +429,6 @@ function is_submodule()
       popd &> /dev/null
     fi
   popd &> /dev/null
-  #
-  # git rev-parse --git-dir | awk -F '/.git' '{print $1}')"
-  #   The (usually) absolute path to the repository's .git directory or the
-  #   submodule's equivalent (e.g., .git/modules/docker/recipes); e.g., from
-  #   /src/vsi_common/linux, this command prints /src/vsi_common/.git
-  # git rev-parse --show-toplevel
-  #   The absolute path to the current repository/submodule work tree; e.g.,
-  #   from /src/vsi_common/docker/recipes/hooks, this command prints
-  #   /src/vsi_common/docker/recipes
-  # git rev-parse --show-cdup
-  #   The relative path from the CWD to the current repository/submodule
-  #   work tree; e.g., from /src/vsi_common/docker/recipes/hooks, this command
-  #   prints ../ Although, from /src/vsi_common/docker/recipes, this
-  #   command prints '' (unfortunately)
-  # git rev-parse --show-prefix
-  #   The relative path from the current repository/submodule work tree to the
-  #   CWD
-  # git rev-parse --show-superproject-working-tree (available in git v2.13.7)
-  #   The absolute path to the working tree of the superproject of the current
-  #   submodule; e.g., from /src/vsi_common/docker/recipes/hooks, this command
-  #   prints /src/vsi_common
-
   return "${is_submod}"
 }
 
@@ -443,7 +446,7 @@ function is_submodule()
 # RE Should mirror git_project_git_dir
 function git_project_root_dir()
 {
-  local toplevel="$("${GIT}" rev-parse --show-toplevel 2> /dev/null)"
+  local toplevel="$(git_helper_toplevel)"
   if is_submodule; then
     pushd "${toplevel}/../" &> /dev/null
       git_project_root_dir
@@ -486,7 +489,7 @@ function git_project_git_dir()
     # will (unfortunately/surprisingly) not output anything. (Similarly,
     # core.worktree isn't set). Fortunately, in this case, --git-dir is correct
     local dir
-    dir="$("${GIT}" rev-parse --show-toplevel)"
+    dir="$("${GIT}" rev-parse --show-toplevel)" # Don't use git_helper_toplevel, logic reasons
     if [ -z "${dir:+set}" ]; then
       dir="$("${GIT}" rev-parse --git-dir)"
       if [ "${dir}" == "." ]; then
@@ -584,66 +587,61 @@ function git_submodule_summary()
   # If we are not in the top-level directory of the repo, change to it and
   # re-call this function
   # Alternatively, re-write using git_submodule_displaypaths
-  local up_path="$("${GIT}" rev-parse --show-cdup)"
-  if [ -n "${up_path:+set}" ]; then
-    pushd "${up_path}" &> /dev/null
-      git_submodule_summary
-    popd &> /dev/null
-    return
-  fi
+  local up_path="$(git_helper_cdup)"
+  pushd "${up_path}" &> /dev/null
+    echo "Entering ${PWD}"
 
-  echo "Entering ${PWD}"
+    local OLD_IFS="${IFS}"
+    IFS=$'\n'
+    local submodule_keys=($(git_submodule_names))
+    IFS="${OLD_IFS}"
 
-  local OLD_IFS="${IFS}"
-  IFS=$'\n'
-  local submodule_keys=($(git_submodule_names))
-  IFS="${OLD_IFS}"
+    local sm_key
+    for sm_key in ${submodule_keys[@]+"${submodule_keys[@]}"}; do
+      local sm_path="$("${GIT}" config --file .gitmodules --get submodule."${sm_key}".path)"
 
-  local sm_key
-  for sm_key in ${submodule_keys[@]+"${submodule_keys[@]}"}; do
-    local sm_path="$("${GIT}" config --file .gitmodules --get submodule."${sm_key}".path)"
-
-    # List the changes (in commits) to the working tree of a submodule
-    # cf. git submodule summary, which doesn't show that there is modified or
-    # staged content, although it does count up differences (ahead/behind)
-    # RE The implementation for git submodule summary sm_path [1] and this
-    # command, git diff --submodule=log sm_path [2], are not the same
-    # RE Unfortunately, both commands only list the first parents [3]
-    # Alternatively, git -c status.submoduleSummary=True status sm_path is
-    # similar as well
-    # REVIEW Because of these limitations, it might be nicer if this function
-    # entered into each submodule and ran git log... directly (which is not too
-    # hard, see below), which could show the full set of changes (in commits)
-    # to the working tree (not only the first parents)
-    # RE Could even run git status --porcelain=1 to show changes in the working
-    # tree
-    #
-    # [1] https://github.com/git/git/blob/v2.24.1/git-submodule.sh#L777
-    # [2] https://github.com/git/git/blob/v2.24.1/diff.c#L3400 =>
-    #     https://github.com/git/git/blob/v2.24.1/submodule.c#L613-L640
-    #     https://github.com/git/git/blob/v2.24.1/submodule.c#L554-L563
-    # [3] https://github.com/git/git/blob/v2.24.1/submodule.c#L450
-    "${GIT}" diff --submodule=log "${sm_path}"
+      # List the changes (in commits) to the working tree of a submodule
+      # cf. git submodule summary, which doesn't show that there is modified or
+      # staged content, although it does count up differences (ahead/behind)
+      # RE The implementation for git submodule summary sm_path [1] and this
+      # command, git diff --submodule=log sm_path [2], are not the same
+      # RE Unfortunately, both commands only list the first parents [3]
+      # Alternatively, git -c status.submoduleSummary=True status sm_path is
+      # similar as well
+      # REVIEW Because of these limitations, it might be nicer if this function
+      # entered into each submodule and ran git log... directly (which is not too
+      # hard, see below), which could show the full set of changes (in commits)
+      # to the working tree (not only the first parents)
+      # RE Could even run git status --porcelain=1 to show changes in the working
+      # tree
+      #
+      # [1] https://github.com/git/git/blob/v2.24.1/git-submodule.sh#L777
+      # [2] https://github.com/git/git/blob/v2.24.1/diff.c#L3400 =>
+      #     https://github.com/git/git/blob/v2.24.1/submodule.c#L613-L640
+      #     https://github.com/git/git/blob/v2.24.1/submodule.c#L554-L563
+      # [3] https://github.com/git/git/blob/v2.24.1/submodule.c#L450
+      "${GIT}" diff --submodule=log "${sm_path}"
 
 
-    # git diff --submodule=log SHA~1..SHA sm_path (or equivalently
-    # git log --patch --submodule=log SHA~1..SHA sm_path) can also be used to
-    # list the changes (in commits) to a submodule (but again, only the first
-    # parents) between two commits in the enclosing repository
-    # RE For example,
-    #     git diff --submodule=log 0088b126~1..0088b126 docker/recipes
-    # ~=  git log --patch --submodule=log 0088b126~1..0088b126 docker/recipes
-    # vs  ( cd docker/recipes && git log --graph 18ca5ee9..fe4f42d4 --first-parent )
-    # cf. ( cd docker/recipes && git log --graph 18ca5ee9..fe4f42d4 )
+      # git diff --submodule=log SHA~1..SHA sm_path (or equivalently
+      # git log --patch --submodule=log SHA~1..SHA sm_path) can also be used to
+      # list the changes (in commits) to a submodule (but again, only the first
+      # parents) between two commits in the enclosing repository
+      # RE For example,
+      #     git diff --submodule=log 0088b126~1..0088b126 docker/recipes
+      # ~=  git log --patch --submodule=log 0088b126~1..0088b126 docker/recipes
+      # vs  ( cd docker/recipes && git log --graph 18ca5ee9..fe4f42d4 --first-parent )
+      # cf. ( cd docker/recipes && git log --graph 18ca5ee9..fe4f42d4 )
 
 
-    if [ -n "${_recursive_summary:+set}" ]; then
-      pushd "${sm_path}" &>/dev/null
-        # Depth-first traversal
-        git_submodule_summary
-      popd &>/dev/null
-    fi
-  done
+      if [ -n "${_recursive_summary:+set}" ]; then
+        pushd "${sm_path}" &>/dev/null
+          # Depth-first traversal
+          git_submodule_summary
+        popd &>/dev/null
+      fi
+    done
+  popd &> /dev/null
 }
 
 #**
@@ -694,8 +692,9 @@ function git_submodule_displaypaths()
     recursive_flag=("--recursive")
   fi
 
+  # Slashes are added because that's how the git 1.8.3 compatibility code was originally written
   # Relative path from the CWD to the root of the current repository
-  local up_path="$("${GIT}" rev-parse --show-cdup)"
+  local up_path="$(git_helper_cdup)/"
   # Relative path from the root of the current repository to the CWD
   local relative_cwd="$("${GIT}" rev-parse --show-prefix)"
   # Guarantee a trailing / or empty string (this probably is guaranteed by
@@ -716,6 +715,11 @@ function git_submodule_displaypaths()
   # At some point, prefix was deprecated and removed in favor of displaypath
   local submodule_paths
   if [ "${submodule_foreach_rv}" -eq "0" ]; then
+    # The following logic works based off of these variables being empty instead of `./` for proper output
+    if [ "${up_path}" = "./" ]; then
+      up_path=
+    fi
+
     pushd "${up_path}" &> /dev/null
       # In git v1.8.3, git submodule must be run in the toplevel of the working
       # tree
@@ -818,8 +822,8 @@ function git_submodule_urls()
 
   # git submodule foreach must be run from the top-level working tree in
   # git v1.8.3
-  local git_top_dir="$("${GIT}" rev-parse --show-cdup)"
-  pushd "${git_top_dir:-.}" &> /dev/null
+  local git_top_dir="$(git_helper_cdup)"
+  pushd "${git_top_dir}" &> /dev/null
     # Query the URL from the submodule's repository configuration
     # (e.g., .git/modules/docker/recipes/config)
     # REVIEW Should i unset GIT_DIR?
@@ -910,8 +914,8 @@ function git_submodule_names()
 
   # git submodule foreach must be run from the top-level working tree in
   # git v1.8.3
-  local git_top_dir="$("${GIT}" rev-parse --show-cdup)"
-  pushd "${git_top_dir:-.}" &> /dev/null
+  local git_top_dir="$(git_helper_cdup)"
+  pushd "${git_top_dir}" &> /dev/null
     "${GIT}" submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} 'echo "${name}"'
   popd &> /dev/null
   #
@@ -977,8 +981,8 @@ function git_submodule_toplevels()
 
   # git submodule foreach must be run from the top-level working tree in
   # git v1.8.3
-  local git_top_dir="$("${GIT}" rev-parse --show-cdup)"
-  pushd "${git_top_dir:-.}" &> /dev/null
+  local git_top_dir="$(git_helper_cdup)"
+  pushd "${git_top_dir}" &> /dev/null
     "${GIT}" submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} \
       'if [ "${OS-}" = "Windows_NT" ]; then
          cygpath "${toplevel}"
@@ -1172,7 +1176,7 @@ function git_submodule_sync()
   # If we are not in the top-level directory of the repo, change to it
   # Alternatively, strip the 'git rev-parse --show-cdup' prefix off of each
   # in_displaypath
-  local up_path="$("${GIT}" rev-parse --show-cdup)"
+  local up_path="$(git_helper_cdup)"
   pushd "${up_path}" &> /dev/null
     _git_submodule_sync "${remote_name}" "${submodule_names[@]}"
   popd &> /dev/null
@@ -1262,7 +1266,7 @@ function git_submodule_is_published_recursive()
   local is_tracked_change_private=0
 
   # If we are not in the top-level directory of the repo, change to it
-  local up_path="$("${GIT}" rev-parse --show-cdup)"
+  local up_path="$(git_helper_cdup)"
   pushd "${up_path}" &> /dev/null
     _git_submodule_is_published_recursive
   popd &> /dev/null

--- a/linux/git_functions.bsh
+++ b/linux/git_functions.bsh
@@ -818,7 +818,8 @@ function git_submodule_urls()
 
   # git submodule foreach must be run from the top-level working tree in
   # git v1.8.3
-  pushd "$("${GIT}" rev-parse --show-cdup)" &> /dev/null
+  local git_top_dir="$("${GIT}" rev-parse --show-cdup)"
+  pushd "${git_top_dir:-.}" &> /dev/null
     # Query the URL from the submodule's repository configuration
     # (e.g., .git/modules/docker/recipes/config)
     # REVIEW Should i unset GIT_DIR?
@@ -909,7 +910,8 @@ function git_submodule_names()
 
   # git submodule foreach must be run from the top-level working tree in
   # git v1.8.3
-  pushd "$("${GIT}" rev-parse --show-cdup)" &> /dev/null
+  local git_top_dir="$("${GIT}" rev-parse --show-cdup)"
+  pushd "${git_top_dir:-.}" &> /dev/null
     "${GIT}" submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} 'echo "${name}"'
   popd &> /dev/null
   #
@@ -975,7 +977,8 @@ function git_submodule_toplevels()
 
   # git submodule foreach must be run from the top-level working tree in
   # git v1.8.3
-  pushd "$("${GIT}" rev-parse --show-cdup)" &> /dev/null
+  local git_top_dir="$("${GIT}" rev-parse --show-cdup)"
+  pushd "${git_top_dir:-.}" &> /dev/null
     "${GIT}" submodule foreach --quiet ${recursive_flag[@]+"${recursive_flag[@]}"} \
       'if [ "${OS-}" = "Windows_NT" ]; then
          cygpath "${toplevel}"

--- a/linux/git_functions.bsh
+++ b/linux/git_functions.bsh
@@ -715,12 +715,12 @@ function git_submodule_displaypaths()
   # At some point, prefix was deprecated and removed in favor of displaypath
   local submodule_paths
   if [ "${submodule_foreach_rv}" -eq "0" ]; then
-    # The following logic works based off of these variables being empty instead of `./` for proper output
-    if [ "${up_path}" = "./" ]; then
-      up_path=
-    fi
-
     pushd "${up_path}" &> /dev/null
+      # The following logic works based off of these variables being empty instead of `./` for proper output
+      if [ "${up_path}" = "./" ]; then
+        up_path=
+      fi
+
       # In git v1.8.3, git submodule must be run in the toplevel of the working
       # tree
       # git v1.8.3 does not support git -C

--- a/linux/just_files/docker_functions.bsh
+++ b/linux/just_files/docker_functions.bsh
@@ -1037,7 +1037,10 @@ function parse_docker_compose()
     # This is one of the few times the directory you are in matters. To create
     # an expected default behavior, switch to the JUSTFILE dir before searching
     # for the docker compose file.
-    pushd "${JUST_DOCKER_COMPOSE_DIR-$(dirname "${JUSTFILE}")}" > /dev/null
+    # "./_" is used so that when JUSTFILE and JUST_DOCKER_COMPOSE_DIR are unset,
+    # it will use that value that is dirnamed and throws away "/_" and results
+    # in pushd . to handle the bash 5.3 issue where pushd "" is now an error
+    pushd "${JUST_DOCKER_COMPOSE_DIR-$(dirname "${JUSTFILE-./_}")}" > /dev/null
       parent_find_files docker-compose.yml docker-compose.yaml
     popd > /dev/null
 

--- a/linux/just_files/docker_functions.bsh
+++ b/linux/just_files/docker_functions.bsh
@@ -1038,8 +1038,8 @@ function parse_docker_compose()
     # an expected default behavior, switch to the JUSTFILE dir before searching
     # for the docker compose file.
     # "./_" is used so that when JUSTFILE and JUST_DOCKER_COMPOSE_DIR are unset,
-    # it will use that value that is dirnamed and throws away "/_" and results
-    # in pushd . to handle the bash 5.3 issue where pushd "" is now an error
+    # it will dirname that value, which throws away "/_" and results in pushd .
+    # in order to handle the bash 5.3 issue where pushd "" is now an error
     pushd "${JUST_DOCKER_COMPOSE_DIR-$(dirname "${JUSTFILE-./_}")}" > /dev/null
       parent_find_files docker-compose.yml docker-compose.yaml
     popd > /dev/null

--- a/linux/just_files/just_git_airgap_repo.bsh
+++ b/linux/just_files/just_git_airgap_repo.bsh
@@ -394,7 +394,7 @@ function add_import-repo_just_project()
 
           JUST_LOCAL_SETTINGS=/dev/null source "${VSI_COMMON_DIR}/linux/just_env" /dev/null
 
-          source "${VSI_COMMON_DIR}/linux/just_git_airgap_repo.bsh"
+          source "${VSI_COMMON_DIR}/linux/just_files/just_git_airgap_repo.bsh"
 
           cd "${AIRGAP_MIRROR_CWD}"
           function caseify() { defaultify ${@+"${@}"}; }

--- a/linux/just_files/just_git_functions.bsh
+++ b/linux/just_files/just_git_functions.bsh
@@ -405,7 +405,8 @@ git_reattach_heads()
 {
   # git submodule foreach must be run from the top-level working tree in
   # git v1.8.3
-  pushd "$("${GIT}" rev-parse --show-cdup)" &> /dev/null
+  local git_top_dir="$("${GIT}" rev-parse --show-cdup)"
+  pushd "${git_top_dir:-.}" &> /dev/null
     local submodule_paths
     if [ "${#}" -eq "0" ]; then
       local OLD_IFS="${IFS}"

--- a/linux/just_files/singularity_functions.bsh
+++ b/linux/just_files/singularity_functions.bsh
@@ -194,7 +194,8 @@ function singular_load_env()
     # This is one of the few times the directory you are in matters. To create
     # an expected default behavior, switch to the JUSTFILE dir before searching
     # for the docker compose file.
-    pushd "${JUST_SINGULAR_COMPOSE_DIR-$(dirname "${JUSTFILE}")}" > /dev/null
+    # "./_" see docker_functions.bsh for explanation
+    pushd "${JUST_SINGULAR_COMPOSE_DIR-$(dirname "${JUSTFILE-./_}")}" > /dev/null
       parent_find_files singular-compose.env
     popd > /dev/null
 

--- a/linux/uwecho.bsh
+++ b/linux/uwecho.bsh
@@ -118,10 +118,11 @@ function uwecho()
   # Get the line number
   line_number="${line_number%% *}"
 
-  # In the case of a multiline command, determine number of lines to backtrack
-  local lines="$(echo -n ${@+"${@}"} | wc -l)"
-  line_number="$((line_number-lines))"
-
+  if [ "${bash_behavior_multiline_caller}" = "0" ]; then
+    # In the case of a multiline command, determine number of lines to backtrack
+    local lines="$(echo -n ${@+"${@}"} | wc -l)"
+    line_number="$((line_number-lines))"
+  fi
 
   local source_line="$(sed -n "${line_number}p" "${file_name}")"
 

--- a/tests/int/test-compat.bsh
+++ b/tests/int/test-compat.bsh
@@ -5,6 +5,7 @@ if [ -z "${VSI_COMMON_DIR+set}" ]; then
 fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
+source "${VSI_COMMON_DIR}/tests/test_utils.bsh"
 source "${VSI_COMMON_DIR}/linux/compat.bsh"
 source "${VSI_COMMON_DIR}/linux/aliases.bsh"
 
@@ -40,6 +41,20 @@ begin_test "Readlink on non-existing files"
   else
     ! readlink -f "${TESTDIR}/not_a_file"
   fi
+)
+end_test
+
+begin_test "Check git global flags set"
+(
+  setup_test
+
+  # For various CI tests to work, we need to have some "new" git flags set, or
+  # else git doesn't behave the way we want
+  assert_str_eq "$(git config --get protocol.file.allow)" always
+
+  # safe.directory should be set to * on CI, or places where the UIDs don't
+  # match. Not sure how best to add that here
+  # git config --get-all safe.directory (newline separate list of dirs)
 )
 end_test
 

--- a/tests/int/test-just_git_airgap_repo.bsh
+++ b/tests/int/test-just_git_airgap_repo.bsh
@@ -3,11 +3,11 @@
 if [ -z "${VSI_COMMON_DIR+set}" ]; then
   VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
 fi
-exit 0
+
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${VSI_COMMON_DIR}/tests/test_utils.bsh"
 source "${VSI_COMMON_DIR}/linux/aliases.bsh"
-command -v "${GIT}" &> /dev/null && source "${VSI_COMMON_DIR}/linux/just_git_airgap_repo.bsh"
+command -v "${GIT}" &> /dev/null && source "${VSI_COMMON_DIR}/linux/just_files/just_git_airgap_repo.bsh"
 source "${VSI_COMMON_DIR}/linux/real_path"
 
 # These tests chain together, so no point in continuing after one breaks
@@ -126,7 +126,7 @@ begin_test "Part 1 - Setup test repo"
 )
 end_test
 
-begin_required_fail_test "Part 2 - Initial mirror"
+begin_test "Part 2 - Initial mirror"
 (
   setup_test
   setup_variables
@@ -135,7 +135,7 @@ begin_required_fail_test "Part 2 - Initial mirror"
     # NOTE Uncommited changes to just_git_airgap_repo.bsh will not exist in
     # this repo, so they cannot be not sourced
     source "${BUILD_REPO}/vsi_common/linux/just_files/just_version.bsh"
-    source "${BUILD_REPO}/vsi_common/linux/just_git_airgap_repo.bsh"
+    source "${BUILD_REPO}/vsi_common/linux/just_files/just_git_airgap_repo.bsh"
     GIT_MIRROR_PREP_DIR="${PREP_DIR}"
     begin_fail_zone
     VSI_COMMON_DIR="${BUILD_REPO}"/vsi_common JUST_VERSION="${JUST_VERSION}" JUST_USER_CWD="${PWD}" \
@@ -143,7 +143,6 @@ begin_required_fail_test "Part 2 - Initial mirror"
   popd &> /dev/null
 )
 end_test
-TESTLIB_SKIP_TESTS='.*' # Remove this after fixing part 2
 
 begin_test "Part 3 - Simulating transfer"
 (
@@ -173,7 +172,7 @@ begin_test "Part 4 - Pushing to mirror"
 
   pushd "${TRANSFER_DIR}" &> /dev/null
     source setup.env # Sets VSI_COMMON_DIR to "${TRANSFER_DIR}"/.vsi_common
-    source "${VSI_COMMON_DIR}/linux/just_git_airgap_repo.bsh"
+    source "${VSI_COMMON_DIR}/linux/just_files/just_git_airgap_repo.bsh"
     sed "${sed_flags_i[@]}" -e \
         's|^JUST_GIT_AIRGAP_MIRROR_URL=$|JUST_GIT_AIRGAP_MIRROR_URL="'"${AIRGAP_MIRROR_DIR}"'"|' repo_map.env
     JUST_USER_CWD="${PWD}" relocate_git_defaultify git_import-repo
@@ -193,7 +192,7 @@ begin_test "Part 5 - Cloning from mirror"
     source /dev/stdin <<< "$(git show origin/__just_git_mirror_info_file:repo_map.env 2>/dev/null)"
     git_airgap_submodule_update vsi_common
 
-    source "${AIRGAP_CLONE_DIR}/vsi_common/linux/just_git_airgap_repo.bsh"
+    source "${AIRGAP_CLONE_DIR}/vsi_common/linux/just_files/just_git_airgap_repo.bsh"
 
     # NOTE if an "error: Server does not allow" failure occurs here, see above
     JUST_USER_CWD="${PWD}" relocate_git_defaultify git_airgap-submodule-update
@@ -245,7 +244,7 @@ begin_test "Part 6 - Incremental update"
     # NOTE Uncommited changes to just_git_airgap_repo.bsh will not exist in
     # this repo, so they cannot be sourced
     source "${BUILD_REPO}/vsi_common/linux/just_files/just_version.bsh"
-    source "${BUILD_REPO}/vsi_common/linux/just_git_airgap_repo.bsh"
+    source "${BUILD_REPO}/vsi_common/linux/just_files/just_git_airgap_repo.bsh"
     GIT_MIRROR_PREP_DIR="${PREP_DIR}"
     # URL and branch are chosen automatically
     VSI_COMMON_DIR="${BUILD_REPO}"/vsi_common JUST_VERSION="${JUST_VERSION}" JUST_USER_CWD="${PWD}" \
@@ -268,7 +267,7 @@ begin_test "Part 6 - Incremental update"
   pushd "${TRANSFER_DIR}" &> /dev/null
   (
     source setup.env # Sets VSI_COMMON_DIR to "${TRANSFER_DIR}"/.vsi_common
-    source "${VSI_COMMON_DIR}/linux/just_git_airgap_repo.bsh"
+    source "${VSI_COMMON_DIR}/linux/just_files/just_git_airgap_repo.bsh"
     sed "${sed_flags_i[@]}" -e \
         's|^JUST_GIT_AIRGAP_MIRROR_URL=$|JUST_GIT_AIRGAP_MIRROR_URL="'"${AIRGAP_MIRROR_DIR}"'"|' repo_map.env
     JUST_USER_CWD="${PWD}" relocate_git_defaultify git_import-repo

--- a/tests/int/test-just_git_airgap_repo.bsh
+++ b/tests/int/test-just_git_airgap_repo.bsh
@@ -3,7 +3,7 @@
 if [ -z "${VSI_COMMON_DIR+set}" ]; then
   VSI_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
 fi
-
+exit 0
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
 source "${VSI_COMMON_DIR}/tests/test_utils.bsh"
 source "${VSI_COMMON_DIR}/linux/aliases.bsh"

--- a/tests/test-compat.bsh
+++ b/tests/test-compat.bsh
@@ -354,6 +354,14 @@ begin_test "Bash flags"
     bash -xv "${TESTDIR}/foo_19"
   fi
 
+  ### bash_behavior_null_pushd
+  if [ "${bash_behavior_null_pushd}" = "0" ]; then
+    pushd ""
+    popd
+  elif pushd ""; then
+    false
+  fi
+
   ### bash_behavior_strict_posix_functions
   function foo_20()
   {

--- a/tests/test-compat.bsh
+++ b/tests/test-compat.bsh
@@ -362,6 +362,31 @@ begin_test "Bash flags"
     false
   fi
 
+  ### bash_behavior_multiline_caller
+
+
+  function callee_test()
+  {
+    call_info="$(caller)"
+  }
+  line_bookmark=${LINENO}
+  function caller_test()
+  {
+    local call_info
+
+    callee_test "Foo bar" # bookmaark+5
+    assert_str_eq "${call_info}" "$((line_bookmark+5)) ${BASH_SOURCE[0]}"
+    callee_test "Foo
+                 bar" # bookmaark+7/8
+    assert_str_eq "${call_info}" "$((line_bookmark+8-bash_behavior_multiline_caller)) ${BASH_SOURCE[0]}"
+    callee_test "Foo
+
+
+                 bar" # bookmaark+10/13
+    assert_str_eq "${call_info}" "$((line_bookmark+13-3*bash_behavior_multiline_caller)) ${BASH_SOURCE[0]}"
+  }
+  caller_test
+
   ### bash_behavior_strict_posix_functions
   function foo_20()
   {

--- a/tests/test-just_git_airgap_repo.bsh
+++ b/tests/test-just_git_airgap_repo.bsh
@@ -5,7 +5,7 @@ if [ -z "${VSI_COMMON_DIR+set}" ]; then
 fi
 
 source "${VSI_COMMON_DIR}/tests/testlib.bsh"
-source "${VSI_COMMON_DIR}/linux/just_git_airgap_repo.bsh"
+source "${VSI_COMMON_DIR}/linux/just_files/just_git_airgap_repo.bsh"
 
 function git()
 {

--- a/tests/test-singularity_functions.bsh
+++ b/tests/test-singularity_functions.bsh
@@ -174,8 +174,23 @@ begin_test "Singular compose load environment"
   unset STUFF_SINGULAR_COMPOSE_FILES
   export JUSTFILE="${TESTDIR}/a/b/c/Justfile"
   not singular_load_env foo1 2>/dev/null
+  unset STUFF_SINGULAR_COMPOSE_FILES
   not singular_load_env foo2 2>/dev/null
+  unset STUFF_SINGULAR_COMPOSE_FILES
   not singular_load_env foo3 2>/dev/null
+  unset STUFF_SINGULAR_COMPOSE_FILES
+  singular_load_env foo4
+  declare -p STUFF_SINGULAR_COMPOSE_FILES
+
+  # Find based on cwd
+  unset JUSTFILE STUFF_SINGULAR_COMPOSE_FILES
+  cd "${TESTDIR}/a/b/c"
+  not singular_load_env foo1 2>/dev/null
+  unset JUSTFILE STUFF_SINGULAR_COMPOSE_FILES
+  not singular_load_env foo2 2>/dev/null
+  unset JUSTFILE STUFF_SINGULAR_COMPOSE_FILES
+  not singular_load_env foo3 2>/dev/null
+  unset JUSTFILE STUFF_SINGULAR_COMPOSE_FILES
   singular_load_env foo4
 )
 end_test

--- a/tests/test-uwecho.bsh
+++ b/tests/test-uwecho.bsh
@@ -25,26 +25,26 @@ begin_test "uwecho test"
   is
             a
 
-       test" | [ "$(cat -)" = "${ans}" ]
+       test" | assert_str_eq "$(cat -)" "${ans}"
 
 # Purposefully unindented
 uwecho "this
   is
           a
 
-       test" | [ "$(cat -)" = "${ans}" ]
+       test" | assert_str_eq "$(cat -)" "${ans}"
 
   uwecho "  this
   is
             a
 
-       test" | [ "$(cat -)" = "  ${ans}" ]
+       test" | assert_str_eq "$(cat -)" "  ${ans}"
 
   uwecho   "  this
   is
               a
 
-       test" | [ "$(cat -)" = "  ${ans}" ]
+       test" | assert_str_eq "$(cat -)" "  ${ans}"
 
 
   ans="
@@ -55,12 +55,12 @@ test with extra trailing newline
   uwecho "
           test with extra trailing newline
 
-         " | [ "$(cat -)" = "${ans}         " ]
+         " | assert_str_eq "$(cat -)" "${ans}         "
 
   uwecho "
           test with extra trailing newline
 
-          " | [ "$(xxd -)" = "$(xxd <<< "${ans}")" ]
+          " | assert_str_eq "$(xxd -)" "$(xxd <<< "${ans}")"
 
   # NOTE command substitution strips newlines
   IFS= read -rd '' foo < <(uwecho "

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -350,7 +350,7 @@ trap_chain "atexit" EXIT
 
 if [ -z "${TESTLIB_PS4+set}" ]; then
   if declare -p BASH_SOURCE &> /dev/null; then
-    PS4=$'+\x1b[0m${TESTLIB_BAD_COLOR}${BASH_SOURCE[1]+${TESTLIB_RESET_COLOR}}${BASH_SOURCE[0]##*/}${TESTLIB_RESET_COLOR}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}()}:$?\t'
+    PS4=$'+\x1b[0m${TESTLIB_BAD_COLOR}${BASH_SOURCE[1]+${TESTLIB_RESET_COLOR}}${BASH_SOURCE[0]##*/}${TESTLIB_RESET_COLOR}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}()}\t'
   else # Else sh probably
     # Not as accurate, but better than nothing
     PS4=$'+\x1b[0m${0##*/}:${LINENO})\t'

--- a/tests/testlib.bsh
+++ b/tests/testlib.bsh
@@ -350,7 +350,7 @@ trap_chain "atexit" EXIT
 
 if [ -z "${TESTLIB_PS4+set}" ]; then
   if declare -p BASH_SOURCE &> /dev/null; then
-    PS4=$'+\x1b[0m${TESTLIB_BAD_COLOR}${BASH_SOURCE[1]+${TESTLIB_RESET_COLOR}}${BASH_SOURCE[0]##*/}${TESTLIB_RESET_COLOR}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}()}\t'
+    PS4=$'+\x1b[0m${TESTLIB_BAD_COLOR}${BASH_SOURCE[1]+${TESTLIB_RESET_COLOR}}${BASH_SOURCE[0]##*/}${TESTLIB_RESET_COLOR}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}()}:$?\t'
   else # Else sh probably
     # Not as accurate, but better than nothing
     PS4=$'+\x1b[0m${0##*/}:${LINENO})\t'

--- a/vsi_common.env
+++ b/vsi_common.env
@@ -8,7 +8,7 @@ source "${VSI_COMMON_DIR}/linux/just_files/just_version.bsh"
 : ${VSI_COMMON_GIDS=$(id -G)}
 : ${VSI_COMMON_GROUP_NAMES=$(group_names)}
 
-set_array_default VSI_COMMON_BASH_TEST_VERSIONS 3.2 4.0 4.1 4.2 4.3 4.4 5.0 5.1 5.2
+set_array_default VSI_COMMON_BASH_TEST_VERSIONS 3.2 4.0 4.1 4.2 4.3 4.4 5.0 5.1 5.2 5.3
 
 # Values for using the docs just plugin
 : ${VSI_COMMON_SPHINX_DIR=${VSI_COMMON_DIR}/docs}


### PR DESCRIPTION
There are a few changes in bash 5.3 that lead to incompatibilities and failures in VSI Common.

The primary different is `pushd ""` + `popd` no longer silently works exactly as intended. So many patches had to be added for that.