### PR TITLE
Make uv install less intrusive

### DIFF
--- a/linux/just_files/just_install_functions.bsh
+++ b/linux/just_files/just_install_functions.bsh
@@ -691,7 +691,7 @@ function uv-install()
   download_to_file "${uv_url}" "${uv_script}"
 
   # call install script
-  UV_INSTALL_DIR="${uv_dir}" sh "${uv_script}"
+  UV_UNMANAGED_INSTALL="${uv_dir}" sh "${uv_script}"
 
   # outputs: executable & version
   uv_exe="${uv_dir}/uv"


### PR DESCRIPTION
UV's default behavior is to "add uv to your path" by editing you `.bashrc`, `.profile`, and `.bashrc_profile`.

In additional to that, it tracks your "one true uv install" in `~/.config/uv/uv-receipt.json`.  While this is ok for a user who chooses to install it, this should not be what a project specific copy of uv uses.

`UV_UNMANAGED_INSTALL` has the benefit of both disabling the rc file edits (same as `UV_NO_MODIFY_PATH`) _and_ disabling the `uv-receipt.json` file.